### PR TITLE
US-DM-06: Kilitli özellikler için UpgradeModal ve feature gate eklendi

### DIFF
--- a/apps/frontend/src/components/shared/LockedFeatureButton.tsx
+++ b/apps/frontend/src/components/shared/LockedFeatureButton.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { Lock } from 'lucide-react';
+import { Button, type ButtonProps } from '@/components/ui/button';
+import { useSubscriptionStore } from '@/lib/store/useSubscriptionStore';
+import { hasFeatureAccess } from '@/lib/utils/checkFeatureAccess';
+import type { FeatureKey } from '@/lib/config/plan-features';
+import { UpgradeModal } from '@/features/platform/components/UpgradeModal';
+import { cn } from '@/lib/utils';
+
+interface LockedFeatureButtonProps extends Omit<ButtonProps, 'onClick'> {
+  feature: FeatureKey;
+  onClick?: () => void;
+}
+
+export function LockedFeatureButton({
+  feature,
+  onClick,
+  children,
+  className,
+  variant,
+  disabled,
+  ...rest
+}: LockedFeatureButtonProps) {
+  const plan = useSubscriptionStore((s) => s.plan);
+  const [modalOpen, setModalOpen] = useState(false);
+  const isUnlocked = hasFeatureAccess(plan, feature);
+
+  const handleClick = () => {
+    if (isUnlocked) {
+      onClick?.();
+    } else {
+      setModalOpen(true);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant={isUnlocked ? variant : 'outline'}
+        disabled={disabled}
+        aria-disabled={!isUnlocked}
+        onClick={handleClick}
+        className={cn(!isUnlocked && 'text-muted-foreground opacity-70', className)}
+        {...rest}
+      >
+        {!isUnlocked && <Lock className="mr-2 h-4 w-4" />}
+        {children}
+      </Button>
+      <UpgradeModal open={modalOpen} onOpenChange={setModalOpen} feature={feature} />
+    </>
+  );
+}

--- a/apps/frontend/src/features/platform/components/UpgradeModal.tsx
+++ b/apps/frontend/src/features/platform/components/UpgradeModal.tsx
@@ -1,0 +1,49 @@
+import { useTranslation } from 'react-i18next';
+import { Sparkles } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { getRequiredPlan } from '@/lib/utils/checkFeatureAccess';
+import type { FeatureKey } from '@/lib/config/plan-features';
+
+interface UpgradeModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  feature: FeatureKey;
+}
+
+export function UpgradeModal({ open, onOpenChange, feature }: UpgradeModalProps) {
+  const { t } = useTranslation();
+  const requiredPlan = getRequiredPlan(feature);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <div className="mb-2 inline-flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+            <Sparkles className="text-primary" />
+          </div>
+          <DialogTitle>{t('upgrade.title')}</DialogTitle>
+          <DialogDescription>
+            {t('upgrade.description', {
+              feature: t(`features.${feature}`),
+              plan: t(`plans.${requiredPlan}`),
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('upgrade.dismiss')}
+          </Button>
+          <Button type="button">{t('upgrade.viewPlans')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/lib/config/plan-features.ts
+++ b/apps/frontend/src/lib/config/plan-features.ts
@@ -1,0 +1,16 @@
+import type { SubscriptionPlan } from '@/lib/store/useSubscriptionStore';
+
+export const PLAN_ORDER: SubscriptionPlan[] = ['free', 'starter', 'pro', 'enterprise'];
+
+export const PLAN_FEATURES = {
+  bulkImport: 'starter',
+  pdfExport: 'starter',
+  excelExport: 'starter',
+  manualPlacement: 'pro',
+  advanced3D: 'pro',
+  multiUser: 'pro',
+  erpIntegration: 'enterprise',
+  apiAccess: 'enterprise',
+} as const satisfies Record<string, SubscriptionPlan>;
+
+export type FeatureKey = keyof typeof PLAN_FEATURES;

--- a/apps/frontend/src/lib/store/useSubscriptionStore.ts
+++ b/apps/frontend/src/lib/store/useSubscriptionStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+export type SubscriptionPlan = 'free' | 'starter' | 'pro' | 'enterprise';
+
+interface SubscriptionStore {
+  plan: SubscriptionPlan;
+  expiresAt: string | null;
+  setPlan: (plan: SubscriptionPlan, expiresAt?: string | null) => void;
+  clear: () => void;
+}
+
+export const useSubscriptionStore = create<SubscriptionStore>((set) => ({
+  plan: 'free',
+  expiresAt: null,
+  setPlan: (plan, expiresAt = null) => set({ plan, expiresAt }),
+  clear: () => set({ plan: 'free', expiresAt: null }),
+}));

--- a/apps/frontend/src/lib/utils/checkFeatureAccess.ts
+++ b/apps/frontend/src/lib/utils/checkFeatureAccess.ts
@@ -1,0 +1,20 @@
+import { useSubscriptionStore, type SubscriptionPlan } from '@/lib/store/useSubscriptionStore';
+import { PLAN_FEATURES, PLAN_ORDER, type FeatureKey } from '@/lib/config/plan-features';
+
+function planRank(plan: SubscriptionPlan): number {
+  return PLAN_ORDER.indexOf(plan);
+}
+
+export function hasFeatureAccess(plan: SubscriptionPlan, feature: FeatureKey): boolean {
+  const required = PLAN_FEATURES[feature];
+  return planRank(plan) >= planRank(required);
+}
+
+export function checkFeatureAccess(feature: FeatureKey): boolean {
+  const { plan } = useSubscriptionStore.getState();
+  return hasFeatureAccess(plan, feature);
+}
+
+export function getRequiredPlan(feature: FeatureKey): SubscriptionPlan {
+  return PLAN_FEATURES[feature];
+}

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -59,5 +59,27 @@
       "submit": "Save",
       "cancel": "Cancel"
     }
+  },
+  "plans": {
+    "free": "Free",
+    "starter": "Starter",
+    "pro": "Pro",
+    "enterprise": "Enterprise"
+  },
+  "features": {
+    "bulkImport": "Bulk product import via Excel",
+    "pdfExport": "PDF report export",
+    "excelExport": "Excel report export",
+    "manualPlacement": "Manual placement editing",
+    "advanced3D": "Advanced 3D visualization",
+    "multiUser": "Multi-user management",
+    "erpIntegration": "ERP integration",
+    "apiAccess": "API access"
+  },
+  "upgrade": {
+    "title": "This feature is not included in your plan",
+    "description": "To use {{feature}}, you need to upgrade to at least the {{plan}} plan.",
+    "viewPlans": "View Plans",
+    "dismiss": "Dismiss"
   }
 }

--- a/apps/frontend/src/locales/tr.json
+++ b/apps/frontend/src/locales/tr.json
@@ -59,5 +59,27 @@
       "submit": "Kaydet",
       "cancel": "İptal"
     }
