### PR TITLE
Feature/us 3 d inf 02 box wrapper

### DIFF
--- a/apps/frontend/src/components/shared/BoxWrapper.tsx
+++ b/apps/frontend/src/components/shared/BoxWrapper.tsx
@@ -1,0 +1,56 @@
+/**
+ * BoxWrapper — Tekil kutu render'ları için zorunlu soyutlama.
+ *
+ * Backend'in Sol-Alt-Arka (LBR) pivot'unu Three.js'in merkez pivot'una
+ * dönüştürür (cx = positionX + width/2, vb.). Tüm tekil `<mesh>` kutu
+ * render'ları bu bileşen üzerinden yapılmalıdır.
+ *
+ * KULLANMA: 50+ kutu senaryosu — performans için `InstancedMesh`
+ * kullanılmalıdır. BoxWrapper her kutu için ayrı `<mesh>` yaratır ve
+ * bu ölçekte draw-call sayısı patlar.
+ *
+ * Bkz. apps/frontend/.claude/CLAUDE.md → "3D Sahne: R3F ve Three.js Standartları"
+ */
+
+interface BoxWrapperProps {
+  width: number;
+  height: number;
+  depth: number;
+  positionX: number;
+  positionY: number;
+  positionZ: number;
+  color?: string;
+  opacity?: number;
+  onClick?: (id: string) => void;
+  itemId?: string;
+}
+
+export function BoxWrapper({
+  width,
+  height,
+  depth,
+  positionX,
+  positionY,
+  positionZ,
+  color = '#2563EB',
+  opacity = 0.85,
+  onClick,
+  itemId,
+}: BoxWrapperProps) {
+  const cx = positionX + width / 2;
+  const cy = positionY + height / 2;
+  const cz = positionZ + depth / 2;
+
+  return (
+    <mesh
+      position={[cx, cy, cz]}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (itemId !== undefined) onClick?.(itemId);
+      }}
+    >
+      <boxGeometry args={[width, height, depth]} />
+      <meshStandardMaterial color={color} transparent opacity={opacity} />
+    </mesh>
+  );
+}


### PR DESCRIPTION
## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

Backend'in Sol-Alt-Arka (LBR) pivot koordinatını Three.js'in merkez pivot
sistemine dönüştüren BoxWrapper bileşenini ekler. Tüm tekil kutu
render'larının tek geçeceği zorunlu soyutlama katmanıdır.

Pivot offset formülü: cx = positionX + width/2, cy = positionY + height/2,
cz = positionZ + depth/2.

color, opacity, onClick ve itemId prop'ları desteklenir; onClick içinde
event.stopPropagation() ile tıklama olayının parent mesh'lere propagate
olması engellenir. 50+ kutu senaryosunda performans için InstancedMesh
kullanılması gerektiği JSDoc'ta belgelenmiştir.

## İlgili User Story / Issue

US-3D-INF-02

## Değişiklik Tipi

- [x ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x ] Manuel test yapıldı

## Kontrol Listesi

- [ x] Kod standartlarına uygun
- [ x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ x] Linter hataları yok
- [ x] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
