### PR TITLE
feat(ci): GHCR entegrasyonu — US-D27-I

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -179,7 +179,7 @@ jobs:
           context: ./apps/backend
           file: ./apps/backend/Dockerfile
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/test' }}
-          tags: ghcr.io/${{ github.repository_owner }}/cargo-pilot-backend:test
+          tags: ghcr.io/divizyon/cargo-pilot-backend:test
           cache-from: type=gha,scope=backend-test
           cache-to: type=gha,mode=max,scope=backend-test
 
@@ -189,7 +189,7 @@ jobs:
           context: ./apps/frontend
           file: ./apps/frontend/Dockerfile
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/test' }}
-          tags: ghcr.io/${{ github.repository_owner }}/cargo-pilot-frontend:test
+          tags: ghcr.io/divizyon/cargo-pilot-frontend:test
           cache-from: type=gha,scope=frontend-test
           cache-to: type=gha,mode=max,scope=frontend-test
 
@@ -252,7 +252,7 @@ jobs:
           file: ./apps/backend/Dockerfile
           push: false
           load: true
-          tags: ghcr.io/${{ github.repository_owner }}/cargo-pilot-backend:test
+          tags: ghcr.io/divizyon/cargo-pilot-backend:test
           cache-from: type=gha,scope=backend-test
           cache-to: type=gha,mode=max,scope=backend-test
 
@@ -263,7 +263,7 @@ jobs:
           file: ./apps/frontend/Dockerfile
           push: false
           load: true
-          tags: ghcr.io/${{ github.repository_owner }}/cargo-pilot-frontend:test
+          tags: ghcr.io/divizyon/cargo-pilot-frontend:test
           cache-from: type=gha,scope=frontend-test
           cache-to: type=gha,mode=max,scope=frontend-test
 

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -129,8 +129,9 @@ jobs:
           echo "Migration kontrolü geçti: bekleyen model değişikliği yok."
 
   # ─── Build job: sadece test'e giden PR'da veya test'e push'ta çalışır ────────
+  # US-D27-I: test branch push'ta image'lar GHCR'a push edilir.
   build:
-    name: Image Build
+    name: Image Build & GHCR Push
     runs-on: ubuntu-latest
     needs: [enforce-test-base]
     if: |
@@ -141,12 +142,26 @@ jobs:
         (github.event_name == 'push' && github.ref == 'refs/heads/test')
       )
 
+    # packages: write — GHCR'a push edebilmek için gerekli
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Kodu al
         uses: actions/checkout@v4
 
       - name: Docker Buildx kur
         uses: docker/setup-buildx-action@v3
+
+      # Sadece test branch'e push'ta GHCR'a login olunur (PR'larda push yapılmaz)
+      - name: GHCR'a giriş yap
+        if: github.event_name == 'push' && github.ref == 'refs/heads/test'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: .NET base image önceden çek (MCR rate limit koruması)
         run: |
@@ -157,23 +172,24 @@ jobs:
             sleep 15
           done
 
-      - name: Backend image build
+      # push: PR'larda false, test branch push'ta true
+      - name: Backend image build ve GHCR push
         uses: docker/build-push-action@v5
         with:
           context: ./apps/backend
           file: ./apps/backend/Dockerfile
-          push: false
-          tags: cargo-pilot-backend:test
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/test' }}
+          tags: ghcr.io/${{ github.repository_owner }}/cargo-pilot-backend:test
           cache-from: type=gha,scope=backend-test
           cache-to: type=gha,mode=max,scope=backend-test
 
-      - name: Frontend image build
+      - name: Frontend image build ve GHCR push
         uses: docker/build-push-action@v5
         with:
           context: ./apps/frontend
           file: ./apps/frontend/Dockerfile
-          push: false
-          tags: cargo-pilot-frontend:test
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/test' }}
+          tags: ghcr.io/${{ github.repository_owner }}/cargo-pilot-frontend:test
           cache-from: type=gha,scope=frontend-test
           cache-to: type=gha,mode=max,scope=frontend-test
 
@@ -227,6 +243,8 @@ jobs:
             sleep 15
           done
 
+      # Tag'ler docker-compose.test.yml'deki image: alanlarıyla eşleşmeli.
+      # load: true → image'ı local Docker daemon'a yükle (no push)
       - name: Backend image build (deploy için)
         uses: docker/build-push-action@v5
         with:
@@ -234,7 +252,7 @@ jobs:
           file: ./apps/backend/Dockerfile
           push: false
           load: true
