### PR TITLE
docs: US-D27-I GHCR entegrasyonu sonrası dokümantasyon güncellendi

### DIFF
--- a/docs/devops/secret-management.md
+++ b/docs/devops/secret-management.md
@@ -91,13 +91,15 @@ ASP.NET Core ortam değişkenlerini `appsettings.json`'ın üstüne otomatik uyg
 |--------|-----------------|
 | `TEST_SSH_HOST` | test-deploy.yml — sunucu IP |
 | `TEST_SSH_PRIVATE_KEY` | test-deploy.yml — SSH deploy key |
-| `TEST_MSSQL_SA_PASSWORD` | test-deploy.yml — test DB parolası |
-| `TEST_MINIO_ROOT_USER` | test-deploy.yml — test MinIO kullanıcısı |
-| `TEST_MINIO_ROOT_PASSWORD` | test-deploy.yml — test MinIO parolası |
-| `SEED_DEFAULT_ADMIN_PASSWORD` | test-deploy.yml — seed admin parolası |
+| `JWT_SECRET` | test-deploy.yml — JWT imzalama anahtarı |
+| `TEST_GHCR_PAT` | test-deploy.yml — GHCR'dan image pull için classic PAT (`read:packages` scope) |
+| `TEST_GHCR_USER` | test-deploy.yml — `TEST_GHCR_PAT`'ı oluşturan GitHub kullanıcı adı |
+
+> **US-D27-I:** Image'lar artık CI'da GHCR'a push edilir (`ghcr.io/divizyon/cargo-pilot-*:test`),
+> sunucu build yapmaz, yalnızca pull eder. `TEST_GHCR_PAT` classic PAT olmalı;
+> fine-grained token GHCR ile çalışmaz.
 
 GitHub → Settings → Secrets and variables → Actions altında yönetilir.
-CI secret yoksa fallback değerler devreye girer (sadece CI ortamı için geçerli, prod için kullanılmaz).
 
 ---
 

--- a/docs/devops/server-requirements.md
+++ b/docs/devops/server-requirements.md
@@ -50,8 +50,8 @@ RAM kullanımı:
   ├── Monitoring (Prometheus + Grafana + Loki + Promtail + cAdvisor + node_exporter) ~1.5 GB
   └── Toplam tahmini       ≈ 6.9 GB / 16 GB (%43)
 
-  ⚠️ Docker image build sırasında .NET + node peak RAM kullanımı +3-5 GB ekler.
-     Build adımları sırayla yapılmalı (backend önce, frontend sonra).
+  ✅ US-D27-I sonrası image build sunucuda yapılmıyor; CI'da GHCR'a push edilip
+     sunucuya pull ediliyor. Build sırasındaki +3-5 GB RAM baskısı ortadan kalktı.
 
 Disk kullanımı:
   ├── OS + Docker images    ~23 GB (2026-04-25 itibarıyla)
@@ -62,7 +62,7 @@ Disk kullanımı:
 
 ### Sonuç: ✅ Yeterli
 Mevcut sunucu kapasitesi prod + test + monitoring stack'i aynı anda çalıştırmaya yeterli.
-Build sırasında paralel image build yapılmamalı (OOM riski).
+Image build CI'da yapıldığından sunucuda OOM riski ortadan kalktı.
 
 ---
 


### PR DESCRIPTION
## Özet

- `docs/devops/secret-management.md` Section 4: Eski/eksik secret listesi güncellendi
  - Kaldırıldı: `TEST_MSSQL_SA_PASSWORD`, `TEST_MINIO_ROOT_USER`, `TEST_MINIO_ROOT_PASSWORD`, `SEED_DEFAULT_ADMIN_PASSWORD` (bunlar `.env.test`'e taşındı, CI secret'ı değil)
  - Eklendi: `JWT_SECRET`, `TEST_GHCR_PAT`, `TEST_GHCR_USER` (classic PAT notu ile)
- `docs/devops/server-requirements.md`: Sunucuda image build yapılmadığı için +3-5 GB RAM baskısı notu kaldırıldı