+  },
+  "plans": {
+    "free": "Ücretsiz",
+    "starter": "Başlangıç",
+    "pro": "Profesyonel",
+    "enterprise": "Kurumsal"
+  },
+  "features": {
+    "bulkImport": "Excel ile toplu ürün içe aktarma",
+    "pdfExport": "PDF rapor çıktısı",
+    "excelExport": "Excel rapor çıktısı",
+    "manualPlacement": "Manuel yerleşim düzenleme",
+    "advanced3D": "Gelişmiş 3D görselleştirme",
+    "multiUser": "Çoklu kullanıcı yönetimi",
+    "erpIntegration": "ERP entegrasyonu",
+    "apiAccess": "API erişimi"
+  },
+  "upgrade": {
+    "title": "Bu özellik paketinizde bulunmuyor",
+    "description": "{{feature}} özelliğini kullanmak için en az {{plan}} paketine geçmeniz gerekiyor.",
+    "viewPlans": "Paketleri Gör",
+    "dismiss": "Vazgeç"
   }
 }


### PR DESCRIPTION
- useSubscriptionStore: plan ('free' | 'starter' | 'pro' | 'enterprise') + expiresAt
- lib/config/plan-features.ts: PLAN_FEATURES sabit nesnesi (merkezi tanım, as const satisfies ile tip güvenli) + PLAN_ORDER hiyerarşisi
- lib/utils/checkFeatureAccess.ts: hasFeatureAccess (saf) + checkFeatureAccess (store'dan okur) + getRequiredPlan
- UpgradeModal: shadcn Dialog tabanlı, feature + gerekli plan gösterimi
- LockedFeatureButton: shared bileşen, Lock ikonu + soluk stil, tıklamada hard redirect yerine modal açılır; modal kapatılınca parent state korunur
- i18n: plans.*, features.*, upgrade.* anahtarları tr/en

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