-          tags: cargo-pilot-backend:test
+          tags: ghcr.io/${{ github.repository_owner }}/cargo-pilot-backend:test
           cache-from: type=gha,scope=backend-test
           cache-to: type=gha,mode=max,scope=backend-test
 
@@ -245,7 +263,7 @@ jobs:
           file: ./apps/frontend/Dockerfile
           push: false
           load: true
-          tags: cargo-pilot-frontend:test
+          tags: ghcr.io/${{ github.repository_owner }}/cargo-pilot-frontend:test
           cache-from: type=gha,scope=frontend-test
           cache-to: type=gha,mode=max,scope=frontend-test
 
@@ -323,12 +341,18 @@ jobs:
       github.ref == 'refs/heads/test'
 
     steps:
+      # US-D27-I: Sunucu artık build yapmıyor; GHCR'dan pull edilen image'ı kullanıyor.
+      # Gerekli GitHub Secret: TEST_GHCR_PAT (read:packages scope'lu PAT)
       - name: Sunucuya bağlan ve test stack'ini güncelle
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          GHCR_PAT: ${{ secrets.TEST_GHCR_PAT }}
+          GHCR_USER: ${{ github.actor }}
         with:
           host: ${{ secrets.TEST_SSH_HOST }}
           username: root
           key: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
+          envs: GHCR_PAT,GHCR_USER
           script: |
             set -e
             cd /opt/cargo-pilot
@@ -339,15 +363,14 @@ jobs:
             git checkout test
             git reset --hard origin/test
 
-            echo "==> Image'lar sırayla build ediliyor (paralel build OOM riskini önler)..."
+            echo "==> GHCR'a giriş yapılıyor..."
+            echo "$GHCR_PAT" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+
+            echo "==> Image'lar GHCR'dan çekiliyor (build yok)..."
             docker compose \
               -f infra/compose/docker-compose.test.yml \
               --env-file infra/env/.env.test \
-              build --no-cache backend
-            docker compose \
-              -f infra/compose/docker-compose.test.yml \
-              --env-file infra/env/.env.test \
-              build --no-cache frontend
+              pull backend frontend
 
             echo "==> Eski stack temizleniyor..."
             docker compose \
@@ -355,13 +378,13 @@ jobs:
               --env-file infra/env/.env.test \
               down --remove-orphans 2>/dev/null || true
 
-            echo "==> Stack ayağa kaldırılıyor (build yok, image hazır)..."
+            echo "==> Stack ayağa kaldırılıyor..."
             docker compose \
               -f infra/compose/docker-compose.test.yml \
               --env-file infra/env/.env.test \
               up -d --no-build
 
-            echo "==> Eski image'lar temizleniyor..."
+            echo "==> Kullanılmayan eski image'lar temizleniyor..."
             docker image prune -f
 
       - name: Test backend health check

--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -2,7 +2,8 @@ name: cargo-pilot-test
 
 services:
   backend:
-    image: cargo-pilot-backend:test
+    # US-D27-I: Image GHCR'dan çekilir; build yalnızca local geliştirme için.
+    image: ghcr.io/${GHCR_OWNER:-divizyon}/cargo-pilot-backend:${IMAGE_TAG:-test}
     build:
       context: ../../apps/backend
       dockerfile: Dockerfile
@@ -40,7 +41,8 @@ services:
       - cargo-pilot-test
 
   frontend:
-    image: cargo-pilot-frontend:test
+    # US-D27-I: Image GHCR'dan çekilir; build yalnızca local geliştirme için.
+    image: ghcr.io/${GHCR_OWNER:-divizyon}/cargo-pilot-frontend:${IMAGE_TAG:-test}
     build:
       context: ../../apps/frontend
       dockerfile: Dockerfile


### PR DESCRIPTION
## Özet

GitHub Container Registry (GHCR) push/pull akışı kuruldu.
Artık sunucu her deploy'da image build etmek zorunda kalmıyor;
GitHub Actions image'ı build edip GHCR'a push ediyor, sunucu sadece pull yapıyor.

## İlgili User Story / Issue

US-D27-I

## Değişiklik Tipi

- [x] 🚀 Yeni özellik (feature)

## Test Edildi mi?

- [x] Manuel test yapıldı

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

Değiştirilen dosyalar:
- `.github/workflows/test-deploy.yml` — build job'a GHCR login+push eklendi, deploy-test-server job'unda build kaldırılıp pull eklendi
- `infra/compose/docker-compose.test.yml` — image tag'leri `ghcr.io/divizyon/...` formatına çekildi

Gerekli GitHub Secret: `TEST_GHCR_PAT` (read:packages scope'lu PAT) — eklendi ✅
