### PR TITLE
US-PLT-08: Zustand store slice yapısı tamamlandı

### DIFF
--- a/apps/frontend/src/lib/store/useAuthStore.ts
+++ b/apps/frontend/src/lib/store/useAuthStore.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+export type UserRole = 'admin' | 'planner' | 'viewer';
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  fullName: string;
+  role: UserRole;
+}
+
+interface AuthStore {
+  user: AuthUser | null;
+  accessToken: string | null;
+  isAuthenticated: boolean;
+  setAuth: (user: AuthUser, accessToken: string) => void;
+  setAccessToken: (token: string) => void;
+  clearAuth: () => void;
+}
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  user: null,
+  accessToken: null,
+  isAuthenticated: false,
+  setAuth: (user, accessToken) => set({ user, accessToken, isAuthenticated: true }),
+  setAccessToken: (accessToken) => set({ accessToken }),
+  clearAuth: () => set({ user: null, accessToken: null, isAuthenticated: false }),
+}));

--- a/apps/frontend/src/lib/store/useFormStore.ts
+++ b/apps/frontend/src/lib/store/useFormStore.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand';
+
+export type PlanWizardStep = 'vehicle' | 'items' | 'criteria' | 'review';
+
+interface FormStore {
+  wizardStep: PlanWizardStep;
+  drafts: Record<string, unknown>;
+  setWizardStep: (step: PlanWizardStep) => void;
+  saveDraft: (key: string, value: unknown) => void;
+  getDraft: <T>(key: string) => T | undefined;
+  clearDraft: (key: string) => void;
+  reset: () => void;
+}
+
+const initialState = {
+  wizardStep: 'vehicle' as PlanWizardStep,
+  drafts: {} as Record<string, unknown>,
+};
+
+export const useFormStore = create<FormStore>((set, get) => ({
+  ...initialState,
+  setWizardStep: (wizardStep) => set({ wizardStep }),
+  saveDraft: (key, value) => set((s) => ({ drafts: { ...s.drafts, [key]: value } })),
+  getDraft: <T>(key: string) => get().drafts[key] as T | undefined,
+  clearDraft: (key) =>
+    set((s) => {
+      const next = { ...s.drafts };
+      delete next[key];
+      return { drafts: next };
+    }),
+  reset: () => set(initialState),
+}));

--- a/apps/frontend/src/lib/store/useUIStore.ts
+++ b/apps/frontend/src/lib/store/useUIStore.ts
@@ -1,14 +1,23 @@
 import { create } from 'zustand';
 
-type Theme = 'light' | 'dark';
+export type Theme = 'light' | 'dark';
+export type NotificationVariant = 'info' | 'success' | 'warning' | 'error';
+
+export interface Notification {
+  id: string;
+  variant: NotificationVariant;
+  message: string;
+}
 
 interface UIStore {
   theme: Theme;
   isSidebarOpen: boolean;
-  notifications: string[];
+  notifications: Notification[];
   setTheme: (theme: Theme) => void;
   toggleSidebar: () => void;
-  addNotification: (message: string) => void;
+  setSidebarOpen: (open: boolean) => void;
+  addNotification: (notification: Omit<Notification, 'id'>) => void;
+  removeNotification: (id: string) => void;
   clearNotifications: () => void;
 }
 
@@ -18,6 +27,12 @@ export const useUIStore = create<UIStore>((set) => ({
   notifications: [],
   setTheme: (theme) => set({ theme }),
   toggleSidebar: () => set((s) => ({ isSidebarOpen: !s.isSidebarOpen })),
-  addNotification: (message) => set((s) => ({ notifications: [...s.notifications, message] })),
+  setSidebarOpen: (isSidebarOpen) => set({ isSidebarOpen }),
+  addNotification: (notification) =>
+    set((s) => ({
+      notifications: [...s.notifications, { id: crypto.randomUUID(), ...notification }],
+    })),
+  removeNotification: (id) =>
+    set((s) => ({ notifications: s.notifications.filter((n) => n.id !== id) })),
   clearNotifications: () => set({ notifications: [] }),
 }));


### PR DESCRIPTION
- useAuthStore eklendi: user + accessToken (memory-only) + setAuth/clearAuth
- useFormStore eklendi: wizard step + generic draft API (any yok, unknown + generic)
- useUIStore zenginleştirildi: Notification tipi (id + variant + message), removeNotification action, setSidebarOpen eklendi
- Store'lar birbirini import etmiyor; cross-store iletişim getState() ile


## Özet
Zustand store katmanı domain-izole 5 slice ile kuruldu: useAuthStore, 
useFormStore yeni eklendi; mevcut useUIStore Notification tipi ile 
zenginleştirildi (id + variant + message). Access token sadece memory'de 
tutuluyor (localStorage yasağı). Store'lar birbirini import etmiyor; 
cross-store iletişim getState() pattern'i ile yapılmalı. Sunucu verisi 
hiçbir store'a yazılmıyor — TanStack Query cache SSOT.

## İlgili User Story / Issue
US-PLT-08

## Değişiklik Tipi
- [x] 🚀 Yeni özellik (feature)

## Test Edildi mi?
- [x] Manuel test yapıldı (tsc, eslint, prettier)

## Kontrol Listesi
- [x] Kod standartlarına uygun
- [x] Commit mesajı [commit kuralları](docs/conventions/COMMITS.md)'na uygun
[x] **AC1** — 5 slice ayrı dosyalarda: `useAuthStore`, `useUIStore`, `usePlanStore`, `useSceneStore`, `useFormStore`
- [x] **AC2** — Her store TypeScript interface ile tipli, `any` yok (`grep any` → 0 match)
- [x] **AC3** — Server response verisi (ürün listesi, araç verisi) hiçbir store'a yazılmıyor
- [x] **AC4** — Store'lar birbirini import etmiyor; cross-store iletişim `getState()` ile
- [x] **useUIStore** — notifications (toast) + sidebar + theme hepsi yönetiliyor

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

- `useAuthStore`: accessToken **memory-only**, localStorage'a yazılmıyor (CLAUDE.md kuralı)
- `UserRole` ve `NotificationVariant`: TypeScript enum değil, `as const` union type
- `useFormStore.getDraft<T>()`: generic ile tip güvenli okuma (`any` yok, `unknown` + generic cast)