### PR TITLE
CI deploy script git ref lock sorunu düzeltildi

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -314,7 +314,8 @@ jobs:
             cd /opt/cargo-pilot
 
             echo "==> Test branch güncelleniyor..."
-            git fetch origin
+            git remote prune origin
+            git fetch --prune origin
             git checkout test
             git reset --hard origin/test
 


### PR DESCRIPTION
git fetch öncesine remote prune ve --prune flag eklendi. Sunucuda biriken stale ref'ler fetch'i kilitliyordu.

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
