### PR TITLE
Feature/us auth 05 hesap kitleme mekanizması

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Errors/AuthErrors.cs
+++ b/apps/backend/CargoPilot.Application/Common/Errors/AuthErrors.cs
@@ -9,8 +9,15 @@ public static class AuthErrors
         "AUTH_INVALID_CREDENTIALS",
         "Email veya şifre hatalı.");
 
-    public static Error AccountLocked(int minutesRemaining) => new(
+    public static Error AccountLocked(int remainingSeconds) => new(
         ErrorType.Unauthorized,
         "AUTH_ACCOUNT_LOCKED",
-        $"Hesabınız çok fazla hatalı giriş denemesi nedeniyle geçici olarak kilitlendi. Lütfen {minutesRemaining} dakika sonra tekrar deneyin.");
+        $"Hesabınız güvenlik nedeniyle geçici olarak kilitlenmiştir. {(int)Math.Ceiling(remainingSeconds / 60.0)} dakika sonra tekrar deneyiniz.",
+        Metadata: new Dictionary<string, object> { ["lockoutRemainingSeconds"] = remainingSeconds });
+
+    public static Error IpLocked(int remainingSeconds) => new(
+        ErrorType.Unauthorized,
+        "AUTH_IP_LOCKED",
+        $"Bu IP adresinden çok fazla hatalı giriş denemesi yapıldı. {(int)Math.Ceiling(remainingSeconds / 60.0)} dakika sonra tekrar deneyiniz.",
+        Metadata: new Dictionary<string, object> { ["lockoutRemainingSeconds"] = remainingSeconds });
 }

--- a/apps/backend/CargoPilot.Application/Common/Models/Error.cs
+++ b/apps/backend/CargoPilot.Application/Common/Models/Error.cs
@@ -19,7 +19,8 @@ public record Error(
     ErrorType Type,
     string Code,
     string Description,
-    IReadOnlyList<ValidationFailure>? ValidationErrors = null)
+    IReadOnlyList<ValidationFailure>? ValidationErrors = null,
+    IReadOnlyDictionary<string, object>? Metadata = null)
 {
     public static readonly Error None = new(ErrorType.None, string.Empty, string.Empty);
 }

