### PR TITLE
fix(ci): server deploy'da paralel build OOM riski giderildi

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -318,17 +318,27 @@ jobs:
             git checkout test
             git reset --hard origin/test
 
+            echo "==> Image'lar sırayla build ediliyor (paralel build OOM riskini önler)..."
+            docker compose \
+              -f infra/compose/docker-compose.test.yml \
+              --env-file infra/env/.env.test \
+              build --no-cache backend
+            docker compose \
+              -f infra/compose/docker-compose.test.yml \
+              --env-file infra/env/.env.test \
+              build --no-cache frontend
+
             echo "==> Eski stack temizleniyor..."
             docker compose \
               -f infra/compose/docker-compose.test.yml \
               --env-file infra/env/.env.test \
               down --remove-orphans 2>/dev/null || true
 
-            echo "==> Test container'ları yeniden build ediliyor..."
+            echo "==> Stack ayağa kaldırılıyor (build yok, image hazır)..."
             docker compose \
               -f infra/compose/docker-compose.test.yml \
               --env-file infra/env/.env.test \
-              up -d --build
+              up -d --no-build
 
             echo "==> Eski image'lar temizleniyor..."
             docker image prune -f


### PR DESCRIPTION
--build flag'i backend ve frontend'i paralel build ediyordu; monitoring stack + MSSQL çalışırken .NET + node peak RAM kullanımı OOM killer'ı tetikleyip sshd'yi öldürüyordu.

Değişiklik:
- backend ve frontend sırayla ayrı build adımlarında build edilir
- stack down/up aşamasında --no-build kullanılır (image hazır gelir)
- down, build bitmeden yapılmıyor; servis kesintisi minimuma iniyor

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
