### PR TITLE
fix(swagger): restore bearer security serialization for protected end…

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Interfaces/IItemRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/IItemRepository.cs
@@ -1,0 +1,10 @@
+using CargoPilot.Domain.Entities;
+
+namespace CargoPilot.Application.Common.Interfaces;
+
+public interface IItemRepository
+{
+    Task<bool> ExistsBySkuAsync(string sku, CancellationToken cancellationToken = default);
+    void Add(Item item);
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/apps/backend/CargoPilot.Application/Features/Items/CreateItem/CreateItemCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Items/CreateItem/CreateItemCommandHandler.cs
@@ -1,0 +1,69 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Entities;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Items.CreateItem;
+
+public sealed class CreateItemCommandHandler : IRequestHandler<CreateItemCommand, Result<Guid>>
+{
+    private readonly IItemRepository _itemRepository;
+    private readonly IValidator<CreateItemCommand> _validator;
+
+    public CreateItemCommandHandler(
+        IItemRepository itemRepository,
+        IValidator<CreateItemCommand> validator)
+    {
+        _itemRepository = itemRepository;
+        _validator = validator;
+    }
+
+    public async Task<Result<Guid>> Handle(
+        CreateItemCommand request,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var skuExists = await _itemRepository.ExistsBySkuAsync(request.SKU, cancellationToken);
+        if (skuExists)
+        {
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Conflict, "Item.SkuAlreadyExists", "Bu SKU zaten kullanımda."));
+        }
+
+        var item = new Item(
+            id: Guid.NewGuid(),
+            sku: request.SKU,
+            name: request.Name,
+            productType: request.ProductType,
+            category: request.Category,
+            width: request.Width,
+            height: request.Height,
+            length: request.Length,
+            weight: request.Weight,
+            fragilityType: request.FragilityType,
+            isStackable: request.IsStackable,
+            maxStackCount: request.MaxStackCount,
+            maxWeightOnTop: request.MaxWeightOnTop,
+            allowedRotations: request.AllowedRotations,
+            barcode: request.Barcode,
+            diameter: request.Diameter,
+            imageUrl: request.ImageUrl,
+            stackGroup: request.StackGroup,
+            specialNotes: request.SpecialNotes);
+
+        _itemRepository.Add(item);
+        await _itemRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<Guid>.Success(item.Id);
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
+++ b/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
@@ -30,6 +30,7 @@ public static class DependencyInjection {
         services.AddScoped<IPasswordHasher, BCryptPasswordHasher>();
         services.AddScoped<IJwtTokenService, JwtTokenService>();
         services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IItemRepository, ItemRepository>();
 
 
         if (!useInMemoryRepository) {

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/ItemRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/ItemRepository.cs
@@ -1,0 +1,31 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CargoPilot.Infrastructure.Persistence.Repositories;
+
+internal sealed class ItemRepository : IItemRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public ItemRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<bool> ExistsBySkuAsync(string sku, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.Items
+            .AnyAsync(i => i.SKU == sku, cancellationToken);
+    }
+
+    public void Add(Item item)
+    {
+        _dbContext.Items.Add(item);
+    }
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        return _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/apps/backend/CargoPilot.WebAPI/CargoPilot.WebAPI.csproj
+++ b/apps/backend/CargoPilot.WebAPI/CargoPilot.WebAPI.csproj
@@ -15,13 +15,13 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.4.1" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.6.14" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/backend/CargoPilot.WebAPI/Controllers/ItemsController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/ItemsController.cs
@@ -1,0 +1,43 @@
+using CargoPilot.Application.Features.Items.CreateItem;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CargoPilot.WebAPI.Controllers;
+
+/// <summary>
+/// Ürün (item) yönetimi endpoint'leri.
+/// </summary>
+[Route("api/v1/items")]
+[Tags("Items")]
+[Authorize]
+public sealed class ItemsController : BaseController
+{
+    private readonly IMediator _mediator;
+
+    public ItemsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Yeni ürün oluşturur.
+    /// </summary>
+    /// <response code="201">Ürün oluşturuldu; oluşturulan ürünün Id'si döner.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    /// <response code="409">Bu SKU zaten kullanımda.</response>
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> CreateItem(
+        [FromBody] CreateItemCommand command,
+        CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(command, cancellationToken);
+        if (result.IsSuccess)
+            return StatusCode(StatusCodes.Status201Created, result);
+
+        return HandleResult(result);
+    }
+}

--- a/apps/backend/CargoPilot.WebAPI/DependencyInjection.cs
+++ b/apps/backend/CargoPilot.WebAPI/DependencyInjection.cs
@@ -5,11 +5,12 @@ using CargoPilot.Application.Abstractions;
 using CargoPilot.WebAPI.HealthChecks;
 using CargoPilot.WebAPI.Middlewares;
 using CargoPilot.WebAPI.Services;
+using CargoPilot.WebAPI.Swagger;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.OpenApi;
+using Microsoft.OpenApi.Models;
 using Prometheus;
 
 namespace CargoPilot.WebAPI;
@@ -21,7 +22,6 @@ public static class DependencyInjection {
         WriteIndented          = false,
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
     };
-
     public static IServiceCollection AddPresentation(
         this IServiceCollection services,
         IConfiguration configuration,
@@ -58,6 +58,7 @@ public static class DependencyInjection {
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen(options =>
         {
+            options.OperationFilter<AuthorizeOperationFilter>();
             options.SwaggerDoc("v1", new OpenApiInfo
             {
                 Title = "CargoPilot API",
@@ -74,16 +75,23 @@ public static class DependencyInjection {
             {
                 Name = "Authorization",
                 Type = SecuritySchemeType.Http,
-                Scheme = "Bearer",
+                Scheme = "bearer",
                 BearerFormat = "JWT",
                 In = ParameterLocation.Header,
                 Description = "JWT token girin. Örnek: Bearer {token}"
             });
 
-            options.AddSecurityRequirement(_ => new OpenApiSecurityRequirement
+            options.AddSecurityRequirement(new OpenApiSecurityRequirement
             {
                 {
-                    new OpenApiSecuritySchemeReference("Bearer"),
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        }
+                    },
                     new List<string>()
                 }
             });

--- a/apps/backend/CargoPilot.WebAPI/Swagger/AuthorizeOperationFilter.cs
+++ b/apps/backend/CargoPilot.WebAPI/Swagger/AuthorizeOperationFilter.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace CargoPilot.WebAPI.Swagger;
+
+public sealed class AuthorizeOperationFilter : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        var hasAuthorize =
+            context.MethodInfo.DeclaringType?.GetCustomAttributes(true).OfType<AuthorizeAttribute>().Any() == true ||
+            context.MethodInfo.GetCustomAttributes(true).OfType<AuthorizeAttribute>().Any();
+
+        var hasAllowAnonymous =
+            context.MethodInfo.DeclaringType?.GetCustomAttributes(true).OfType<AllowAnonymousAttribute>().Any() == true ||
+            context.MethodInfo.GetCustomAttributes(true).OfType<AllowAnonymousAttribute>().Any();
+
+        if (!hasAuthorize || hasAllowAnonymous)
+            return;
+
+        operation.Security = new List<OpenApiSecurityRequirement>
+        {
+            new()
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        }
+                    },
+                    new List<string>()
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
…points

Downgrade to a stable Swashbuckle/OpenAPI combination and align security requirement wiring so Swagger emits Bearer requirements correctly and authorized item creation works end-to-end.

Made-with: Cursor

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
