### PR TITLE
US-DM-03: hassas ürünlerde Z ekseni kilidi için amber uyarı eklendi

### DIFF
--- a/apps/frontend/src/features/data-management/components/ProductForm.tsx
+++ b/apps/frontend/src/features/data-management/components/ProductForm.tsx
@@ -19,7 +19,10 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useProductForm } from '@/features/data-management/hooks/useProductForm';
-import { FRAGILITY_LEVELS, type ProductFormValues } from '@/features/data-management/schemas/productSchema';
+import {
+  FRAGILITY_LEVELS,
+  type ProductFormValues,
+} from '@/features/data-management/schemas/productSchema';
 
 interface ProductFormProps {
   defaultValues?: Partial<ProductFormValues>;
@@ -178,7 +181,8 @@ export function ProductForm({ defaultValues, onSubmit, onCancel }: ProductFormPr
                   checked={field.value}
                   onCheckedChange={(checked) => {
                     field.onChange(checked);
-                    if (!checked) form.setValue('maxStackCount', undefined, { shouldValidate: true });
+                    if (!checked)
+                      form.setValue('maxStackCount', undefined, { shouldValidate: true });
                   }}
                 />
               </FormControl>

--- a/apps/frontend/src/features/data-management/components/ProductForm.tsx
+++ b/apps/frontend/src/features/data-management/components/ProductForm.tsx
@@ -216,6 +216,14 @@ export function ProductForm({ defaultValues, onSubmit, onCancel }: ProductFormPr
         {/* Döndürme izinleri */}
         <div>
           <p className="text-sm font-medium mb-3">{t('forms.product.rotation')}</p>
+          {fragility >= 1 && (
+            <p
+              role="status"
+              className="mb-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+            >
+              {t('forms.product.rotateZLockedWarning')}
+            </p>
+          )}
           <div className="space-y-3">
             {(
               [

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -43,6 +43,7 @@
       "allowRotateX": "X Axis",
       "allowRotateY": "Y Axis",
       "allowRotateZ": "Z Axis",
+      "rotateZLockedWarning": "Z axis is locked for fragile products",
       "submit": "Save",
       "cancel": "Cancel"
     },

--- a/apps/frontend/src/locales/tr.json
+++ b/apps/frontend/src/locales/tr.json
@@ -43,6 +43,7 @@
       "allowRotateX": "X Ekseni",
       "allowRotateY": "Y Ekseni",
       "allowRotateZ": "Z Ekseni",
+      "rotateZLockedWarning": "Hassas ürünlerde Z ekseni kilitlidir",
       "submit": "Kaydet",
       "cancel": "İptal"
     },


### PR DESCRIPTION
Fragility >= 1 seçildiğinde döndürme bölümünün üstünde amber uyarı metni gösteriliyor. Uyarı metni tr/en locale dosyalarına eklendi. Z eksenini kilitleme mantığı (onChange + form.setValue + useWatch) zaten mevcut olduğundan dokunulmadı.

## Özet
Hassas ürünlerde (fragility >= 1) rotasyon bölümünün üstünde amber 
uyarı metni gösteriliyor. Uyarı metni `forms.product.rotateZLockedWarning` 
anahtarıyla tr/en locale dosyalarına eklendi. Z ekseni kilitleme 
mantığı (onChange + form.setValue + dar useWatch) zaten mevcut 
olduğundan dokunulmadı.


## İlgili User Story / Issue US-DM-03

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [x] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x] Manuel test yapıldı

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
- [x] tsc --noEmit temiz
- [x] eslint --max-warnings 0 temiz
- [x] AC1 — allowRotateX/Y/Z bağımsız Switch
- [x] AC2 — fragility >= 1 → allowRotateZ=false + disabled
- [x] AC3 — onChange + form.setValue (useEffect yok)
- [x] AC4 — amber uyarı + dar useWatch