### PR TITLE
Feature/us db01 centralized connection string

### DIFF
--- a/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContextFactory.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContextFactory.cs
@@ -8,13 +8,12 @@ namespace CargoPilot.Infrastructure.Persistence;
 // Runtime tarafta kullanilmaz; sadece tasarim zamani (EF CLI) tarafindan cagirilir.
 public sealed class AppDbContextFactory : IDesignTimeDbContextFactory<AppDbContext>
 {
-    private const string FallbackConnectionString =
-        "Server=localhost;Database=CargoPilotDev;Trusted_Connection=True;TrustServerCertificate=True;";
-
     public AppDbContext CreateDbContext(string[] args)
     {
         var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__DefaultConnection")
-            ?? FallbackConnectionString;
+            ?? throw new InvalidOperationException(
+                "ConnectionStrings__DefaultConnection env var tanımsız. " +
+                "dotnet ef komutlarından önce bu değişkeni set et (örn. infra/env/.env.dev içindeki DATABASE_CONNECTION_STRING değeriyle, host'tan çalıştırırken 'mssql' yerine 'localhost' kullan).");
 
         var optionsBuilder = new DbContextOptionsBuilder<AppDbContext>();
         optionsBuilder.UseSqlServer(connectionString);

--- a/apps/backend/docs/user-story-tracker.md
+++ b/apps/backend/docs/user-story-tracker.md
@@ -126,10 +126,20 @@ Durum gostergeleri:
 - `⬜` Connection resiliency/retry policy ekle
 - `✅` Hassas bilgi loglamasini kaldir (Kapsam: `Program.cs` icindeki `ApplicationSettings:AppName` ve `ConnectionStrings:DefaultConnection` degerlerini konsola yazan `Console.WriteLine` satirlari, composition root refactor'u sirasinda tamamen kaldirildi. Boylece baglanti dizesi ve uygulama meta verisi artik standart cikti akimina yazilmiyor. Disinda: yapilandirilmis log cercevesi (Serilog/ILogger) entegrasyonu ve hassas alan maskeleme kurallari)
 
+### US-DB01: Merkezi baglanti yonetimi — `✅ Tamamlandi`
+Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglanti dizesi artik tek kaynaktan (`infra/env/.env.dev`) okunuyor; ikinci bir hard-coded degere duzelme ihtiyaci kalmadi.
+
+- `✅` `.env.dev.example` + `.env.dev` dosyalarina `DATABASE_CONNECTION_STRING` degiskeni eklendi (Kapsam: MSSQL blogu altina, Docker network icinde gecerli `Server=mssql,1433;Database=CargoPilotDev;User Id=sa;Password=DevPassword123!;TrustServerCertificate=True;` degeri ile; host uzerinden `dotnet ef` calistirilirken `mssql` yerine `localhost` kullanilmasi gerektigi yorum satirinda belirtildi. Disinda: `.env.test.example` ve `.env.prod.example` icin benzer degiskenlerin tanimlanmasi (ilgili ortam compose dosyalari US-D03e kapsaminda tamamlaninca eklenecek))
+- `✅` `docker-compose.dev.yml` backend servisine `ConnectionStrings__DefaultConnection: ${DATABASE_CONNECTION_STRING}` env binding'i eklendi (Kapsam: `.env.dev` -> compose -> container env var zinciri kuruldu; .NET `EnvironmentVariablesConfigurationProvider` bu degeri dogrudan `IConfiguration.GetConnectionString("DefaultConnection")` uzerinden sunuyor, ara bir mapping gerekmiyor. Container yeniden olusturulup env var'in `printenv ConnectionStrings__DefaultConnection` ile dogrulanmasi yapildi. Disinda: kullanilmayan `MSSQL_HOST/PORT/USER/PASSWORD` env entry'lerinin backend servisinden temizlenmesi (ileri bir temizlik commit'ine birakildi; fonksiyonel etki yok))
+- `✅` `AppDbContextFactory` icindeki sert kodlanmis `FallbackConnectionString` kaldirildi (Kapsam: `CargoPilot.Infrastructure/Persistence/AppDbContextFactory.cs` icindeki `Server=localhost;...Trusted_Connection=True;...` sabiti ve `?? FallbackConnectionString` null-coalescing zinciri silindi. Env var tanimsizsa tasarim zamani komutlari net bir `InvalidOperationException` ile durup "dotnet ef komutlarindan once bu degiskeni set et" mesajiyla kullaniciyi `.env.dev` degerine yonlendiriyor; sessiz localhost-fallback davranisi boylece ortadan kaldirildi. Disinda: `Program.cs:9`'daki `useInMemoryRepository: builder.Environment.IsDevelopment()` flag'i — runtime'da MSSQL'e gecis icin ayri bir commit'e birakildi, bu is sadece altyapiyi hazirladi))
+
 **Kanitlar:**
 - `CargoPilot.WebAPI/Program.cs`
 - `CargoPilot.WebAPI/appsettings.Development.json`
 - `CargoPilot.WebAPI/appsettings.Staging.json`
+- `infra/env/.env.dev.example`
+- `infra/compose/docker-compose.dev.yml`
+- `CargoPilot.Infrastructure/Persistence/AppDbContextFactory.cs`
 
 ---
 

--- a/infra/compose/docker-compose.dev.yml
+++ b/infra/compose/docker-compose.dev.yml
@@ -7,6 +7,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Development
       ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__DefaultConnection: ${DATABASE_CONNECTION_STRING}
       MSSQL_HOST: mssql
       MSSQL_PORT: 1433
       MSSQL_DATABASE: ${MSSQL_DATABASE}

--- a/infra/env/.env.dev.example
+++ b/infra/env/.env.dev.example
@@ -23,6 +23,11 @@ MSSQL_PORT=1433
 MSSQL_DATABASE=CargoPilotDev
 MSSQL_SA_PASSWORD=DevPassword123!
 
+# Backend'in runtime'da okuduğu tek bağlantı dizesi.
+# Host = mssql (Docker network içindeki servis adı). Host makinesinden
+# dotnet ef için kullanılırken 'mssql' yerine 'localhost' yazılmalıdır.
+DATABASE_CONNECTION_STRING=Server=mssql,1433;Database=CargoPilotDev;User Id=sa;Password=DevPassword123!;TrustServerCertificate=True;
+
 # ─── MinIO ───────────────────────────────────
 # Object storage için gerekli yapılandırma
 MINIO_API_PORT=9000


### PR DESCRIPTION
Özet
Veritabanı bağlantı dizesi yönetimi merkezi hale getirildi. Sert kodlanmış (hard-coded) bağlantı dizeleri temizlenerek, yapılandırmanın sadece çevresel değişkenler (.env) ve Docker katmanı üzerinden okunması sağlandı.

İlgili User Story / Issue
US-DB01 - Merkezi Bağlantı Yönetimi ve Bulut DB Entegrasyonu

Değişiklik Tipi
[x] 🚀 Yeni özellik (feature)

[ ] 🐛 Bug düzeltme (bugfix)

Test Edildi mi?
[x] Manuel test yapıldı

Not: Container içinde printenv ile değişken kontrolü yapıldı ve backend servisinin değişkeni başarıyla okuduğu doğrulandı.

Kontrol Listesi
[x] Kod standartlarına uygun

[x] Commit mesajları [commit kurallarına](https://www.google.com/search?q=docs/conventions/COMMITS.md) uygun

[x] Linter hataları yok

[x] Self-review yapıldı

[x] Dokümantasyon güncellendi (gerekiyorsa)

Ek Notlar
infra/env/.env.dev dosyasına DATABASE_CONNECTION_STRING eklendi.

docker-compose.dev.yml dosyasında backend servisi için ConnectionStrings__DefaultConnection eşleşmesi yapıldı.

AppDbContextFactory.cs içindeki fallback bağlantı dizesi kaldırılarak fail-fast prensibi uygulandı.
