### PR TITLE
Feature/us vy dat 02 product form redesign

### DIFF
--- a/apps/frontend/src/features/data-management/components/ProductForm.tsx
+++ b/apps/frontend/src/features/data-management/components/ProductForm.tsx
@@ -1,16 +1,7 @@
 import type { ReactNode } from 'react';
 import { Controller, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import {
-  Ban,
-  Box,
-  Cylinder,
-  Droplets,
-  HelpCircle,
-  Move3d,
-  Package,
-  Wine,
-} from 'lucide-react';
+import { Ban, Box, Cylinder, Droplets, HelpCircle, Move3d, Package, Wine } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import {
   Form,
@@ -304,365 +295,364 @@ export function ProductForm({
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
           <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_380px]">
-          {/* SOL — Form alanları */}
-          <div className="space-y-8">
-            {/* Kimlik */}
-            <section className="space-y-3">
-              <SectionTitle>{t('forms.product.sectionIdentity')}</SectionTitle>
-              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                <FormField
-                  control={form.control}
-                  name="name"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>{t('forms.product.name')}</FormLabel>
-                      <FormControl>
-                        <Input
-                          className={COMPACT_INPUT}
-                          placeholder={t('forms.product.namePlaceholder')}
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="sku"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>{t('forms.product.sku')}</FormLabel>
-                      <FormControl>
-                        <Input
-                          className={COMPACT_INPUT}
-                          placeholder={t('forms.product.skuPlaceholder')}
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </section>
-
-            {/* Ürün Tipi & Hassasiyet */}
-            <section className="space-y-3">
-              <SectionTitle>{t('forms.product.sectionType')}</SectionTitle>
-              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                <FormField
-                  control={form.control}
-                  name="productType"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="block">{t('forms.product.sectionType')}</FormLabel>
-                      <FormControl>
-                        <ToggleGroup
-                          type="single"
-                          value={field.value}
-                          onValueChange={(value) => value && field.onChange(value)}
-                          className="flex flex-wrap"
-                        >
-                          {PRODUCT_TYPE_OPTIONS.map(({ value, labelKey, Icon }) => (
-                            <ToggleGroupItem key={value} value={value} aria-label={t(labelKey)}>
-                              <Icon className="h-5 w-5" strokeWidth={1.5} />
-                              <span className="text-xs">{t(labelKey)}</span>
-                            </ToggleGroupItem>
-                          ))}
-                        </ToggleGroup>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name="fragility"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="block">{t('forms.product.fragility')}</FormLabel>
-                      <FormControl>
-                        <ToggleGroup
-                          type="single"
-                          value={String(field.value)}
-                          onValueChange={(value) => {
-                            if (value === '') return;
-                            const num = Number(value);
-                            field.onChange(num);
-                            if (num === FRAGILITY_LEVELS.NonFragile) {
-                              form.setValue('maxStackCount', 1, { shouldValidate: false });
-                              form.setValue('isStackable', false, { shouldValidate: false });
-                            }
-                          }}
-                          className="flex flex-wrap"
-                        >
-                          <ToggleGroupItem value={String(FRAGILITY_LEVELS.NonFragile)}>
-                            <NonStackableIcon className="h-5 w-5" />
-                            <span className="text-xs">{t('forms.product.fragilityNonFragile')}</span>
-                          </ToggleGroupItem>
-                          <ToggleGroupItem value={String(FRAGILITY_LEVELS.Fragile)}>
-                            <Wine className="h-5 w-5 text-amber-500" strokeWidth={1.5} />
-                            <span className="text-xs">{t('forms.product.fragilityFragile')}</span>
-                          </ToggleGroupItem>
-                          <ToggleGroupItem value={String(FRAGILITY_LEVELS.Liquid)}>
-                            <Droplets className="h-5 w-5 text-blue-500" strokeWidth={1.5} />
-                            <span className="text-xs">{t('forms.product.fragilityLiquid')}</span>
-                          </ToggleGroupItem>
-                        </ToggleGroup>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </section>
-
-            {/* Fiziksel Özellikler — Genişlik / Yükseklik / Uzunluk / Ağırlık / Katman Sayısı */}
-            <section className="space-y-3">
-              <SectionTitle>{t('forms.product.sectionPhysical')}</SectionTitle>
-              <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-5">
-                <DimensionField
-                  form={form}
-                  name="width"
-                  unitName="widthUnit"
-                  labelKey="forms.product.width"
-                />
-                <DimensionField
-                  form={form}
-                  name="height"
-                  unitName="heightUnit"
-                  labelKey="forms.product.height"
-                />
-                <DimensionField
-                  form={form}
-                  name="length"
-                  unitName="lengthUnit"
-                  labelKey="forms.product.length"
-                />
-                <FormField
-                  control={form.control}
-                  name="weight"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>{t('forms.product.weight')}</FormLabel>
-                      <div className="relative">
+            {/* SOL — Form alanları */}
+            <div className="space-y-8">
+              {/* Kimlik */}
+              <section className="space-y-3">
+                <SectionTitle>{t('forms.product.sectionIdentity')}</SectionTitle>
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('forms.product.name')}</FormLabel>
                         <FormControl>
                           <Input
-                            type="number"
-                            step="0.1"
-                            min={0}
-                            className={COMPACT_INPUT_WITH_UNIT}
+                            className={COMPACT_INPUT}
+                            placeholder={t('forms.product.namePlaceholder')}
                             {...field}
-                            value={field.value ?? ''}
-                            onChange={(e) =>
-                              field.onChange(
-                                e.target.value === '' ? undefined : e.target.valueAsNumber,
-                              )
-                            }
                           />
                         </FormControl>
-                        <Controller
-                          control={form.control}
-                          name="weightUnit"
-                          render={({ field: unitField }) => (
-                            <Select value={unitField.value} onValueChange={unitField.onChange}>
-                              <SelectTrigger className={UNIT_TRIGGER}>
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                {WEIGHT_KEYS.map((unit) => (
-                                  <SelectItem key={unit} value={unit}>
-                                    {unit}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                          )}
-                        />
-                      </div>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="maxStackCount"
-                  render={({ field }) => {
-                    const lockToOne = fragility === FRAGILITY_LEVELS.NonFragile;
-                    return (
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="sku"
+                    render={({ field }) => (
                       <FormItem>
-                        <div className="flex items-center justify-between gap-2">
-                          <FormLabel className="m-0">
-                            {t('forms.product.layerCount')}
-                          </FormLabel>
-                          <Badge
-                            variant="outline"
-                            aria-hidden={!isNonStackableSelected}
-                            className={cn(
-                              'h-5 gap-1 border-amber-300 bg-amber-50 px-1.5 text-[10px] text-amber-800',
-                              !isNonStackableSelected && 'invisible',
-                            )}
-                          >
-                            {t('forms.product.nonStackable')}
-                          </Badge>
-                        </div>
+                        <FormLabel>{t('forms.product.sku')}</FormLabel>
                         <FormControl>
                           <Input
-                            type="number"
-                            min={1}
-                            step={1}
-                            placeholder="1"
-                            disabled={lockToOne}
-                            className={cn(COMPACT_INPUT, lockToOne && 'cursor-not-allowed')}
+                            className={COMPACT_INPUT}
+                            placeholder={t('forms.product.skuPlaceholder')}
                             {...field}
-                            value={lockToOne ? 1 : (field.value ?? '')}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </section>
+
+              {/* Ürün Tipi & Hassasiyet */}
+              <section className="space-y-3">
+                <SectionTitle>{t('forms.product.sectionType')}</SectionTitle>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <FormField
+                    control={form.control}
+                    name="productType"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="block">{t('forms.product.sectionType')}</FormLabel>
+                        <FormControl>
+                          <ToggleGroup
+                            type="single"
+                            value={field.value}
+                            onValueChange={(value) => value && field.onChange(value)}
+                            className="flex flex-wrap"
+                          >
+                            {PRODUCT_TYPE_OPTIONS.map(({ value, labelKey, Icon }) => (
+                              <ToggleGroupItem key={value} value={value} aria-label={t(labelKey)}>
+                                <Icon className="h-5 w-5" strokeWidth={1.5} />
+                                <span className="text-xs">{t(labelKey)}</span>
+                              </ToggleGroupItem>
+                            ))}
+                          </ToggleGroup>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  <FormField
+                    control={form.control}
+                    name="fragility"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="block">{t('forms.product.fragility')}</FormLabel>
+                        <FormControl>
+                          <ToggleGroup
+                            type="single"
+                            value={String(field.value)}
+                            onValueChange={(value) => {
+                              if (value === '') return;
+                              const num = Number(value);
+                              field.onChange(num);
+                              if (num === FRAGILITY_LEVELS.NonFragile) {
+                                form.setValue('maxStackCount', 1, { shouldValidate: false });
+                                form.setValue('isStackable', false, { shouldValidate: false });
+                              }
+                            }}
+                            className="flex flex-wrap"
+                          >
+                            <ToggleGroupItem value={String(FRAGILITY_LEVELS.NonFragile)}>
+                              <NonStackableIcon className="h-5 w-5" />
+                              <span className="text-xs">
+                                {t('forms.product.fragilityNonFragile')}
+                              </span>
+                            </ToggleGroupItem>
+                            <ToggleGroupItem value={String(FRAGILITY_LEVELS.Fragile)}>
+                              <Wine className="h-5 w-5 text-amber-500" strokeWidth={1.5} />
+                              <span className="text-xs">{t('forms.product.fragilityFragile')}</span>
+                            </ToggleGroupItem>
+                            <ToggleGroupItem value={String(FRAGILITY_LEVELS.Liquid)}>
+                              <Droplets className="h-5 w-5 text-blue-500" strokeWidth={1.5} />
+                              <span className="text-xs">{t('forms.product.fragilityLiquid')}</span>
+                            </ToggleGroupItem>
+                          </ToggleGroup>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              </section>
+
+              {/* Fiziksel Özellikler — Genişlik / Yükseklik / Uzunluk / Ağırlık / Katman Sayısı */}
+              <section className="space-y-3">
+                <SectionTitle>{t('forms.product.sectionPhysical')}</SectionTitle>
+                <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-5">
+                  <DimensionField
+                    form={form}
+                    name="width"
+                    unitName="widthUnit"
+                    labelKey="forms.product.width"
+                  />
+                  <DimensionField
+                    form={form}
+                    name="height"
+                    unitName="heightUnit"
+                    labelKey="forms.product.height"
+                  />
+                  <DimensionField
+                    form={form}
+                    name="length"
+                    unitName="lengthUnit"
+                    labelKey="forms.product.length"
+                  />
+                  <FormField
+                    control={form.control}
+                    name="weight"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t('forms.product.weight')}</FormLabel>
+                        <div className="relative">
+                          <FormControl>
+                            <Input
+                              type="number"
+                              step="0.1"
+                              min={0}
+                              className={COMPACT_INPUT_WITH_UNIT}
+                              {...field}
+                              value={field.value ?? ''}
+                              onChange={(e) =>
+                                field.onChange(
+                                  e.target.value === '' ? undefined : e.target.valueAsNumber,
+                                )
+                              }
+                            />
+                          </FormControl>
+                          <Controller
+                            control={form.control}
+                            name="weightUnit"
+                            render={({ field: unitField }) => (
+                              <Select value={unitField.value} onValueChange={unitField.onChange}>
+                                <SelectTrigger className={UNIT_TRIGGER}>
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {WEIGHT_KEYS.map((unit) => (
+                                    <SelectItem key={unit} value={unit}>
+                                      {unit}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            )}
+                          />
+                        </div>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="maxStackCount"
+                    render={({ field }) => {
+                      const lockToOne = fragility === FRAGILITY_LEVELS.NonFragile;
+                      return (
+                        <FormItem>
+                          <div className="flex items-center justify-between gap-2">
+                            <FormLabel className="m-0">{t('forms.product.layerCount')}</FormLabel>
+                            <Badge
+                              variant="outline"
+                              aria-hidden={!isNonStackableSelected}
+                              className={cn(
+                                'h-5 gap-1 border-amber-300 bg-amber-50 px-1.5 text-[10px] text-amber-800',
+                                !isNonStackableSelected && 'invisible',
+                              )}
+                            >
+                              {t('forms.product.nonStackable')}
+                            </Badge>
+                          </div>
+                          <FormControl>
+                            <Input
+                              type="number"
+                              min={1}
+                              step={1}
+                              placeholder="1"
+                              disabled={lockToOne}
+                              className={cn(COMPACT_INPUT, lockToOne && 'cursor-not-allowed')}
+                              {...field}
+                              value={lockToOne ? 1 : (field.value ?? '')}
+                              onChange={(e) => {
+                                if (lockToOne) return;
+                                const value = e.target.value === '' ? 1 : e.target.valueAsNumber;
+                                field.onChange(value);
+                                form.setValue('isStackable', value > 1, { shouldValidate: false });
+                              }}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      );
+                    }}
+                  />
+                </div>
+              </section>
+
+              {/* Kısıtlar — sadece eksen rotasyonu */}
+              <section className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <SectionTitle>{t('forms.product.sectionConstraints')}</SectionTitle>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button type="button" aria-label={t('forms.product.axisGuideAria')}>
+                        <HelpCircle className="h-4 w-4 text-muted-foreground" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <div className="space-y-1">
+                        <p className="font-medium">{t('forms.product.axisGuideTitle')}</p>
+                        <p>{t('forms.product.axisXTooltip')}</p>
+                        <p>{t('forms.product.axisYTooltip')}</p>
+                        <p>{t('forms.product.axisZTooltip')}</p>
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+
+                <div className="grid grid-cols-3 gap-2">
+                  {ROTATION_AXES.map(({ name: axisFieldName, labelKey, tooltipKey, axis }) => (
+                    <FormField
+                      key={axisFieldName}
+                      control={form.control}
+                      name={axisFieldName}
+                      render={({ field }) => (
+                        <FormItem className="m-0 space-y-0">
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                type="button"
+                                aria-pressed={field.value}
+                                aria-label={t(tooltipKey)}
+                                onClick={() => field.onChange(!field.value)}
+                                className={cn(
+                                  'flex h-full w-full flex-col items-center justify-center gap-1 rounded-md border bg-zinc-50 px-2 py-1.5 text-center transition-all',
+                                  field.value
+                                    ? 'border-primary text-primary shadow-sm ring-1 ring-primary/20'
+                                    : 'border-zinc-200 text-muted-foreground hover:border-zinc-300',
+                                )}
+                              >
+                                <AxisBoxIllustration axis={axis} active={field.value} />
+                                <span className="text-xs font-medium leading-none text-foreground">
+                                  {t(labelKey)}
+                                </span>
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>{t(tooltipKey)}</TooltipContent>
+                          </Tooltip>
+                        </FormItem>
+                      )}
+                    />
+                  ))}
+                </div>
+              </section>
+
+              {/* Özel Taşıma Notları */}
+              <section className="space-y-3">
+                <SectionTitle>{t('forms.product.sectionNotes')}</SectionTitle>
+                <FormField
+                  control={form.control}
+                  name="notes"
+                  render={({ field }) => {
+                    const value = field.value ?? '';
+                    const length = value.length;
+                    const isOverLimit = length >= NOTES_MAX_LENGTH;
+                    return (
+                      <FormItem>
+                        <FormLabel className="sr-only">{t('forms.product.notesLabel')}</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            rows={3}
+                            maxLength={NOTES_MAX_LENGTH}
+                            placeholder={t('forms.product.notesPlaceholder')}
+                            className="resize-none overflow-y-auto border-zinc-200 bg-zinc-50 focus-visible:ring-2 focus-visible:ring-primary/40"
+                            {...field}
+                            value={value}
                             onChange={(e) => {
-                              if (lockToOne) return;
-                              const value = e.target.value === '' ? 1 : e.target.valueAsNumber;
-                              field.onChange(value);
-                              form.setValue('isStackable', value > 1, { shouldValidate: false });
+                              const next = e.target.value.slice(0, NOTES_MAX_LENGTH);
+                              field.onChange(next);
                             }}
                           />
                         </FormControl>
+                        <div className="mt-1 flex items-start justify-between gap-3 text-xs">
+                          <p className="text-muted-foreground">{t('forms.product.notesHelper')}</p>
+                          <span
+                            aria-live="polite"
+                            className={cn(
+                              'shrink-0 tabular-nums',
+                              isOverLimit ? 'font-semibold text-red-600' : 'text-muted-foreground',
+                            )}
+                          >
+                            {t('forms.product.notesCounter', {
+                              count: length,
+                              max: NOTES_MAX_LENGTH,
+                            })}
+                          </span>
+                        </div>
                         <FormMessage />
                       </FormItem>
                     );
                   }}
                 />
-              </div>
-            </section>
+              </section>
+            </div>
 
-            {/* Kısıtlar — sadece eksen rotasyonu */}
-            <section className="space-y-3">
-              <div className="flex items-center justify-between">
-                <SectionTitle>{t('forms.product.sectionConstraints')}</SectionTitle>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button type="button" aria-label={t('forms.product.axisGuideAria')}>
-                      <HelpCircle className="h-4 w-4 text-muted-foreground" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <div className="space-y-1">
-                      <p className="font-medium">{t('forms.product.axisGuideTitle')}</p>
-                      <p>{t('forms.product.axisXTooltip')}</p>
-                      <p>{t('forms.product.axisYTooltip')}</p>
-                      <p>{t('forms.product.axisZTooltip')}</p>
-                    </div>
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-
-              <div className="grid grid-cols-3 gap-2">
-                {ROTATION_AXES.map(({ name: axisFieldName, labelKey, tooltipKey, axis }) => (
-                  <FormField
-                    key={axisFieldName}
-                    control={form.control}
-                    name={axisFieldName}
-                    render={({ field }) => (
-                      <FormItem className="m-0 space-y-0">
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              type="button"
-                              aria-pressed={field.value}
-                              aria-label={t(tooltipKey)}
-                              onClick={() => field.onChange(!field.value)}
-                              className={cn(
-                                'flex h-full w-full flex-col items-center justify-center gap-1 rounded-md border bg-zinc-50 px-2 py-1.5 text-center transition-all',
-                                field.value
-                                  ? 'border-primary text-primary shadow-sm ring-1 ring-primary/20'
-                                  : 'border-zinc-200 text-muted-foreground hover:border-zinc-300',
-                              )}
-                            >
-                              <AxisBoxIllustration axis={axis} active={field.value} />
-                              <span className="text-xs font-medium leading-none text-foreground">
-                                {t(labelKey)}
-                              </span>
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>{t(tooltipKey)}</TooltipContent>
-                        </Tooltip>
-                      </FormItem>
-                    )}
-                  />
-                ))}
-              </div>
-            </section>
-
-            {/* Özel Taşıma Notları */}
-            <section className="space-y-3">
-              <SectionTitle>{t('forms.product.sectionNotes')}</SectionTitle>
-              <FormField
-                control={form.control}
-                name="notes"
-                render={({ field }) => {
-                  const value = field.value ?? '';
-                  const length = value.length;
-                  const isOverLimit = length >= NOTES_MAX_LENGTH;
-                  return (
-                    <FormItem>
-                      <FormLabel className="sr-only">{t('forms.product.notesLabel')}</FormLabel>
-                      <FormControl>
-                        <Textarea
-                          rows={3}
-                          maxLength={NOTES_MAX_LENGTH}
-                          placeholder={t('forms.product.notesPlaceholder')}
-                          className="resize-none overflow-y-auto border-zinc-200 bg-zinc-50 focus-visible:ring-2 focus-visible:ring-primary/40"
-                          {...field}
-                          value={value}
-                          onChange={(e) => {
-                            const next = e.target.value.slice(0, NOTES_MAX_LENGTH);
-                            field.onChange(next);
-                          }}
-                        />
-                      </FormControl>
-                      <div className="mt-1 flex items-start justify-between gap-3 text-xs">
-                        <p className="text-muted-foreground">{t('forms.product.notesHelper')}</p>
-                        <span
-                          aria-live="polite"
-                          className={cn(
-                            'shrink-0 tabular-nums',
-                            isOverLimit ? 'font-semibold text-red-600' : 'text-muted-foreground',
-                          )}
-                        >
-                          {t('forms.product.notesCounter', {
-                            count: length,
-                            max: NOTES_MAX_LENGTH,
-                          })}
-                        </span>
-                      </div>
-                      <FormMessage />
-                    </FormItem>
-                  );
-                }}
-              />
-            </section>
-
-          </div>
-
-          {/* SAĞ — 3D Önizleme (Three.js placeholder) */}
-          <PreviewPanel
-            name={name}
-            productType={productType ?? 'box'}
-            length={length}
-            lengthUnit={lengthUnit}
-            width={width}
-            widthUnit={widthUnit}
-            height={height}
-            heightUnit={heightUnit}
-            weight={weight}
-            weightUnit={weightUnit}
-            volumeCm3={volumeCm3}
-            maxStackCount={maxStackCount ?? 1}
-            fragility={fragility ?? 0}
-            allowRotateX={allowRotateX}
-            allowRotateY={allowRotateY}
-            allowRotateZ={allowRotateZ}
-            notes={notes}
-          />
+            {/* SAĞ — 3D Önizleme (Three.js placeholder) */}
+            <PreviewPanel
+              name={name}
+              productType={productType ?? 'box'}
+              length={length}
+              lengthUnit={lengthUnit}
+              width={width}
+              widthUnit={widthUnit}
+              height={height}
+              heightUnit={heightUnit}
+              weight={weight}
+              weightUnit={weightUnit}
+              volumeCm3={volumeCm3}
+              maxStackCount={maxStackCount ?? 1}
+              fragility={fragility ?? 0}
+              allowRotateX={allowRotateX}
+              allowRotateY={allowRotateY}
+              allowRotateZ={allowRotateZ}
+              notes={notes}
+            />
           </div>
 
           {/* Aksiyonlar — sayfa genişliği boyunca, en sağda */}
@@ -768,27 +758,12 @@ function PreviewPanel(props: PreviewPanelProps) {
         {/* Canlı veri özeti */}
         <dl className="space-y-2 text-sm">
           <PreviewRow label={t('forms.product.name')} value={name || '—'} emphasize />
-          <PreviewRow
-            label={t('forms.product.width')}
-            value={fmt(width, widthUnit)}
-          />
-          <PreviewRow
-            label={t('forms.product.height')}
-            value={fmt(height, heightUnit)}
-          />
-          <PreviewRow
-            label={t('forms.product.length')}
-            value={fmt(length, lengthUnit)}
-          />
-          <PreviewRow
-            label={t('forms.product.weight')}
-            value={fmt(weight, weightUnit)}
-          />
+          <PreviewRow label={t('forms.product.width')} value={fmt(width, widthUnit)} />
+          <PreviewRow label={t('forms.product.height')} value={fmt(height, heightUnit)} />
+          <PreviewRow label={t('forms.product.length')} value={fmt(length, lengthUnit)} />
+          <PreviewRow label={t('forms.product.weight')} value={fmt(weight, weightUnit)} />
           <PreviewRow label={t('forms.product.fragility')} value={fragilityLabel} />
-          <PreviewRow
-            label={t('forms.product.layerCount')}
-            value={String(maxStackCount)}
-          />
+          <PreviewRow label={t('forms.product.layerCount')} value={String(maxStackCount)} />
           <PreviewRow
             label={<Move3d className="h-4 w-4" aria-hidden />}
             value={

--- a/apps/frontend/src/features/data-management/components/ProductForm.tsx
+++ b/apps/frontend/src/features/data-management/components/ProductForm.tsx
@@ -1,23 +1,14 @@
-import type { ComponentType, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { Controller, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import {
-  ArrowLeftRight,
-  ArrowUpDown,
   Ban,
   Box,
   Cylinder,
   Droplets,
   HelpCircle,
-  Layers,
   Move3d,
   Package,
-  PackageOpen,
-  Ruler,
-  ShieldOff,
-  StickyNote,
-  Tag,
-  Weight,
   Wine,
 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
@@ -46,7 +37,6 @@ import {
   DIMENSION_UNITS,
   FRAGILITY_LEVELS,
   NOTES_MAX_LENGTH,
-  NOTES_PREVIEW_LENGTH,
   WEIGHT_UNITS,
   toCentimeters,
   type DimensionUnitKey,
@@ -92,6 +82,11 @@ const ROTATION_AXES = [
     axis: 'z' as AxisKey,
   },
 ] as const;
+
+const COMPACT_INPUT = 'h-9 border-zinc-200 bg-zinc-50';
+const COMPACT_INPUT_WITH_UNIT = 'h-9 border-zinc-200 bg-zinc-50 pr-16';
+const UNIT_TRIGGER =
+  'absolute right-1 top-1/2 h-7 w-14 -translate-y-1/2 gap-1 border-0 bg-transparent px-2 py-0 text-xs text-muted-foreground shadow-none focus:ring-0 focus:ring-offset-0';
 
 interface NonStackableIconProps {
   className?: string;
@@ -149,7 +144,6 @@ function ProductTypeIllustration({ type }: ProductTypeIllustrationProps) {
   if (type === 'pallet') {
     return (
       <svg width="140" height="120" viewBox="0 0 140 120" fill="none">
-        {/* üstteki koli */}
         <path
           d="M30 20 L70 8 L110 20 L110 60 L70 72 L30 60 Z"
           stroke={stroke}
@@ -159,7 +153,6 @@ function ProductTypeIllustration({ type }: ProductTypeIllustrationProps) {
         />
         <path d="M30 20 L70 32 L110 20" stroke={stroke} strokeWidth="1.5" />
         <path d="M70 32 L70 72" stroke={stroke} strokeWidth="1.5" />
-        {/* palet üst plaka */}
         <path
           d="M14 76 L70 92 L126 76 L126 84 L70 100 L14 84 Z"
           stroke={stroke}
@@ -167,7 +160,6 @@ function ProductTypeIllustration({ type }: ProductTypeIllustrationProps) {
           strokeLinejoin="round"
           fill="none"
         />
-        {/* palet ayakları */}
         <path d="M22 86 L22 102 L50 110 L50 94" stroke={stroke} strokeWidth="1.5" fill="none" />
         <path d="M70 100 L70 116" stroke={stroke} strokeWidth="1.5" />
         <path d="M118 86 L118 102 L90 110 L90 94" stroke={stroke} strokeWidth="1.5" fill="none" />
@@ -175,7 +167,6 @@ function ProductTypeIllustration({ type }: ProductTypeIllustrationProps) {
     );
   }
 
-  // box (default)
   return (
     <svg width="120" height="120" viewBox="0 0 120 120" fill="none">
       <path
@@ -203,13 +194,12 @@ function AxisBoxIllustration({ axis, active }: AxisBoxIllustrationProps) {
   return (
     <div className="relative">
       <svg
-        width="48"
-        height="44"
+        width="32"
+        height="28"
         viewBox="0 0 72 64"
         fill="none"
         className={cn('transition-opacity', active ? 'opacity-100' : 'opacity-40')}
       >
-        {/* 2D perspektif kutu */}
         <path
           d="M14 22 L36 12 L58 22 L58 46 L36 56 L14 46 Z"
           stroke={stroke}
@@ -219,8 +209,6 @@ function AxisBoxIllustration({ axis, active }: AxisBoxIllustrationProps) {
         />
         <path d="M14 22 L36 32 L58 22" stroke={stroke} strokeWidth="1.5" strokeLinejoin="round" />
         <path d="M36 32 L36 56" stroke={stroke} strokeWidth="1.5" />
-
-        {/* Eksen oku */}
         {axis === 'x' && (
           <>
             <path d="M2 34 L70 34" stroke={arrowColor} strokeWidth="1.5" strokeLinecap="round" />
@@ -244,7 +232,7 @@ function AxisBoxIllustration({ axis, active }: AxisBoxIllustrationProps) {
         )}
       </svg>
       {!active && (
-        <Ban className="absolute inset-0 m-auto h-7 w-7 text-red-500" strokeWidth={2} aria-hidden />
+        <Ban className="absolute inset-0 m-auto h-5 w-5 text-red-500" strokeWidth={2} aria-hidden />
       )}
     </div>
   );
@@ -304,7 +292,7 @@ export function ProductForm({
     ],
   });
 
-  const isNonStackable = !maxStackCount || maxStackCount <= 1;
+  const isNonStackableSelected = fragility === FRAGILITY_LEVELS.NonFragile;
 
   const widthCm = Number.isFinite(width) ? toCentimeters(width, widthUnit ?? 'cm') : 0;
   const heightCm = Number.isFinite(height) ? toCentimeters(height, heightUnit ?? 'cm') : 0;
@@ -314,118 +302,127 @@ export function ProductForm({
   return (
     <TooltipProvider delayDuration={150}>
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-          {/* Bölüm 1 — Kimlik */}
-          <section className="space-y-4">
-            <SectionTitle icon={Tag}>{t('forms.product.sectionIdentity')}</SectionTitle>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-              <FormField
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('forms.product.name')}</FormLabel>
-                    <FormControl>
-                      <Input placeholder={t('forms.product.namePlaceholder')} {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="sku"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>{t('forms.product.sku')}</FormLabel>
-                    <FormControl>
-                      <Input placeholder={t('forms.product.skuPlaceholder')} {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-          </section>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_380px]">
+          {/* SOL — Form alanları */}
+          <div className="space-y-8">
+            {/* Kimlik */}
+            <section className="space-y-3">
+              <SectionTitle>{t('forms.product.sectionIdentity')}</SectionTitle>
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('forms.product.name')}</FormLabel>
+                      <FormControl>
+                        <Input
+                          className={COMPACT_INPUT}
+                          placeholder={t('forms.product.namePlaceholder')}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="sku"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t('forms.product.sku')}</FormLabel>
+                      <FormControl>
+                        <Input
+                          className={COMPACT_INPUT}
+                          placeholder={t('forms.product.skuPlaceholder')}
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </section>
 
-          {/* Bölüm 2 — Ürün Tipi + Kırılganlık */}
-          <section className="space-y-4">
-            <SectionTitle icon={PackageOpen}>{t('forms.product.sectionType')}</SectionTitle>
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-              <FormField
-                control={form.control}
-                name="productType"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="block">{t('forms.product.sectionType')}</FormLabel>
-                    <FormControl>
-                      <ToggleGroup
-                        type="single"
-                        value={field.value}
-                        onValueChange={(value) => value && field.onChange(value)}
-                        className="flex flex-wrap"
-                      >
-                        {PRODUCT_TYPE_OPTIONS.map(({ value, labelKey, Icon }) => (
-                          <ToggleGroupItem key={value} value={value} aria-label={t(labelKey)}>
-                            <Icon className="h-6 w-6" strokeWidth={1.5} />
-                            <span className="text-xs">{t(labelKey)}</span>
+            {/* Ürün Tipi & Hassasiyet */}
+            <section className="space-y-3">
+              <SectionTitle>{t('forms.product.sectionType')}</SectionTitle>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="productType"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="block">{t('forms.product.sectionType')}</FormLabel>
+                      <FormControl>
+                        <ToggleGroup
+                          type="single"
+                          value={field.value}
+                          onValueChange={(value) => value && field.onChange(value)}
+                          className="flex flex-wrap"
+                        >
+                          {PRODUCT_TYPE_OPTIONS.map(({ value, labelKey, Icon }) => (
+                            <ToggleGroupItem key={value} value={value} aria-label={t(labelKey)}>
+                              <Icon className="h-5 w-5" strokeWidth={1.5} />
+                              <span className="text-xs">{t(labelKey)}</span>
+                            </ToggleGroupItem>
+                          ))}
+                        </ToggleGroup>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="fragility"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="block">{t('forms.product.fragility')}</FormLabel>
+                      <FormControl>
+                        <ToggleGroup
+                          type="single"
+                          value={String(field.value)}
+                          onValueChange={(value) => {
+                            if (value === '') return;
+                            const num = Number(value);
+                            field.onChange(num);
+                            if (num === FRAGILITY_LEVELS.NonFragile) {
+                              form.setValue('maxStackCount', 1, { shouldValidate: false });
+                              form.setValue('isStackable', false, { shouldValidate: false });
+                            }
+                          }}
+                          className="flex flex-wrap"
+                        >
+                          <ToggleGroupItem value={String(FRAGILITY_LEVELS.NonFragile)}>
+                            <NonStackableIcon className="h-5 w-5" />
+                            <span className="text-xs">{t('forms.product.fragilityNonFragile')}</span>
                           </ToggleGroupItem>
-                        ))}
-                      </ToggleGroup>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+                          <ToggleGroupItem value={String(FRAGILITY_LEVELS.Fragile)}>
+                            <Wine className="h-5 w-5 text-amber-500" strokeWidth={1.5} />
+                            <span className="text-xs">{t('forms.product.fragilityFragile')}</span>
+                          </ToggleGroupItem>
+                          <ToggleGroupItem value={String(FRAGILITY_LEVELS.Liquid)}>
+                            <Droplets className="h-5 w-5 text-blue-500" strokeWidth={1.5} />
+                            <span className="text-xs">{t('forms.product.fragilityLiquid')}</span>
+                          </ToggleGroupItem>
+                        </ToggleGroup>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </section>
 
-              <FormField
-                control={form.control}
-                name="fragility"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="block">{t('forms.product.fragility')}</FormLabel>
-                    <FormControl>
-                      <ToggleGroup
-                        type="single"
-                        value={String(field.value)}
-                        onValueChange={(value) => {
-                          if (value === '') return;
-                          const num = Number(value);
-                          field.onChange(num);
-                          if (num === FRAGILITY_LEVELS.NonFragile) {
-                            form.setValue('maxStackCount', 1, { shouldValidate: false });
-                            form.setValue('isStackable', false, { shouldValidate: false });
-                          }
-                        }}
-                        className="flex flex-wrap"
-                      >
-                        <ToggleGroupItem value={String(FRAGILITY_LEVELS.NonFragile)}>
-                          <NonStackableIcon className="h-6 w-6" />
-                          <span className="text-xs">{t('forms.product.fragilityNonFragile')}</span>
-                        </ToggleGroupItem>
-                        <ToggleGroupItem value={String(FRAGILITY_LEVELS.Fragile)}>
-                          <Wine className="h-6 w-6 text-amber-500" strokeWidth={1.5} />
-                          <span className="text-xs">{t('forms.product.fragilityFragile')}</span>
-                        </ToggleGroupItem>
-                        <ToggleGroupItem value={String(FRAGILITY_LEVELS.Liquid)}>
-                          <Droplets className="h-6 w-6 text-blue-500" strokeWidth={1.5} />
-                          <span className="text-xs">{t('forms.product.fragilityLiquid')}</span>
-                        </ToggleGroupItem>
-                      </ToggleGroup>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-          </section>
-
-          {/* Bölüm 3 — Fiziksel Özellikler */}
-          <section className="space-y-4">
-            <SectionTitle icon={Ruler}>{t('forms.product.sectionPhysical')}</SectionTitle>
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-              {/* Sol: alt alta input'lar */}
-              <div className="space-y-4">
+            {/* Fiziksel Özellikler — Genişlik / Yükseklik / Uzunluk / Ağırlık / Katman Sayısı */}
+            <section className="space-y-3">
+              <SectionTitle>{t('forms.product.sectionPhysical')}</SectionTitle>
+              <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-5">
                 <DimensionField
                   form={form}
                   name="width"
@@ -456,7 +453,7 @@ export function ProductForm({
                             type="number"
                             step="0.1"
                             min={0}
-                            className="pr-20"
+                            className={COMPACT_INPUT_WITH_UNIT}
                             {...field}
                             value={field.value ?? ''}
                             onChange={(e) =>
@@ -471,7 +468,7 @@ export function ProductForm({
                           name="weightUnit"
                           render={({ field: unitField }) => (
                             <Select value={unitField.value} onValueChange={unitField.onChange}>
-                              <SelectTrigger className="absolute inset-y-1 right-1 h-auto w-16 border-0 bg-transparent text-xs text-muted-foreground shadow-none focus:ring-0 focus:ring-offset-0">
+                              <SelectTrigger className={UNIT_TRIGGER}>
                                 <SelectValue />
                               </SelectTrigger>
                               <SelectContent>
@@ -489,182 +486,165 @@ export function ProductForm({
                     </FormItem>
                   )}
                 />
-              </div>
-
-              {/* Sağ: ürün illustrasyonu (hacim içinde) — yalnızca md+ */}
-              <div
-                aria-live="polite"
-                className="relative hidden min-h-[200px] flex-col items-center justify-center gap-3 rounded-md border bg-muted/30 p-6 text-muted-foreground md:flex"
-              >
-                <ProductTypeIllustration type={productType ?? 'box'} />
-                <div className="text-center">
-                  <span className="block text-xs uppercase tracking-wide text-muted-foreground">
-                    {t('forms.product.volume')}
-                  </span>
-                  <span className="mt-1 block text-lg font-semibold text-foreground">
-                    {volumeCm3 > 0 ? formatVolume(volumeCm3) : '—'}
-                  </span>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          {/* Bölüm 4 — Kısıtlar */}
-          <section className="space-y-4">
-            <div className="flex items-center justify-between">
-              <SectionTitle icon={ShieldOff}>{t('forms.product.sectionConstraints')}</SectionTitle>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label={t('forms.product.axisGuideAria')}
-                    className="ml-2"
-                  >
-                    <HelpCircle className="h-4 w-4 text-muted-foreground" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <div className="space-y-1">
-                    <p className="font-medium">{t('forms.product.axisGuideTitle')}</p>
-                    <p>{t('forms.product.axisXTooltip')}</p>
-                    <p>{t('forms.product.axisYTooltip')}</p>
-                    <p>{t('forms.product.axisZTooltip')}</p>
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-            </div>
-
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
-              {/* Katman Sayısı */}
-              <FormField
-                control={form.control}
-                name="maxStackCount"
-                render={({ field }) => (
-                  <FormItem className="flex flex-col rounded-md border p-3">
-                    <div className="mb-2 flex items-center justify-between gap-2">
-                      <FormLabel className="m-0 flex items-center gap-1.5 text-sm font-medium">
-                        <Layers className="h-4 w-4 text-muted-foreground" />
-                        {t('forms.product.layerCount')}
-                      </FormLabel>
-                      {isNonStackable && (
-                        <Badge
-                          variant="outline"
-                          className="h-5 gap-1 border-amber-300 bg-amber-50 px-1.5 text-[10px] text-amber-800"
-                        >
-                          <NonStackableIcon className="h-3 w-3" />
-                          {t('forms.product.nonStackable')}
-                        </Badge>
-                      )}
-                    </div>
-                    <FormControl>
-                      <Input
-                        type="number"
-                        min={1}
-                        step={1}
-                        placeholder="1"
-                        className="mt-auto"
-                        {...field}
-                        value={field.value ?? ''}
-                        onChange={(e) => {
-                          const value = e.target.value === '' ? 1 : e.target.valueAsNumber;
-                          field.onChange(value);
-                          form.setValue('isStackable', value > 1, { shouldValidate: false });
-                        }}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* X / Y / Z eksen kartları — kart kendisi toggle */}
-              {ROTATION_AXES.map(({ name: axisFieldName, labelKey, tooltipKey, axis }) => (
                 <FormField
-                  key={axisFieldName}
                   control={form.control}
-                  name={axisFieldName}
-                  render={({ field }) => (
-                    <FormItem className="m-0 space-y-0">
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <button
-                            type="button"
-                            aria-pressed={field.value}
-                            aria-label={t(tooltipKey)}
-                            onClick={() => field.onChange(!field.value)}
+                  name="maxStackCount"
+                  render={({ field }) => {
+                    const lockToOne = fragility === FRAGILITY_LEVELS.NonFragile;
+                    return (
+                      <FormItem>
+                        <div className="flex items-center justify-between gap-2">
+                          <FormLabel className="m-0">
+                            {t('forms.product.layerCount')}
+                          </FormLabel>
+                          <Badge
+                            variant="outline"
+                            aria-hidden={!isNonStackableSelected}
                             className={cn(
-                              'flex w-full flex-col items-center justify-center gap-2 rounded-md border p-3 text-center transition-colors',
-                              field.value
-                                ? 'border-primary bg-primary/5 text-primary'
-                                : 'border-border bg-muted/30 text-muted-foreground hover:bg-muted/60',
+                              'h-5 gap-1 border-amber-300 bg-amber-50 px-1.5 text-[10px] text-amber-800',
+                              !isNonStackableSelected && 'invisible',
                             )}
                           >
-                            <span className="text-sm font-medium text-foreground">
-                              {t(labelKey)}
-                            </span>
-                            <AxisBoxIllustration axis={axis} active={field.value} />
-                          </button>
-                        </TooltipTrigger>
-                        <TooltipContent>{t(tooltipKey)}</TooltipContent>
-                      </Tooltip>
-                    </FormItem>
-                  )}
+                            {t('forms.product.nonStackable')}
+                          </Badge>
+                        </div>
+                        <FormControl>
+                          <Input
+                            type="number"
+                            min={1}
+                            step={1}
+                            placeholder="1"
+                            disabled={lockToOne}
+                            className={cn(COMPACT_INPUT, lockToOne && 'cursor-not-allowed')}
+                            {...field}
+                            value={lockToOne ? 1 : (field.value ?? '')}
+                            onChange={(e) => {
+                              if (lockToOne) return;
+                              const value = e.target.value === '' ? 1 : e.target.valueAsNumber;
+                              field.onChange(value);
+                              form.setValue('isStackable', value > 1, { shouldValidate: false });
+                            }}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
                 />
-              ))}
-            </div>
-          </section>
+              </div>
+            </section>
 
-          {/* Bölüm 5 — Özel Taşıma Notları */}
-          <section className="space-y-4">
-            <SectionTitle icon={StickyNote}>{t('forms.product.sectionNotes')}</SectionTitle>
-            <FormField
-              control={form.control}
-              name="notes"
-              render={({ field }) => {
-                const value = field.value ?? '';
-                const length = value.length;
-                const isOverLimit = length >= NOTES_MAX_LENGTH;
-                return (
-                  <FormItem>
-                    <FormLabel className="sr-only">{t('forms.product.notesLabel')}</FormLabel>
-                    <FormControl>
-                      <Textarea
-                        rows={4}
-                        maxLength={NOTES_MAX_LENGTH}
-                        placeholder={t('forms.product.notesPlaceholder')}
-                        className="resize-y transition-shadow focus-visible:ring-2 focus-visible:ring-primary/40"
-                        {...field}
-                        value={value}
-                        onChange={(e) => {
-                          const next = e.target.value.slice(0, NOTES_MAX_LENGTH);
-                          field.onChange(next);
-                        }}
-                      />
-                    </FormControl>
-                    <div className="mt-1 flex items-start justify-between gap-3 text-xs">
-                      <p className="text-muted-foreground">{t('forms.product.notesHelper')}</p>
-                      <span
-                        aria-live="polite"
-                        className={cn(
-                          'shrink-0 tabular-nums',
-                          isOverLimit ? 'font-semibold text-red-600' : 'text-muted-foreground',
-                        )}
-                      >
-                        {t('forms.product.notesCounter', {
-                          count: length,
-                          max: NOTES_MAX_LENGTH,
-                        })}
-                      </span>
+            {/* Kısıtlar — sadece eksen rotasyonu */}
+            <section className="space-y-3">
+              <div className="flex items-center justify-between">
+                <SectionTitle>{t('forms.product.sectionConstraints')}</SectionTitle>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button type="button" aria-label={t('forms.product.axisGuideAria')}>
+                      <HelpCircle className="h-4 w-4 text-muted-foreground" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <div className="space-y-1">
+                      <p className="font-medium">{t('forms.product.axisGuideTitle')}</p>
+                      <p>{t('forms.product.axisXTooltip')}</p>
+                      <p>{t('forms.product.axisYTooltip')}</p>
+                      <p>{t('forms.product.axisZTooltip')}</p>
                     </div>
-                    <FormMessage />
-                  </FormItem>
-                );
-              }}
-            />
-          </section>
+                  </TooltipContent>
+                </Tooltip>
+              </div>
 
-          {/* Ürün Özet Kartı */}
-          <ProductSummaryCard
+              <div className="grid grid-cols-3 gap-2">
+                {ROTATION_AXES.map(({ name: axisFieldName, labelKey, tooltipKey, axis }) => (
+                  <FormField
+                    key={axisFieldName}
+                    control={form.control}
+                    name={axisFieldName}
+                    render={({ field }) => (
+                      <FormItem className="m-0 space-y-0">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              aria-pressed={field.value}
+                              aria-label={t(tooltipKey)}
+                              onClick={() => field.onChange(!field.value)}
+                              className={cn(
+                                'flex h-full w-full flex-col items-center justify-center gap-1 rounded-md border bg-zinc-50 px-2 py-1.5 text-center transition-all',
+                                field.value
+                                  ? 'border-primary text-primary shadow-sm ring-1 ring-primary/20'
+                                  : 'border-zinc-200 text-muted-foreground hover:border-zinc-300',
+                              )}
+                            >
+                              <AxisBoxIllustration axis={axis} active={field.value} />
+                              <span className="text-xs font-medium leading-none text-foreground">
+                                {t(labelKey)}
+                              </span>
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent>{t(tooltipKey)}</TooltipContent>
+                        </Tooltip>
+                      </FormItem>
+                    )}
+                  />
+                ))}
+              </div>
+            </section>
+
+            {/* Özel Taşıma Notları */}
+            <section className="space-y-3">
+              <SectionTitle>{t('forms.product.sectionNotes')}</SectionTitle>
+              <FormField
+                control={form.control}
+                name="notes"
+                render={({ field }) => {
+                  const value = field.value ?? '';
+                  const length = value.length;
+                  const isOverLimit = length >= NOTES_MAX_LENGTH;
+                  return (
+                    <FormItem>
+                      <FormLabel className="sr-only">{t('forms.product.notesLabel')}</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          rows={3}
+                          maxLength={NOTES_MAX_LENGTH}
+                          placeholder={t('forms.product.notesPlaceholder')}
+                          className="resize-none overflow-y-auto border-zinc-200 bg-zinc-50 focus-visible:ring-2 focus-visible:ring-primary/40"
+                          {...field}
+                          value={value}
+                          onChange={(e) => {
+                            const next = e.target.value.slice(0, NOTES_MAX_LENGTH);
+                            field.onChange(next);
+                          }}
+                        />
+                      </FormControl>
+                      <div className="mt-1 flex items-start justify-between gap-3 text-xs">
+                        <p className="text-muted-foreground">{t('forms.product.notesHelper')}</p>
+                        <span
+                          aria-live="polite"
+                          className={cn(
+                            'shrink-0 tabular-nums',
+                            isOverLimit ? 'font-semibold text-red-600' : 'text-muted-foreground',
+                          )}
+                        >
+                          {t('forms.product.notesCounter', {
+                            count: length,
+                            max: NOTES_MAX_LENGTH,
+                          })}
+                        </span>
+                      </div>
+                      <FormMessage />
+                    </FormItem>
+                  );
+                }}
+              />
+            </section>
+
+          </div>
+
+          {/* SAĞ — 3D Önizleme (Three.js placeholder) */}
+          <PreviewPanel
             name={name}
             productType={productType ?? 'box'}
             length={length}
@@ -683,18 +663,16 @@ export function ProductForm({
             allowRotateZ={allowRotateZ}
             notes={notes}
           />
+          </div>
 
+          {/* Aksiyonlar — sayfa genişliği boyunca, en sağda */}
           <div className="flex justify-end gap-3 border-t pt-4">
             {onCancel && (
               <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
                 {t('forms.product.cancel')}
               </Button>
             )}
-            <Button
-              type="submit"
-              disabled={isSubmitting}
-              className="bg-black text-white hover:bg-black/90"
-            >
+            <Button type="submit" disabled={isSubmitting}>
               {isSubmitting ? t('forms.product.submitting') : t('forms.product.submit')}
             </Button>
           </div>
@@ -704,7 +682,7 @@ export function ProductForm({
   );
 }
 
-interface ProductSummaryCardProps {
+interface PreviewPanelProps {
   name?: string;
   productType: 'box' | 'barrel' | 'pallet';
   length?: number;
@@ -724,26 +702,27 @@ interface ProductSummaryCardProps {
   notes?: string;
 }
 
-function ProductSummaryCard({
-  name,
-  productType,
-  length,
-  lengthUnit,
-  width,
-  widthUnit,
-  height,
-  heightUnit,
-  weight,
-  weightUnit,
-  volumeCm3,
-  maxStackCount,
-  fragility,
-  allowRotateX,
-  allowRotateY,
-  allowRotateZ,
-  notes,
-}: ProductSummaryCardProps) {
+function PreviewPanel(props: PreviewPanelProps) {
   const { t } = useTranslation();
+  const {
+    name,
+    productType,
+    length,
+    lengthUnit,
+    width,
+    widthUnit,
+    height,
+    heightUnit,
+    weight,
+    weightUnit,
+    volumeCm3,
+    maxStackCount,
+    fragility,
+    allowRotateX,
+    allowRotateY,
+    allowRotateZ,
+    notes,
+  } = props;
 
   const fmt = (val?: number, unit?: string) =>
     val !== undefined && Number.isFinite(val) && unit ? `${val} ${unit}` : '—';
@@ -755,176 +734,115 @@ function ProductSummaryCard({
         ? t('forms.product.fragilityFragile')
         : t('forms.product.fragilityNonFragile');
 
-  const FragilityIcon =
-    fragility === FRAGILITY_LEVELS.Liquid
-      ? Droplets
-      : fragility === FRAGILITY_LEVELS.Fragile
-        ? Wine
-        : NonStackableIcon;
-
-  const isStackable = maxStackCount > 1;
-  const allRotationsFree = allowRotateX && allowRotateY && allowRotateZ;
   const lockedAxes: string[] = [];
   if (!allowRotateX) lockedAxes.push('X');
   if (!allowRotateY) lockedAxes.push('Y');
   if (!allowRotateZ) lockedAxes.push('Z');
+  const allRotationsFree = lockedAxes.length === 0;
 
   return (
-    <div className="rounded-2xl border bg-background p-6">
-      <div className="flex flex-col gap-6 md:flex-row md:items-center">
-        {/* Ürün illustrasyonu */}
-        <div className="flex h-32 w-32 shrink-0 items-center justify-center rounded-xl bg-slate-50 text-slate-500 ring-1 ring-slate-200">
-          <div className="[&_svg]:h-20 [&_svg]:w-20">
-            <ProductTypeIllustration type={productType} />
-          </div>
-        </div>
-
-        {/* Ad + İstif Sayısı */}
-        <div className="flex min-w-[140px] flex-col gap-3 md:border-r md:pr-6">
-          <div>
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">
-              {t('forms.product.name')}
-            </p>
-            <p className="mt-0.5 text-lg font-bold text-foreground">{name || '—'}</p>
-          </div>
-          <div>
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">
-              {t('forms.product.layerCount')}
-            </p>
-            <p className="mt-0.5 inline-flex items-center gap-1.5 text-base font-semibold text-foreground">
-              <Layers className="h-4 w-4 text-muted-foreground" />
-              {maxStackCount}
+    <aside className="lg:sticky lg:top-6 lg:self-start">
+      <div className="flex flex-col gap-4">
+        {/* 3D placeholder kutusu */}
+        <div className="relative flex aspect-square items-center justify-center overflow-hidden rounded-xl border border-dashed border-zinc-300 bg-zinc-50">
+          <div className="flex flex-col items-center gap-3 text-zinc-400">
+            <div className="text-zinc-500">
+              <ProductTypeIllustration type={productType} />
+            </div>
+            <p className="px-6 text-center text-xs uppercase tracking-wide">
+              {t('forms.product.previewPlaceholder')}
             </p>
           </div>
         </div>
 
-        {/* Ölçü metrikleri */}
-        <div className="grid flex-1 grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-5">
-          <SummaryMetric
-            label={t('forms.product.length')}
-            icon={ArrowLeftRight}
-            value={fmt(length, lengthUnit)}
-          />
-          <SummaryMetric
+        {/* Anlık Hacim — 3D placeholder hemen altı */}
+        <div className="flex items-baseline justify-between rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('forms.product.volume')}
+          </span>
+          <span className="text-lg font-semibold tabular-nums text-foreground">
+            {volumeCm3 > 0 ? formatVolume(volumeCm3) : '—'}
+          </span>
+        </div>
+
+        {/* Canlı veri özeti */}
+        <dl className="space-y-2 text-sm">
+          <PreviewRow label={t('forms.product.name')} value={name || '—'} emphasize />
+          <PreviewRow
             label={t('forms.product.width')}
-            icon={ArrowLeftRight}
             value={fmt(width, widthUnit)}
           />
-          <SummaryMetric
+          <PreviewRow
             label={t('forms.product.height')}
-            icon={ArrowUpDown}
             value={fmt(height, heightUnit)}
           />
-          <SummaryMetric
+          <PreviewRow
+            label={t('forms.product.length')}
+            value={fmt(length, lengthUnit)}
+          />
+          <PreviewRow
             label={t('forms.product.weight')}
-            icon={Weight}
             value={fmt(weight, weightUnit)}
           />
-          <SummaryMetric
-            label={t('forms.product.volume')}
-            icon={Box}
-            value={volumeCm3 > 0 ? formatVolume(volumeCm3) : '—'}
-            className="col-span-2 sm:col-span-1"
+          <PreviewRow label={t('forms.product.fragility')} value={fragilityLabel} />
+          <PreviewRow
+            label={t('forms.product.layerCount')}
+            value={String(maxStackCount)}
           />
-        </div>
-      </div>
+          <PreviewRow
+            label={<Move3d className="h-4 w-4" aria-hidden />}
+            value={
+              allRotationsFree
+                ? t('forms.product.summaryRotationFree')
+                : t('forms.product.summaryRotationLocked', { axes: lockedAxes.join(', ') })
+            }
+          />
+        </dl>
 
-      {/* Kısıtlar */}
-      <div className="mt-6 border-t pt-4">
-        <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          {t('forms.product.sectionConstraints')}
-        </p>
-        <div className="flex flex-wrap items-center gap-x-8 gap-y-2 text-sm">
-          <span className="inline-flex items-center gap-2 font-medium text-foreground">
-            <FragilityIcon
-              className={cn(
-                'h-5 w-5',
-                fragility === FRAGILITY_LEVELS.Liquid
-                  ? 'text-blue-500'
-                  : fragility === FRAGILITY_LEVELS.Fragile
-                    ? 'text-amber-500'
-                    : 'text-muted-foreground',
-              )}
-            />
-            {fragilityLabel}
-          </span>
-          <span className="inline-flex items-center gap-2 font-medium text-foreground">
-            <Layers
-              className={cn('h-5 w-5', isStackable ? 'text-foreground' : 'text-muted-foreground')}
-            />
-            {isStackable
-              ? t('forms.product.summaryStackable')
-              : t('forms.product.summaryNonStackable')}
-          </span>
-          <span className="inline-flex items-center gap-2 font-medium text-foreground">
-            <Move3d
-              className={cn(
-                'h-5 w-5',
-                allRotationsFree ? 'text-foreground' : 'text-muted-foreground',
-              )}
-            />
-            {allRotationsFree
-              ? t('forms.product.summaryRotationFree')
-              : t('forms.product.summaryRotationLocked', { axes: lockedAxes.join(', ') })}
-          </span>
-        </div>
-      </div>
-
-      {/* Özel Taşıma Notu — kart alt bandı */}
-      {notes && notes.trim().length > 0 && (
-        <div className="mt-4 flex items-start gap-2 rounded-md border border-dashed border-border bg-muted/30 p-3 text-sm text-foreground">
-          <StickyNote className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
-          <div className="min-w-0">
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {notes && notes.trim().length > 0 && (
+          <div className="rounded-md border border-dashed border-zinc-300 bg-zinc-50 p-3 text-xs text-foreground">
+            <p className="mb-1 font-semibold uppercase tracking-wide text-muted-foreground">
               {t('forms.product.notesSummaryLabel')}
             </p>
-            <p className="mt-0.5 truncate">
-              {notes.length > NOTES_PREVIEW_LENGTH
-                ? `${notes.slice(0, NOTES_PREVIEW_LENGTH).trimEnd()}…`
-                : notes}
-            </p>
+            <p className="whitespace-pre-wrap break-words">{notes}</p>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </aside>
   );
 }
 
-interface SummaryMetricProps {
-  label: string;
-  icon: ComponentType<{ className?: string }>;
-  value: string;
-  className?: string;
+interface PreviewRowProps {
+  label: ReactNode;
+  value: ReactNode;
+  emphasize?: boolean;
 }
 
-function SummaryMetric({ label, icon: Icon, value, className }: SummaryMetricProps) {
+function PreviewRow({ label, value, emphasize = false }: PreviewRowProps) {
   return (
-    <div
-      className={cn(
-        'flex min-w-0 flex-col items-center justify-between gap-1 text-center',
-        className,
-      )}
-    >
-      <span className="text-xs uppercase tracking-wide text-muted-foreground">{label}</span>
-      <Icon className="h-5 w-5 text-muted-foreground" />
-      <span className="truncate text-sm font-semibold text-foreground">{value}</span>
+    <div className="flex items-baseline justify-between gap-3">
+      <dt className="text-xs uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd
+        className={cn(
+          'truncate text-right',
+          emphasize ? 'text-base font-semibold text-foreground' : 'text-sm text-foreground',
+        )}
+      >
+        {value}
+      </dd>
     </div>
   );
 }
 
 interface SectionTitleProps {
   children: ReactNode;
-  icon?: ComponentType<{ className?: string }>;
 }
 
-function SectionTitle({ children, icon: Icon }: SectionTitleProps) {
+function SectionTitle({ children }: SectionTitleProps) {
   return (
-    <div className="flex items-center gap-2 border-b pb-2">
-      {Icon && <Icon className="h-4 w-4 text-muted-foreground" />}
-      <h3 className={cn('text-sm font-semibold uppercase tracking-wide text-muted-foreground')}>
-        {children}
-      </h3>
-    </div>
+    <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+      {children}
+    </h3>
   );
 }
 
@@ -950,7 +868,7 @@ function DimensionField({ form, name, unitName, labelKey }: DimensionFieldProps)
                 type="number"
                 step="0.1"
                 min={0}
-                className="pr-20"
+                className={COMPACT_INPUT_WITH_UNIT}
                 {...field}
                 value={field.value ?? ''}
                 onChange={(e) =>
@@ -963,7 +881,7 @@ function DimensionField({ form, name, unitName, labelKey }: DimensionFieldProps)
               name={unitName}
               render={({ field: unitField }) => (
                 <Select value={unitField.value} onValueChange={unitField.onChange}>
-                  <SelectTrigger className="absolute inset-y-1 right-1 h-auto w-16 border-0 bg-transparent text-xs text-muted-foreground shadow-none focus:ring-0 focus:ring-offset-0">
+                  <SelectTrigger className={UNIT_TRIGGER}>
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>

--- a/apps/frontend/src/lib/api/itemMappers.ts
+++ b/apps/frontend/src/lib/api/itemMappers.ts
@@ -1,0 +1,93 @@
+import {
+  toCentimeters,
+  type ProductFormValues,
+  type ProductType,
+} from '@/features/data-management/schemas/productSchema';
+
+export const ITEM_CATEGORY = {
+  Package: 0,
+  Pallet: 1,
+  Box: 2,
+} as const;
+export type ItemCategoryValue = (typeof ITEM_CATEGORY)[keyof typeof ITEM_CATEGORY];
+
+export const ALLOWED_ROTATIONS = {
+  All: 0,
+  NoVertical: 1,
+  Fixed: 2,
+} as const;
+export type AllowedRotationsValue = (typeof ALLOWED_ROTATIONS)[keyof typeof ALLOWED_ROTATIONS];
+
+export interface CreateItemRequest {
+  sku: string;
+  barcode?: string | null;
+  name: string;
+  productType: string;
+  category: ItemCategoryValue;
+  width: number;
+  height: number;
+  length: number;
+  diameter?: number | null;
+  weight: number;
+  fragilityType: 0 | 1 | 2 | 3 | 4;
+  isStackable: boolean;
+  maxStackCount: number;
+  maxWeightOnTop: number;
+  allowedRotations: AllowedRotationsValue;
+  imageUrl?: string | null;
+  stackGroup?: string | null;
+  specialNotes?: string | null;
+}
+
+export function toCategory(productType: ProductType): ItemCategoryValue {
+  if (productType === 'pallet') return ITEM_CATEGORY.Pallet;
+  if (productType === 'box') return ITEM_CATEGORY.Box;
+  return ITEM_CATEGORY.Package;
+}
+
+export function toAllowedRotations(
+  allowRotateX: boolean,
+  allowRotateY: boolean,
+  allowRotateZ: boolean,
+): AllowedRotationsValue {
+  if (allowRotateX && allowRotateY && allowRotateZ) return ALLOWED_ROTATIONS.All;
+  if (allowRotateX && !allowRotateY && allowRotateZ) return ALLOWED_ROTATIONS.NoVertical;
+  return ALLOWED_ROTATIONS.Fixed;
+}
+
+export function toMaxWeightOnTop(
+  weight: number,
+  isStackable: boolean,
+  maxStackCount: number,
+): number {
+  if (!isStackable) return 0;
+  const layersAbove = Math.max(maxStackCount - 1, 1);
+  return Math.max(weight * layersAbove, 1);
+}
+
+export function buildCreateItemPayload(values: ProductFormValues): CreateItemRequest {
+  const maxStackCount = values.maxStackCount ?? 1;
+  const isStackable = maxStackCount > 1;
+  const trimmedNotes = values.notes?.trim();
+
+  return {
+    sku: values.sku,
+    name: values.name,
+    productType: values.productType,
+    category: toCategory(values.productType),
+    width: toCentimeters(values.width, values.widthUnit),
+    height: toCentimeters(values.height, values.heightUnit),
+    length: toCentimeters(values.length, values.lengthUnit),
+    weight: values.weight,
+    fragilityType: values.fragility as 0 | 1 | 2 | 3 | 4,
+    isStackable,
+    maxStackCount: isStackable ? maxStackCount : 0,
+    maxWeightOnTop: toMaxWeightOnTop(values.weight, isStackable, maxStackCount),
+    allowedRotations: toAllowedRotations(
+      values.allowRotateX,
+      values.allowRotateY,
+      values.allowRotateZ,
+    ),
+    specialNotes: trimmedNotes && trimmedNotes.length > 0 ? trimmedNotes : null,
+  };
+}

--- a/apps/frontend/src/lib/api/useItems.ts
+++ b/apps/frontend/src/lib/api/useItems.ts
@@ -1,14 +1,28 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { z } from 'zod';
 import { toast } from 'sonner';
+import type { AxiosError } from 'axios';
 import { itemSchema } from '@/lib/types/item';
-import {
-  toCentimeters,
-  type ProductFormValues,
-  DIMENSION_UNITS,
-  WEIGHT_UNITS,
-} from '@/features/data-management/schemas/productSchema';
+import type { ProductFormValues } from '@/features/data-management/schemas/productSchema';
+import { axiosInstance } from './axiosInstance';
 import { apiFetch } from './fetcher';
+import { buildCreateItemPayload } from './itemMappers';
+
+const ITEMS_ENDPOINT = '/api/v1/items';
+
+interface ProblemDetails {
+  type?: string;
+  title?: string;
+  status?: number;
+  detail?: string;
+  instance?: string;
+}
+
+interface CreateItemResponse {
+  isSuccess?: boolean;
+  message?: string;
+  data?: { id: string };
+}
 
 interface ItemFilters {
   search?: string;
@@ -36,44 +50,38 @@ export function useItem(id: string) {
   });
 }
 
-const createItemResponseSchema = itemSchema.partial({ id: true });
-
-function buildCreateItemPayload(values: ProductFormValues) {
-  return {
-    name: values.name,
-    sku: values.sku,
-    productType: values.productType,
-    width: toCentimeters(values.width, values.widthUnit),
-    widthUnitId: DIMENSION_UNITS[values.widthUnit],
-    height: toCentimeters(values.height, values.heightUnit),
-    heightUnitId: DIMENSION_UNITS[values.heightUnit],
-    length: toCentimeters(values.length, values.lengthUnit),
-    lengthUnitId: DIMENSION_UNITS[values.lengthUnit],
-    weight: values.weight,
-    weightUnitId: WEIGHT_UNITS[values.weightUnit],
-    fragility: values.fragility,
-    isStackable: values.isStackable,
-    maxStackCount: values.maxStackCount ?? null,
-    allowRotateX: values.allowRotateX,
-    allowRotateY: values.allowRotateY,
-    allowRotateZ: values.allowRotateZ,
-  };
-}
-
 export function useCreateItem() {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (values: ProductFormValues) =>
-      apiFetch('/items', createItemResponseSchema, {
-        method: 'POST',
-        body: JSON.stringify(buildCreateItemPayload(values)),
-      }),
+
+  return useMutation<CreateItemResponse, AxiosError<ProblemDetails>, ProductFormValues>({
+    mutationFn: (values) =>
+      axiosInstance
+        .post<CreateItemResponse>(ITEMS_ENDPOINT, buildCreateItemPayload(values))
+        .then((r) => r.data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['items'] });
-      toast.success('Ürün başarıyla eklendi');
+      toast.success('Ürün başarıyla eklendi', { position: 'bottom-right' });
     },
-    onError: (err) => {
-      toast.error(err instanceof Error ? err.message : 'Ürün eklenemedi');
+    onError: (error) => {
+      const status = error.response?.status;
+      const detail = error.response?.data?.detail;
+
+      if (status === 409) {
+        toast.error('Bu SKU zaten kullanılıyor.', { position: 'bottom-right' });
+        return;
+      }
+
+      if (status === 400) {
+        toast.error(detail ?? 'Doğrulama hatası. Lütfen alanları kontrol edin.', {
+          position: 'bottom-right',
+        });
+        return;
+      }
+
+      // 401, 5xx ve network hataları zaten axiosInstance interceptor'ında toast'lanıyor.
+      if (status && status !== 401 && status < 500) {
+        toast.error(detail ?? 'Ürün eklenemedi.', { position: 'bottom-right' });
+      }
     },
   });
 }

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -32,7 +32,7 @@
       "width": "Width",
       "height": "Height",
       "length": "Length",
-      "weight": "Weight (kg)",
+      "weight": "Weight",
       "fragility": "Fragility Level",
       "fragilityNonFragile": "Non-Fragile",
       "fragilityFragile": "Fragile",
@@ -77,7 +77,8 @@
       "notesPlaceholder": "e.g. Forklift only, keep away from sunlight.",
       "notesHelper": "Use this to communicate constraints beyond the standard ones to handling teams.",
       "notesCounter": "{{count}} / {{max}}",
-      "notesSummaryLabel": "Note"
+      "notesSummaryLabel": "Note",
+      "previewPlaceholder": "Three.js scene will be integrated here"
     },
     "vehicle": {
       "title": "Vehicle Definition",

--- a/apps/frontend/src/locales/tr.json
+++ b/apps/frontend/src/locales/tr.json
@@ -32,7 +32,7 @@
       "width": "Genişlik",
       "height": "Yükseklik",
       "length": "Uzunluk",
-      "weight": "Ağırlık (kg)",
+      "weight": "Ağırlık",
       "fragility": "Kısıtlar",
       "fragilityNonFragile": "İstiflenemez",
       "fragilityFragile": "Kırılgan",
@@ -77,7 +77,8 @@
       "notesPlaceholder": "Örn: Sadece forklift ile taşınabilir, güneş ışığından uzak tutun.",
       "notesHelper": "Standart kısıtların dışında kalan spesifik uyarıları taşıma ekiplerine iletmek için kullanın.",
       "notesCounter": "{{count}} / {{max}}",
-      "notesSummaryLabel": "Not"
+      "notesSummaryLabel": "Not",
+      "previewPlaceholder": "Buraya Three.js sahnesi entegre edilecek"
     },
     "vehicle": {
       "title": "Araç Tanımlama",

--- a/apps/frontend/src/pages/ProductCreatePage.tsx
+++ b/apps/frontend/src/pages/ProductCreatePage.tsx
@@ -1,6 +1,4 @@
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 import { ProductForm } from '@/features/data-management/components/ProductForm';
 import { useCreateItem } from '@/lib/api/useItems';
 
@@ -11,32 +9,21 @@ export function ProductCreatePage() {
   return (
     <div className="flex w-full flex-col gap-6">
       <div>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="mb-2 -ml-2 gap-1 text-muted-foreground"
-          onClick={() => navigate('/products')}
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Ürünlere Dön
-        </Button>
         <h1 className="text-2xl font-bold tracking-tight text-foreground">Yeni Ürün Ekle</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           Ürünün kimliğini, fiziksel özelliklerini ve kısıtlarını tanımlayın.
         </p>
       </div>
 
-      <div className="rounded-2xl border border-border bg-background p-6 shadow-sm">
-        <ProductForm
-          isSubmitting={createItem.isPending}
-          onCancel={() => navigate('/products')}
-          onSubmit={(values) =>
-            createItem.mutate(values, {
-              onSuccess: () => navigate('/products'),
-            })
-          }
-        />
-      </div>
+      <ProductForm
+        isSubmitting={createItem.isPending}
+        onCancel={() => navigate('/products')}
+        onSubmit={(values) =>
+          createItem.mutate(values, {
+            onSuccess: () => navigate('/products'),
+          })
+        }
+      />
     </div>
   );
 }

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -1,20 +1,26 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
-  },
-  server: {
-    proxy: {
-      '/api': {
-        target: process.env.VITE_API_BASE_URL || 'http://localhost:8081',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const proxyTarget =
+    env.VITE_DEV_PROXY_TARGET || env.VITE_API_BASE_URL || "http://localhost:8081";
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
       },
     },
-  },
+    server: {
+      proxy: {
+        "/api": {
+          target: proxyTarget,
+          changeOrigin: true,
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
# Özet

Ürün ekleme formu yeniden tasarlandı ve `POST /api/v1/items` endpoint'ine bağlandı.

- 2 kolonlu layout: sol form, sağ Three.js placeholder + canlı önizleme
- Header butonu, dış kart wrapper, gereksiz ikonlar ve "(kg)" tekrarı kaldırıldı
- Input'lar zinc-50 + h-9 kompakt; eksen kartları küçük, seçim sadece border
- Katman sayısı fiziksel özelliklere taşındı, "İstiflenemez" iken disabled
- Özel taşıma notları bölümü + canlı 500 karakter sayacı
- `useCreateItem` axiosInstance'a geçirildi, payload mapper eklendi
- ProblemDetails parse: 409 SKU çakışması, 400 validation toast'ları
- Vite proxy hedefi env'den okunuyor (dev CORS bypass)

## İlgili User Story

US-VY-DAT-02

## Değişiklik Tipi

- [x] 🚀 Yeni özellik (feature)

## Test Edildi mi?

- [x] Manuel test:
  - Lokal dev → backend'e POST → 201 Created ✅
  - Aynı SKU → 409 toast "Bu SKU zaten kullanılıyor" ✅
  - Liste sayfası TanStack Query invalidate ile yenileniyor ✅

## Kontrol Listesi

- [x] TypeScript temiz (`npx tsc --noEmit`)
- [x] ESLint temiz (`npm run lint --max-warnings 0`)
- [x] `npm run build` başarılı
- [x] Commit mesajları COMMITS.md kurallarına uygun
- [x] Self-review yapıldı

## Açık Noktalar (Backend ekibine sorulmuş, cevap bekleniyor)

1. `barrel` → backend'de `Barrel` enum eklenecek mi, şimdilik `Package`'a maplenıyor
2. `allowedRotations` mantığı doğrulansın
3. `maxWeightOnTop` form alanı gerek mi? Şimdilik otomatik hesap
4. Fragility 5 değer (Flammable/Oxidizing) ayrı ticket'ta mı eklenecek