### PR TITLE
api/auth route prefiksi v1 ile hizalandı

### DIFF
--- a/apps/backend/CargoPilot.WebAPI/Controllers/AuthController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/AuthController.cs
@@ -7,7 +7,7 @@ namespace CargoPilot.WebAPI.Controllers;
 /// <summary>
 /// Kimlik doğrulama ve oturum yönetimi endpoint'leri.
 /// </summary>
-[Route("api/auth")]
+[Route("api/v1/auth")]
 public sealed class AuthController : BaseController
 {
     private readonly IMediator _mediator;

--- a/apps/frontend/src/lib/api/axiosInstance.ts
+++ b/apps/frontend/src/lib/api/axiosInstance.ts
@@ -32,7 +32,7 @@ axiosInstance.interceptors.response.use(
       config._retry = true;
       try {
         const { data } = await axios.post<{ accessToken: string }>(
-          '/auth/refresh',
+          '/api/v1/auth/refresh',
           {},
           { baseURL: API_BASE_URL, withCredentials: true },
         );


### PR DESCRIPTION
Backend AuthController route'u api/auth yerine api/v1/auth olarak güncellendi. Frontend axiosInstance refresh endpoint'i /auth/refresh yerine /api/v1/auth/refresh olarak düzeltildi.

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