--- a/apps/backend/CargoPilot.Domain/Entities/AppUser.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/AppUser.cs
@@ -4,7 +4,7 @@ namespace CargoPilot.Domain.Entities;
 
 public sealed class AppUser : BaseEntity {
     private const int _maxFailedAttempts = 5;
-    private const int _lockoutDurationMinutes = 15;
+    private static readonly int[] _lockoutDurationsMinutes = [2, 5, 10];
 
     public Guid? CompanyId { get; private set; }
     public string FirstName { get; private set; } = null!;
@@ -15,6 +15,7 @@ public sealed class AppUser : BaseEntity {
     public string? ExternalSystemId { get; private set; }
     public AuthProvider AuthProvider { get; private set; }
     public int FailedLoginAttempts { get; private set; }
+    public int LockoutCount { get; private set; }
     public DateTime? LockoutEndUtc { get; private set; }
 
     // EF Core sets navigation properties via materialization.
@@ -51,12 +52,17 @@ public sealed class AppUser : BaseEntity {
 
     public void RecordFailedLogin() {
         FailedLoginAttempts++;
-        if (FailedLoginAttempts >= _maxFailedAttempts)
-            LockoutEndUtc = DateTime.UtcNow.AddMinutes(_lockoutDurationMinutes);
+        if (FailedLoginAttempts >= _maxFailedAttempts) {
+            var durationIndex = Math.Min(LockoutCount, _lockoutDurationsMinutes.Length - 1);
+            LockoutEndUtc = DateTime.UtcNow.AddMinutes(_lockoutDurationsMinutes[durationIndex]);
+            LockoutCount++;
+            FailedLoginAttempts = 0;
+        }
     }
 
     public void ResetLoginAttempts() {
         FailedLoginAttempts = 0;
+        LockoutCount = 0;
         LockoutEndUtc = null;
     }
 }

--- a/apps/backend/CargoPilot.Domain/Entities/IpLoginAttempt.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/IpLoginAttempt.cs
@@ -1,0 +1,33 @@
+namespace CargoPilot.Domain.Entities;
+
+public sealed class IpLoginAttempt {
+    private const int _maxFailedAttempts = 5;
+    private static readonly int[] _lockoutDurationsMinutes = [2, 5, 10];
+
+    public string IpAddress { get; private set; } = null!;
+    public int FailedAttempts { get; private set; }
+    public int LockoutCount { get; private set; }
+    public DateTime? LockoutEndUtc { get; private set; }
+    public DateTime LastAttemptUtc { get; private set; }
+
+    private IpLoginAttempt() { }
+
+    public IpLoginAttempt(string ipAddress) {
+        IpAddress = ipAddress;
+        LastAttemptUtc = DateTime.UtcNow;
+    }
+
+    public bool IsLockedOut() =>
+        LockoutEndUtc.HasValue && LockoutEndUtc.Value > DateTime.UtcNow;
+
+    public void RecordFailedAttempt() {
+        FailedAttempts++;
+        LastAttemptUtc = DateTime.UtcNow;
+        if (FailedAttempts >= _maxFailedAttempts) {
+            var durationIndex = Math.Min(LockoutCount, _lockoutDurationsMinutes.Length - 1);
+            LockoutEndUtc = DateTime.UtcNow.AddMinutes(_lockoutDurationsMinutes[durationIndex]);
+            LockoutCount++;
+            FailedAttempts = 0;
+        }
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Auth/AuthService.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Auth/AuthService.cs
@@ -54,19 +54,50 @@ internal sealed class AuthService : IAuthService
         if (user is null)
             return Result<LoginResponse>.Failure(AuthErrors.InvalidCredentials);
 
+        // AC3: IP-based lockout check
+        if (!string.IsNullOrEmpty(ipAddress))
+        {
+            var ipAttempt = await _context.IpLoginAttempts
+                .FirstOrDefaultAsync(x => x.IpAddress == ipAddress, cancellationToken);
+
+            if (ipAttempt is not null && ipAttempt.IsLockedOut())
+            {
+                var ipRemaining = (int)Math.Ceiling((ipAttempt.LockoutEndUtc!.Value - DateTime.UtcNow).TotalSeconds);
+                return Result<LoginResponse>.Failure(AuthErrors.IpLocked(ipRemaining));
+            }
+        }
+
+        // AC1: User-based lockout check
         if (user.IsLockedOut())
         {
-            var remaining = (int)Math.Ceiling((user.LockoutEndUtc!.Value - DateTime.UtcNow).TotalMinutes);
-            return Result<LoginResponse>.Failure(AuthErrors.AccountLocked(remaining));
+            var remainingSeconds = (int)Math.Ceiling((user.LockoutEndUtc!.Value - DateTime.UtcNow).TotalSeconds);
+            return Result<LoginResponse>.Failure(AuthErrors.AccountLocked(remainingSeconds));
         }
 
         if (!passwordValid)
         {
+            // AC1 + AC3: record failed attempt for both user and IP
             user.RecordFailedLogin();
+
+            if (!string.IsNullOrEmpty(ipAddress))
+            {
+                var ipAttempt = await _context.IpLoginAttempts
+                    .FirstOrDefaultAsync(x => x.IpAddress == ipAddress, cancellationToken);
+
+                if (ipAttempt is null)
+                {
+                    ipAttempt = new IpLoginAttempt(ipAddress);
+                    _context.IpLoginAttempts.Add(ipAttempt);
+                }
+
+                ipAttempt.RecordFailedAttempt();
+            }
+
             await _context.SaveChangesAsync(cancellationToken);
             return Result<LoginResponse>.Failure(AuthErrors.InvalidCredentials);
         }
 
+        // AC4: reset on successful login
         user.ResetLoginAttempts();
 
         var now = DateTime.UtcNow;

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContext.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContext.cs
@@ -19,6 +19,7 @@ public class AppDbContext : DbContext {
     public DbSet<UserLogin> UserLogins => Set<UserLogin>();
     public DbSet<Item> Items => Set<Item>();
     public DbSet<Vehicle> Vehicles => Set<Vehicle>();
+    public DbSet<IpLoginAttempt> IpLoginAttempts => Set<IpLoginAttempt>();
 
     public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) {
         ApplyAuditFields();
@@ -37,6 +38,7 @@ public class AppDbContext : DbContext {
         modelBuilder.ApplyConfiguration(new UserLoginConfiguration());
         modelBuilder.ApplyConfiguration(new ItemConfiguration());
         modelBuilder.ApplyConfiguration(new VehicleConfiguration());
+        modelBuilder.ApplyConfiguration(new IpLoginAttemptConfiguration());
     }
 
     private void ApplyAuditFields() {

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/AppUserConfiguration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/AppUserConfiguration.cs
@@ -58,6 +58,10 @@ internal sealed class AppUserConfiguration : IEntityTypeConfiguration<AppUser> {
             .IsRequired()
             .HasDefaultValue(0);
 
+        builder.Property(user => user.LockoutCount)
+            .IsRequired()
+            .HasDefaultValue(0);
+
         builder.Property(user => user.LockoutEndUtc);
 
         builder.HasIndex(user => user.Email)

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/IpLoginAttemptConfiguration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/IpLoginAttemptConfiguration.cs
@@ -1,0 +1,29 @@
+using CargoPilot.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CargoPilot.Infrastructure.Persistence.Configurations;
+
+internal sealed class IpLoginAttemptConfiguration : IEntityTypeConfiguration<IpLoginAttempt> {
+    public void Configure(EntityTypeBuilder<IpLoginAttempt> builder) {
+        builder.ToTable("IpLoginAttempts");
+        builder.HasKey(x => x.IpAddress);
+
+        builder.Property(x => x.IpAddress)
+            .HasMaxLength(45)
+            .IsRequired();
+
+        builder.Property(x => x.FailedAttempts)
+            .IsRequired()
+            .HasDefaultValue(0);
+
+        builder.Property(x => x.LockoutCount)
+            .IsRequired()
+            .HasDefaultValue(0);
+
+        builder.Property(x => x.LockoutEndUtc);
+
+        builder.Property(x => x.LastAttemptUtc)
+            .IsRequired();
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260428183421_AddProgressiveLockoutAndIpTracking.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260428183421_AddProgressiveLockoutAndIpTracking.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428183421_AddProgressiveLockoutAndIpTracking")]
+    partial class AddProgressiveLockoutAndIpTracking
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260428183421_AddProgressiveLockoutAndIpTracking.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260428183421_AddProgressiveLockoutAndIpTracking.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProgressiveLockoutAndIpTracking : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "LockoutCount",
+                table: "Users",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateTable(
+                name: "IpLoginAttempts",
+                columns: table => new
+                {
+                    IpAddress = table.Column<string>(type: "nvarchar(45)", maxLength: 45, nullable: false),
+                    FailedAttempts = table.Column<int>(type: "int", nullable: false, defaultValue: 0),
+                    LockoutCount = table.Column<int>(type: "int", nullable: false, defaultValue: 0),
+                    LockoutEndUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    LastAttemptUtc = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_IpLoginAttempts", x => x.IpAddress);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "IpLoginAttempts");
+
+            migrationBuilder.DropColumn(
+                name: "LockoutCount",
+                table: "Users");
+        }
+    }
+}


### PR DESCRIPTION
- 5 hatalı denemede progressive kilit: 1. 2 dk, 2. 5 dk, 3.+ 10 dk
- IP bazlı kilit mekanizması eklendi (IpLoginAttempts tablosu)
- Kilit hata mesajı AC2 formatına güncellendi
- Error modeline Metadata desteği eklendi (lockoutRemainingSeconds)
- Başarılı girişte LockoutCount sıfırlanıyor
- Migration: AddProgressiveLockoutAndIpTracking

## Özet

Özet
US-AUTH-05 kapsamında hesap kilitleme mekanizması backend'e eklendi. 5 hatalı denemede hesap kilitlenir; kilit süresi her yeni kilitlemede artar (2 → 5 → 10 dk). Ek olarak IP bazlı kilit mekanizması da devreye alındı; farklı IP'lerden gelen denemeler hem kullanıcı sayacına hem de IP sayacına yansır. Hata response'una lockoutRemainingSeconds alanı eklendi.

İlgili User Story / Issue
US-AUTH-05

Değişiklik Tipi
 🚀 Yeni özellik (feature)
Test Edildi mi?
 Manuel test yapıldı
Kontrol Listesi
 Kod standartlarına uygun
 Commit mesajları [commit kurallarına](vscode-webview://0fqe5j111o39ctng830occ9l2q4o9h10unjt04h31j1ieurd5h0r/docs/conventions/COMMITS.md) uygun
 Linter hataları yok
 Self-review yapıldı
 Dokümantasyon güncellendi (gerekiyorsa)
Ek Notlar
AC1 — Progressive kilit: 5 hatalı denemede hesap kilitlenir. 1. kilitlemede 2 dk, 2. kilitlemede 5 dk, 3. ve sonrasında 10 dk. LockoutCount ile takip edilir; başarılı girişte sıfırlanır.

AC2 — Hata mesajı: "Hesabınız güvenlik nedeniyle geçici olarak kilitlenmiştir. X dakika sonra tekrar deneyiniz." mesajı döner. Response'da metadata.lockoutRemainingSeconds alanı ile kalan süre saniye cinsinden de iletilir (frontend sayaç için).

AC3 — IP bazlı kilit: IpLoginAttempts tablosu eklendi. Her başarısız denemede hem kullanıcı hem de kaynak IP sayacı güncellenir. IP de aynı progressive kilit kuralına (2/5/10 dk) tabidir.

AC4 — Sıfırlama: Başarılı girişte FailedLoginAttempts, LockoutCount ve LockoutEndUtc sıfırlanır.

Migration: AddProgressiveLockoutAndIpTracking — Users tablosuna LockoutCount sütunu eklendi, IpLoginAttempts tablosu oluşturuldu.