### PR TITLE
fix(ci): Image Build job adı branch protection kuralıyla eşleştirildi - US-D27-I

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -131,7 +131,7 @@ jobs:
   # ─── Build job: sadece test'e giden PR'da veya test'e push'ta çalışır ────────
   # US-D27-I: test branch push'ta image'lar GHCR'a push edilir.
   build:
-    name: Image Build & GHCR Push
+    name: Image Build
     runs-on: ubuntu-latest
     needs: [enforce-test-base]
     if: |


### PR DESCRIPTION
## Özet

- `Image Build & GHCR Push` → `Image Build` olarak rename edildi
- Branch protection required check `Image Build` adını bekliyordu; yeni isim eşleşmediği için test PR'ında "Waiting for status to be reported" hatası alınıyordu
- Job'un içeriği ve GHCR push mantığı değişmedi, sadece `name:` alanı düzeltildi