### PR TITLE
fix(ci): GHCR login kullanıcısı TEST_GHCR_USER secret'ından alındı - US-D27-I

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -342,12 +342,12 @@ jobs:
 
     steps:
       # US-D27-I: Sunucu artık build yapmıyor; GHCR'dan pull edilen image'ı kullanıyor.
-      # Gerekli GitHub Secret: TEST_GHCR_PAT (read:packages scope'lu PAT)
+      # Gerekli GitHub Secret'lar: TEST_GHCR_PAT (read:packages scope'lu PAT), TEST_GHCR_USER (PAT sahibi kullanıcı adı)
       - name: Sunucuya bağlan ve test stack'ini güncelle
         uses: appleboy/ssh-action@v1.0.3
         env:
           GHCR_PAT: ${{ secrets.TEST_GHCR_PAT }}
-          GHCR_USER: ${{ github.actor }}
+          GHCR_USER: ${{ secrets.TEST_GHCR_USER }}
         with:
           host: ${{ secrets.TEST_SSH_HOST }}
           username: root


### PR DESCRIPTION
## Özet

- `GHCR_USER: ${{ github.actor }}` → `GHCR_USER: ${{ secrets.TEST_GHCR_USER }}` değiştirildi
- `github.actor` workflow'u tetikleyen kişiyi döndürür; PAT farklı bir kullanıcıya aitse sunucudaki `docker login ghcr.io` başarısız olur
- `TEST_GHCR_USER` secret'ı PAT sahibini açıkça tanımlar, login güvenilir hale gelir

## Gerekli GitHub Secret

`TEST_GHCR_USER` → GHCR PAT'ını oluşturan kullanıcının GitHub kullanıcı adı

## Test Notu

`test` branch'ine push sonrası `deploy-test-server` job'unda `docker login ghcr.io` adımının başarılı geçtiği doğrulanmalı.