### PR TITLE
feat(planning): US-OPT-10 ghost mode ve X-Ray level filtresi ekle

### DIFF
--- a/apps/frontend/src/components/shared/BoxWrapper.tsx
+++ b/apps/frontend/src/components/shared/BoxWrapper.tsx
@@ -16,6 +16,7 @@ interface BoxWrapperProps {
   itemId?: string;
   isSelected?: boolean;
   isHidden?: boolean;
+  isGhosted?: boolean;
 }
 
 export function BoxWrapper({
@@ -32,6 +33,7 @@ export function BoxWrapper({
   itemId,
   isSelected = false,
   isHidden = false,
+  isGhosted = false,
 }: BoxWrapperProps) {
   const cx = positionX + width / 2;
   const cy = positionY + height / 2;
@@ -70,7 +72,8 @@ export function BoxWrapper({
         <meshStandardMaterial
           color={color}
           transparent
-          opacity={isSelected ? 0.95 : opacity}
+          opacity={isGhosted ? 0.1 : isSelected ? 0.95 : opacity}
+          depthWrite={!isGhosted}
           emissive={isSelected ? color : '#000000'}
           emissiveIntensity={isSelected ? 0.25 : 0}
         />

--- a/apps/frontend/src/features/planning/components/scene/CargoMeshInstanced.tsx
+++ b/apps/frontend/src/features/planning/components/scene/CargoMeshInstanced.tsx
@@ -5,26 +5,34 @@ import { useSceneStore } from '@/lib/store/useSceneStore';
 import { BoxWrapper } from '@/components/shared/BoxWrapper';
 import { SCENE } from '@/lib/config/scene-config';
 import { applyOrientationQuaternion, rotatedDimensions } from '@/lib/utils/boxOrientations';
+import { isGhosted, isPlacementVisible } from '@/lib/utils/sceneFilter';
 import { useDragBox } from '@/features/planning/components/scene/useDragBox';
 import type { DragState } from '@/features/planning/components/scene/useDragBox';
 
 const INSTANCED_THRESHOLD = SCENE.INSTANCED_THRESHOLD;
-const COLOR_VIOLATION = SCENE.COLORS.VIOLATION;
-const COLOR_SELECTED = SCENE.COLORS.SELECTED;
-const COLOR_NORMAL = SCENE.COLORS.NORMAL;
+const COLOR_VIOLATION = new THREE.Color(SCENE.COLORS.VIOLATION);
+const COLOR_NORMAL = new THREE.Color(SCENE.COLORS.NORMAL);
+const SCALE_ZERO = new THREE.Vector3(0, 0, 0);
 
 interface CargoMeshInstancedProps {
   planId: string;
 }
 
+// ─── InstancedBoxes ────────────────────────────────────────────────────────────
+
 function InstancedBoxes() {
-  const meshRef = useRef<THREE.InstancedMesh>(null);
+  const opaqueRef = useRef<THREE.InstancedMesh>(null);
+  const ghostRef = useRef<THREE.InstancedMesh>(null);
+  const violationRef = useRef<THREE.InstancedMesh>(null);
   const edgeMeshRef = useRef<THREE.InstancedMesh>(null);
+
   const placements = usePlanStore((s) => s.placements);
   const vehicle = usePlanStore((s) => s.selectedVehicle);
   const selectedItemId = useSceneStore((s) => s.selectedItemId);
   const selectedInstanceId = useSceneStore((s) => s.selectedInstanceId);
   const hiddenItemIds = useSceneStore((s) => s.hiddenItemIds);
+  const activeLayer = useSceneStore((s) => s.activeLayer);
+  const xRayMode = useSceneStore((s) => s.xRayMode);
   const setSelectedItemId = useSceneStore((s) => s.setSelectedItemId);
   const setSelectedInstanceId = useSceneStore((s) => s.setSelectedInstanceId);
   const { startDrag } = useDragBox();
@@ -44,22 +52,18 @@ function InstancedBoxes() {
     [edgesGeo],
   );
 
-  // US-OPT-14: InstancedMesh tek bir draw call — frustum culling avantaj sağlamaz, ama
-  // unit-cube bounding sphere yüzünden kamera off-axis olunca tüm sahne kaybolma riski var.
-  // matrixAutoUpdate=false: root mesh statik, dünya matrisinin her frame yeniden hesaplanması gereksiz.
   useEffect(() => {
-    if (meshRef.current) {
-      meshRef.current.frustumCulled = false;
-      meshRef.current.matrixAutoUpdate = false;
-    }
-    if (edgeMeshRef.current) {
-      edgeMeshRef.current.frustumCulled = false;
-      edgeMeshRef.current.matrixAutoUpdate = false;
+    for (const ref of [opaqueRef, ghostRef, violationRef, edgeMeshRef]) {
+      if (ref.current) {
+        ref.current.frustumCulled = false;
+        ref.current.matrixAutoUpdate = false;
+      }
     }
   }, []);
 
   useEffect(() => {
-    if (!meshRef.current) return;
+    if (!opaqueRef.current || !ghostRef.current || !violationRef.current) return;
+
     const matrix = new THREE.Matrix4();
     const color = new THREE.Color();
     const quaternion = new THREE.Quaternion();
@@ -67,48 +71,93 @@ function InstancedBoxes() {
     const scale = new THREE.Vector3();
 
     placements.forEach((p, i) => {
-      const isHidden = hiddenItemIds.includes(p.itemId);
-      const isInstanceSelected = selectedInstanceId === i;
-      const isItemSelected = p.itemId === selectedItemId;
+      const visible = isPlacementVisible(p, i, {
+        selectedInstanceId,
+        selectedItemId,
+        hiddenItemIds,
+      });
+      const ghosted = isGhosted(p, activeLayer);
 
-      // Drag sırasında live pozisyon kullan
       const px = dragState?.idx === i ? dragState.x : p.positionX;
       const py = dragState?.idx === i ? dragState.y : p.positionY;
       const pz = dragState?.idx === i ? dragState.z : p.positionZ;
 
-      // Effective dims (rotated) zaten p.width/height/depth'te. Base'i türetip scale'e veriyoruz.
       const base = rotatedDimensions(p.width, p.height, p.depth, p.orientationIndex);
-
       position.set(px + p.width / 2, py + p.height / 2, pz + p.depth / 2);
-      // Glow için seçili instance'ı InstancedMesh'ten gizle, BoxWrapper olarak ayrı render et.
-      const visible = !isHidden && !isInstanceSelected && !isItemSelected;
-      scale.set(visible ? base.width : 0, visible ? base.height : 0, visible ? base.depth : 0);
       applyOrientationQuaternion(quaternion, p.orientationIndex);
+
+      // Opaque mesh: visible ve ghost değil
+      if (visible && !ghosted) {
+        scale.set(base.width, base.height, base.depth);
+      } else {
+        scale.copy(SCALE_ZERO);
+      }
       matrix.compose(position, quaternion, scale);
+      opaqueRef.current!.setMatrixAt(i, matrix);
 
-      meshRef.current!.setMatrixAt(i, matrix);
-      meshRef.current!.setColorAt(
-        i,
-        isInstanceSelected || isItemSelected
-          ? color.setHex(COLOR_SELECTED)
-          : p.isViolation
-            ? color.setHex(COLOR_VIOLATION)
-            : p.color
-              ? color.set(p.color)
-              : color.setHex(COLOR_NORMAL),
-      );
+      // Ghost mesh: visible ve ghost
+      if (visible && ghosted) {
+        scale.set(base.width, base.height, base.depth);
+      } else {
+        scale.copy(SCALE_ZERO);
+      }
+      matrix.compose(position, quaternion, scale);
+      ghostRef.current!.setMatrixAt(i, matrix);
 
+      // Violation wireframe: sadece xRayMode açıkken ihlal olan kutular
+      if (xRayMode && p.isViolation && visible) {
+        scale.set(base.width, base.height, base.depth);
+      } else {
+        scale.copy(SCALE_ZERO);
+      }
+      matrix.compose(position, quaternion, scale);
+      violationRef.current!.setMatrixAt(i, matrix);
+
+      // Renk (opaque mesh için)
+      color.copy(p.isViolation ? COLOR_VIOLATION : p.color ? color.set(p.color) : COLOR_NORMAL);
+      opaqueRef.current!.setColorAt(i, color);
+      // Ghost mesh aynı rengi alır, material opacity ile şeffaflaşır
+      ghostRef.current!.setColorAt(i, color);
+
+      // Edge mesh opaque ile senkron
       edgeMeshRef.current?.setMatrixAt(i, matrix);
     });
 
-    meshRef.current.instanceMatrix.needsUpdate = true;
-    if (meshRef.current.instanceColor) {
-      meshRef.current.instanceColor.needsUpdate = true;
-    }
-    if (edgeMeshRef.current) {
-      edgeMeshRef.current.instanceMatrix.needsUpdate = true;
-    }
-  }, [placements, selectedItemId, selectedInstanceId, hiddenItemIds, dragState]);
+    opaqueRef.current.instanceMatrix.needsUpdate = true;
+    ghostRef.current.instanceMatrix.needsUpdate = true;
+    violationRef.current.instanceMatrix.needsUpdate = true;
+    if (edgeMeshRef.current) edgeMeshRef.current.instanceMatrix.needsUpdate = true;
+
+    if (opaqueRef.current.instanceColor) opaqueRef.current.instanceColor.needsUpdate = true;
+    if (ghostRef.current.instanceColor) ghostRef.current.instanceColor.needsUpdate = true;
+  }, [
+    placements,
+    selectedItemId,
+    selectedInstanceId,
+    hiddenItemIds,
+    activeLayer,
+    xRayMode,
+    dragState,
+  ]);
+
+  // Edge mesh opaque mesh ile aynı matrix'i paylaşmalı — ayrı bir pass
+  useEffect(() => {
+    if (!edgeMeshRef.current || !opaqueRef.current) return;
+    const matrix = new THREE.Matrix4();
+    placements.forEach((_, i) => {
+      opaqueRef.current!.getMatrixAt(i, matrix);
+      edgeMeshRef.current!.setMatrixAt(i, matrix);
+    });
+    edgeMeshRef.current.instanceMatrix.needsUpdate = true;
+  }, [
+    placements,
+    selectedItemId,
+    selectedInstanceId,
+    hiddenItemIds,
+    activeLayer,
+    xRayMode,
+    dragState,
+  ]);
 
   const selectedPlacements = useMemo(
     () =>
@@ -124,8 +173,9 @@ function InstancedBoxes() {
 
   return (
     <>
+      {/* Opaque mesh — normal görünür kutular */}
       <instancedMesh
-        ref={meshRef}
+        ref={opaqueRef}
         args={[undefined, undefined, placements.length]}
         castShadow
         receiveShadow
@@ -133,8 +183,7 @@ function InstancedBoxes() {
           e.stopPropagation();
           const instanceId = e.instanceId;
           if (instanceId === undefined) return;
-          const p = placements[instanceId];
-          if (!p) return;
+          if (!placements[instanceId]) return;
           setSelectedItemId(null);
           setSelectedInstanceId(selectedInstanceId === instanceId ? null : instanceId);
         }}
@@ -150,9 +199,50 @@ function InstancedBoxes() {
         <boxGeometry args={[1, 1, 1]} />
         <meshStandardMaterial transparent opacity={0.85} />
       </instancedMesh>
+
+      {/* Ghost mesh — activeLayer önündeki kutular %10 opaklıkta */}
+      <instancedMesh
+        ref={ghostRef}
+        args={[undefined, undefined, placements.length]}
+        onClick={(e) => {
+          e.stopPropagation();
+          const instanceId = e.instanceId;
+          if (instanceId === undefined) return;
+          if (!placements[instanceId]) return;
+          setSelectedItemId(null);
+          setSelectedInstanceId(selectedInstanceId === instanceId ? null : instanceId);
+        }}
+        onPointerDown={(e) => {
+          e.stopPropagation();
+          const instanceId = e.instanceId;
+          if (instanceId === undefined || !vehicle) return;
+          setSelectedItemId(null);
+          setSelectedInstanceId(instanceId);
+          startDrag(instanceId, placements, vehicle, setDragState, e);
+        }}
+      >
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial transparent opacity={0.1} depthWrite={false} />
+      </instancedMesh>
+
+      {/* Violation wireframe — xRayMode'da ihlaller her zaman görünür */}
+      <instancedMesh ref={violationRef} args={[undefined, undefined, placements.length]}>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshBasicMaterial
+          color={SCENE.COLORS.VIOLATION}
+          wireframe
+          depthTest={false}
+          transparent
+          opacity={0.9}
+        />
+      </instancedMesh>
+
+      {/* Edge lines — opaque mesh ile senkron */}
       <instancedMesh ref={edgeMeshRef} args={[edgesGeo, undefined, placements.length]}>
         <lineBasicMaterial color="#000000" />
       </instancedMesh>
+
+      {/* Selected box — BoxWrapper ile glow */}
       {selectedPlacements.map(({ p, idx }) => {
         const ds = dragState?.idx === idx ? dragState : null;
         const px = ds ? ds.x : p.positionX;
@@ -187,12 +277,15 @@ function InstancedBoxes() {
   );
 }
 
+// ─── CargoMeshInstanced ────────────────────────────────────────────────────────
+
 export function CargoMeshInstanced({ planId: _planId }: CargoMeshInstancedProps) {
   const placements = usePlanStore((s) => s.placements);
   const vehicle = usePlanStore((s) => s.selectedVehicle);
   const selectedItemId = useSceneStore((s) => s.selectedItemId);
   const selectedInstanceId = useSceneStore((s) => s.selectedInstanceId);
   const hiddenItemIds = useSceneStore((s) => s.hiddenItemIds);
+  const activeLayer = useSceneStore((s) => s.activeLayer);
   const setSelectedItemId = useSceneStore((s) => s.setSelectedItemId);
   const setSelectedInstanceId = useSceneStore((s) => s.setSelectedInstanceId);
   const { startDrag } = useDragBox();
@@ -206,6 +299,7 @@ export function CargoMeshInstanced({ planId: _planId }: CargoMeshInstancedProps)
         {placements.map((p, i) => {
           const isInstanceSelected = selectedInstanceId === i;
           const isItemSelected = p.itemId === selectedItemId;
+          const ghosted = isGhosted(p, activeLayer);
           const ds = dragState?.idx === i ? dragState : null;
           const px = ds ? ds.x : p.positionX;
           const py = ds ? ds.y : p.positionY;
@@ -225,6 +319,7 @@ export function CargoMeshInstanced({ planId: _planId }: CargoMeshInstancedProps)
               itemId={p.itemId}
               isSelected={isInstanceSelected || isItemSelected}
               isHidden={hiddenItemIds.includes(p.itemId)}
+              isGhosted={ghosted}
               onClick={() => {
                 setSelectedItemId(null);
                 setSelectedInstanceId(selectedInstanceId === i ? null : i);

--- a/apps/frontend/src/features/planning/components/scene/LevelControls.tsx
+++ b/apps/frontend/src/features/planning/components/scene/LevelControls.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Eye, EyeOff, Layers } from 'lucide-react';
 import { Slider } from '@/components/ui/slider';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { usePlanStore } from '@/lib/store/usePlanStore';
 import { useSceneStore } from '@/lib/store/useSceneStore';
+import { useDebounce } from '@/lib/hooks/useDebounce';
 import { SCENE } from '@/lib/config/scene-config';
 
 interface LevelControlsProps {
@@ -13,29 +14,35 @@ interface LevelControlsProps {
 
 export function LevelControls({ className }: LevelControlsProps) {
   const vehicle = usePlanStore((s) => s.selectedVehicle);
-  const activeLayer = useSceneStore((s) => s.activeLayer);
   const setActiveLayer = useSceneStore((s) => s.setActiveLayer);
   const xRayMode = useSceneStore((s) => s.xRayMode);
   const toggleXRayMode = useSceneStore((s) => s.toggleXRayMode);
 
-  // Vehicle değiştiğinde activeLayer'ı tavana resetle (limitsiz "hepsi görünür").
+  // Local state sürükleme sırasında slider'ı anlık günceller;
+  // debounce ile store'a yazılır → instanceMatrix.needsUpdate gereksiz tetiklenmez.
+  // key={vehicle.id} ile parent bu bileşeni yeniden mount eder → state otomatik sıfırlanır.
+  const [localValue, setLocalValue] = useState(0);
+  const debouncedValue = useDebounce(localValue, 80);
+
+  // Debounced değer değişince store'a yaz
   useEffect(() => {
-    setActiveLayer(Number.POSITIVE_INFINITY);
-  }, [vehicle?.id, setActiveLayer]);
+    setActiveLayer(debouncedValue);
+  }, [debouncedValue, setActiveLayer]);
 
   if (!vehicle) return null;
 
-  const max = vehicle.height;
-  const sliderValue = Number.isFinite(activeLayer) ? Math.min(activeLayer, max) : max;
+  const max = vehicle.length;
+  const pct = max > 0 ? Math.round((localValue / max) * 100) : 0;
 
   return (
     <TooltipProvider delayDuration={120}>
       <div
         className={cn(
-          'pointer-events-auto flex flex-col items-center gap-2 rounded-lg border border-zinc-200 bg-white/90 p-2 shadow-sm backdrop-blur',
+          'pointer-events-auto flex items-center gap-3 rounded-lg border border-zinc-200 bg-white/90 px-3 py-2 shadow-sm backdrop-blur',
           className,
         )}
       >
+        {/* X-Ray toggle */}
         <Tooltip>
           <TooltipTrigger asChild>
             <button
@@ -43,42 +50,42 @@ export function LevelControls({ className }: LevelControlsProps) {
               onClick={toggleXRayMode}
               aria-pressed={xRayMode}
               className={cn(
-                'flex h-8 w-8 items-center justify-center rounded-md border transition-colors',
+                'flex h-7 w-7 shrink-0 items-center justify-center rounded-md border transition-colors',
                 xRayMode
                   ? 'border-zinc-900 bg-zinc-900 text-white'
                   : 'border-zinc-200 bg-white text-zinc-700 hover:bg-zinc-50',
               )}
             >
-              {xRayMode ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              {xRayMode ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
             </button>
           </TooltipTrigger>
-          <TooltipContent side="left">
-            {xRayMode ? 'Ghost mod açık (X-Ray)' : 'Ghost modu aç'}
+          <TooltipContent side="top">
+            {xRayMode ? 'X-Ray kapat' : 'X-Ray aç (ihlalleri vurgula)'}
           </TooltipContent>
         </Tooltip>
 
-        <div className="flex items-center gap-1 text-[10px] text-zinc-500">
-          <Layers className="h-3 w-3" />
-          <span>{Number.isFinite(activeLayer) ? `${Math.round(sliderValue)} cm` : 'Hepsi'}</span>
-        </div>
+        {/* Depth slider label */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="flex items-center gap-1.5 text-[11px] text-zinc-500 shrink-0">
+              <Layers className="h-3 w-3" />
+              <span className="w-8 tabular-nums">{pct > 0 ? `${pct}%` : 'Hepsi'}</span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="top">Derinlik ghost filtresi (Z ekseni)</TooltipContent>
+        </Tooltip>
 
-        <div className="flex h-48 items-center justify-center">
-          <Slider
-            orientation="vertical"
-            min={0}
-            max={max}
-            step={SCENE.LEVEL_FILTER_STEP_CM}
-            value={[sliderValue]}
-            onValueChange={(values: number[]) => {
-              const next = values[0];
-              // Slider tavanda → +Infinity (default); altındaysa kullanıcı limit koymuş.
-              setActiveLayer(next >= max ? Number.POSITIVE_INFINITY : next);
-            }}
-            aria-label="Yükseklik filtresi"
-          />
-        </div>
-
-        <span className="text-[10px] text-zinc-400">0</span>
+        {/* Horizontal depth slider — 0=hepsi normal, max=hepsi ghost */}
+        <Slider
+          orientation="horizontal"
+          min={0}
+          max={max}
+          step={SCENE.LEVEL_FILTER_STEP_CM}
+          value={[localValue]}
+          onValueChange={(values: number[]) => setLocalValue(values[0])}
+          aria-label="Derinlik ghost filtresi"
+          className="w-32"
+        />
       </div>
     </TooltipProvider>
   );

--- a/apps/frontend/src/features/planning/components/scene/PlanCanvas.tsx
+++ b/apps/frontend/src/features/planning/components/scene/PlanCanvas.tsx
@@ -6,8 +6,10 @@ import { SceneControls } from '@/features/planning/components/scene/SceneControl
 import { CargoMeshInstanced } from '@/features/planning/components/scene/CargoMeshInstanced';
 import { ContainerMesh } from '@/features/planning/components/scene/ContainerMesh';
 import { CogMarker } from '@/features/planning/components/scene/CogMarker';
+import { LevelControls } from '@/features/planning/components/scene/LevelControls';
 import { SceneDisposer } from '@/lib/three/SceneDisposer';
 import { SCENE } from '@/lib/config/scene-config';
+import { usePlanStore } from '@/lib/store/usePlanStore';
 import { SelectedBoxCoords } from '@/features/planning/components/scene/SelectedBoxCoords';
 import { BalancePanel } from '@/features/planning/components/scene/BalancePanel';
 
@@ -51,6 +53,8 @@ function SnapshotBridge({
 }
 
 export function PlanCanvas({ className, planId = '', snapshotRef }: PlanCanvasProps) {
+  const vehicleId = usePlanStore((s) => s.selectedVehicle?.id);
+
   return (
     <div className={className} style={{ width: '100%', height: '100%', position: 'relative' }}>
       <Canvas
@@ -78,6 +82,9 @@ export function PlanCanvas({ className, planId = '', snapshotRef }: PlanCanvasPr
       </Canvas>
       <SelectedBoxCoords />
       <BalancePanel />
+      <div className="absolute bottom-4 left-4 pointer-events-auto">
+        <LevelControls key={vehicleId} />
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/lib/store/useSceneStore.ts
+++ b/apps/frontend/src/lib/store/useSceneStore.ts
@@ -31,7 +31,7 @@ interface SceneStore {
 }
 
 const initialState = {
-  activeLayer: Number.POSITIVE_INFINITY,
+  activeLayer: 0,
   selectedBoxId: null,
   selectedItemId: null,
   selectedInstanceId: null as number | null,

--- a/apps/frontend/src/lib/utils/sceneFilter.test.ts
+++ b/apps/frontend/src/lib/utils/sceneFilter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { PlacementWithDimensions } from '@/lib/types/loadingPlan';
-import { isAboveActiveLayer, isPlacementVisible } from './sceneFilter';
+import { isGhosted, isPlacementVisible } from './sceneFilter';
 
 function makePlacement(overrides: Partial<PlacementWithDimensions> = {}): PlacementWithDimensions {
   return {
@@ -14,36 +14,42 @@ function makePlacement(overrides: Partial<PlacementWithDimensions> = {}): Placem
     width: 50,
     height: 50,
     depth: 50,
+    weight: 10,
     ...overrides,
   };
 }
 
 const EMPTY_STATE = {
-  activeLayer: Number.POSITIVE_INFINITY,
   selectedInstanceId: null,
   selectedItemId: null,
   hiddenItemIds: [] as string[],
 };
 
-describe('isAboveActiveLayer', () => {
-  it('+Infinity activeLayer → hiçbir kutu üstte değil', () => {
-    expect(isAboveActiveLayer({ positionY: 100, height: 50 }, Number.POSITIVE_INFINITY)).toBe(
-      false,
-    );
+describe('isGhosted', () => {
+  it('activeLayer = 0 (default) → hiçbir kutu ghost değil', () => {
+    expect(isGhosted({ positionZ: 0, depth: 50 }, 0)).toBe(false);
+    expect(isGhosted({ positionZ: 500, depth: 50 }, 0)).toBe(false);
   });
 
-  it('kutunun tavanı tam activeLayer hizasında ise üstte sayılmaz', () => {
-    // y=100, h=50 → tavan = 150. activeLayer = 150 → 150 > 150 false → görünür.
-    expect(isAboveActiveLayer({ positionY: 100, height: 50 }, 150)).toBe(false);
+  it('positionZ < activeLayer → ghost', () => {
+    expect(isGhosted({ positionZ: 100, depth: 50 }, 200)).toBe(true);
   });
 
-  it('kutunun tavanı activeLayer üstündeyse üstte', () => {
-    // tavan = 150, activeLayer = 149 → 150 > 149 → gizli.
-    expect(isAboveActiveLayer({ positionY: 100, height: 50 }, 149)).toBe(true);
+  it('positionZ === activeLayer → ghost değil (tam sınırda normal)', () => {
+    expect(isGhosted({ positionZ: 200, depth: 50 }, 200)).toBe(false);
   });
 
-  it('activeLayer = 0 ise yere oturmuş kutu bile gizlenir', () => {
-    expect(isAboveActiveLayer({ positionY: 0, height: 50 }, 0)).toBe(true);
+  it('positionZ > activeLayer → ghost değil', () => {
+    expect(isGhosted({ positionZ: 300, depth: 50 }, 200)).toBe(false);
+  });
+
+  it('negatif activeLayer → hiçbir kutu ghost değil', () => {
+    expect(isGhosted({ positionZ: 0, depth: 50 }, -1)).toBe(false);
+  });
+
+  it('slider max (vehicle.length) → tüm kutular ghost', () => {
+    expect(isGhosted({ positionZ: 0, depth: 50 }, 600)).toBe(true);
+    expect(isGhosted({ positionZ: 550, depth: 50 }, 600)).toBe(true);
   });
 });
 
@@ -78,7 +84,6 @@ describe('isPlacementVisible', () => {
 
   it('selectedInstanceId aktifse selectedItemId override edilir (sadece o instance gizli)', () => {
     const p = makePlacement({ itemId: 'sku-x' });
-    // index 0, selectedInstanceId 5 — kutu görünür kalmalı (selectedItemId match'ine rağmen)
     expect(
       isPlacementVisible(p, 0, {
         ...EMPTY_STATE,
@@ -88,13 +93,8 @@ describe('isPlacementVisible', () => {
     ).toBe(true);
   });
 
-  it('activeLayer üstündeki kutu gizlenir', () => {
-    const p = makePlacement({ positionY: 200, height: 50 });
-    expect(isPlacementVisible(p, 0, { ...EMPTY_STATE, activeLayer: 100 })).toBe(false);
-  });
-
-  it('activeLayer altındaki kutu görünür', () => {
-    const p = makePlacement({ positionY: 0, height: 50 });
-    expect(isPlacementVisible(p, 0, { ...EMPTY_STATE, activeLayer: 100 })).toBe(true);
+  it('activeLayer ghost mode isPlacementVisible etkilemez — ghost ayrı mesh, gizleme değil', () => {
+    const p = makePlacement({ positionZ: 0, depth: 50 });
+    expect(isPlacementVisible(p, 0, EMPTY_STATE)).toBe(true);
   });
 });

--- a/apps/frontend/src/lib/utils/sceneFilter.ts
+++ b/apps/frontend/src/lib/utils/sceneFilter.ts
@@ -1,35 +1,37 @@
 import type { PlacementWithDimensions } from '@/lib/types/loadingPlan';
 
 interface PositionedBox {
-  positionY: number;
-  height: number;
+  positionZ: number;
+  depth: number;
 }
 
 /**
- * Aktif katman üstünde kalan kutuları filtreler — kutunun TAVANI activeLayer'ı geçiyorsa gizli.
+ * Ghost mode filtresi — kutunun ön yüzü (positionZ) activeLayer'dan küçükse ghost olur.
  *
- * AC1 (US-OPT-10): Y eksenindeki "level filter" mantığı.
- * activeLayer = +Infinity (default) → tüm kutular görünür.
+ * AC2 (US-OPT-10): Slider sağa çekildikçe activeLayer artar; kapıya yakın (küçük Z) kutular
+ * şeffaflaşır, operatör konteynerin içine "süzülür".
+ * activeLayer = 0 (default) → hiçbir kutu ghost değil, hepsi normal.
  */
-export function isAboveActiveLayer(box: PositionedBox, activeLayer: number): boolean {
-  if (!Number.isFinite(activeLayer)) return false;
-  return box.positionY + box.height > activeLayer;
+export function isGhosted(box: PositionedBox, activeLayer: number): boolean {
+  if (activeLayer <= 0) return false;
+  return box.positionZ < activeLayer;
 }
 
 /**
- * Bir placement'ın InstancedMesh'te `scale=0` ile gizlenip gizlenmeyeceğini hesaplar.
+ * Bir placement'ın InstancedMesh'te scale=0 ile tamamen gizlenip gizlenmeyeceğini hesaplar.
  *
  * Gizleme nedenleri:
  *  - hiddenItemIds: kullanıcı SKU bazında gizledi
  *  - selectedInstanceId: glow için BoxWrapper olarak ayrı render edilecek
  *  - selectedItemId: aynı SKU'nun tüm instance'ları glow'a düşer
- *  - activeLayer üstünde kalmak (level filter)
+ *
+ * NOT: Ghost mode (activeLayer) burada kontrol edilmez — ghost kutular hâlâ
+ * sahneye render edilir, sadece ghost InstancedMesh'e taşınır.
  */
 export function isPlacementVisible(
   p: PlacementWithDimensions,
   index: number,
   state: {
-    activeLayer: number;
     selectedInstanceId: number | null;
     selectedItemId: string | null;
     hiddenItemIds: readonly string[];
@@ -38,6 +40,5 @@ export function isPlacementVisible(
   if (state.hiddenItemIds.includes(p.itemId)) return false;
   if (state.selectedInstanceId === index) return false;
   if (state.selectedInstanceId === null && state.selectedItemId === p.itemId) return false;
-  if (isAboveActiveLayer(p, state.activeLayer)) return false;
   return true;
 }


### PR DESCRIPTION
- CargoMeshInstanced: opaque/ghost/violation wireframe olmak üzere üç ayrı InstancedMesh yapısına geçildi
- Ghost mode: positionZ < activeLayer olan kutular %10 opaklıkta render edilir
- X-Ray mode: ihlal olan kutular depthTest=false wireframe ile diğer meshlerin önünde görünür hale getirildi
- LevelControls: yatay Z-ekseni slider, useDebounce(80ms) ile store'a yazılır; key={vehicleId} ile araç değişince sıfırlanır
- BoxWrapper: isGhosted prop eklendi (<50 kutu modu desteği)
- sceneFilter: isAboveActiveLayer kaldırıldı, isGhosted (Z semantiği) yazıldı
- useSceneStore: activeLayer default 0, xRayMode + toggleXRayMode eklendi
- 12 Vitest testi güncellendi/eklendi

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [x] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x] Manuel test yapıldı

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
