### PR TITLE
Ürün özel notlar alanı maksimum karakter sınırı 500 olarak güncellendi.

### DIFF
--- a/apps/backend/CargoPilot.Application/Features/Items/CreateItem/CreateItemCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Items/CreateItem/CreateItemCommandValidator.cs
@@ -98,9 +98,9 @@ public sealed class CreateItemCommandValidator : AbstractValidator<CreateItemCom
                 .WithMessage("Stack group en fazla 100 karakter olabilir.");
 
         RuleFor(x => x.SpecialNotes)
-            .MaximumLength(1000)
+            .MaximumLength(500)
                 .WithErrorCode("ITEM_VAL_SPECIALNOTES_TOO_LONG")
-                .WithMessage("Ozel notlar en fazla 1000 karakter olabilir.");
+                .WithMessage("Ozel notlar en fazla 500 karakter olabilir.");
 
         RuleFor(x => x.MaxStackCount)
             .Equal(0)

--- a/apps/backend/CargoPilot.Application/Features/Items/UpdateItem/UpdateItemCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Items/UpdateItem/UpdateItemCommandValidator.cs
@@ -103,9 +103,9 @@ public sealed class UpdateItemCommandValidator : AbstractValidator<UpdateItemCom
                 .WithMessage("Stack group en fazla 100 karakter olabilir.");
 
         RuleFor(x => x.SpecialNotes)
-            .MaximumLength(1000)
+            .MaximumLength(500)
                 .WithErrorCode("ITEM_VAL_SPECIALNOTES_TOO_LONG")
-                .WithMessage("Ozel notlar en fazla 1000 karakter olabilir.");
+                .WithMessage("Ozel notlar en fazla 500 karakter olabilir.");
 
         RuleFor(x => x.MaxStackCount)
             .Equal(0)

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/ItemConfiguration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/ItemConfiguration.cs
@@ -85,7 +85,7 @@ internal sealed class ItemConfiguration : IEntityTypeConfiguration<Item> {
             .HasMaxLength(100);
 
         builder.Property(item => item.SpecialNotes)
-            .HasMaxLength(1000);
+            .HasMaxLength(500);
 
         builder.HasIndex(item => item.SKU)
             .IsUnique()

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260428154119_UpdateSpecialNotesMaxLength.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260428154119_UpdateSpecialNotesMaxLength.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428154119_UpdateSpecialNotesMaxLength")]
+    partial class UpdateSpecialNotesMaxLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260428154119_UpdateSpecialNotesMaxLength.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260428154119_UpdateSpecialNotesMaxLength.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateSpecialNotesMaxLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "SpecialNotes",
+                table: "Items",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1000)",
+                oldMaxLength: 1000,
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "SpecialNotes",
+                table: "Items",
+                type: "nvarchar(1000)",
+                maxLength: 1000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(500)",
+                oldMaxLength: 500,
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
## Özet

SpecialNotes alanının maksimum karakter sınırı 1000'den 500'e düşürüldü. Validator, DB konfigürasyonu ve migration güncellendi.

## İlgili User Story / Issue

US-VY-DAT-specialnotes

## Değişiklik Tipi

- [x] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x] Manuel test yapıldı

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

SpecialNotes kolonu AddItemModel migration'ında nvarchar(1000) olarak tanımlanmıştı. AC4 gereği 500 karakter olması gerektiğinden yeni migration ile ALTER edildi. Mevcut veritabanında 500 karakteri aşan SpecialNotes kaydı bulunmuyorsa veri kaybı riski yoktur.
