### PR TITLE
fix(infra): Resend config key ve CI deploy env vars düzeltmesi - US-D33

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -224,6 +224,11 @@ jobs:
       Seed__DefaultAdminPassword: ${{ secrets.SEED_DEFAULT_ADMIN_PASSWORD || 'Admin@CargoPilot1!' }}
       # JWT secret — en az 32 karakter olmalı
       JWT_SECRET: ${{ secrets.JWT_SECRET || 'ci-test-secret-key-at-least-32-chars-long!' }}
+      # Resend — CI'da dummy değerler; gerçek değerler sunucudaki .env.test'te
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY || 'ci-resend-api-key-placeholder' }}
+      RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL || 'ci@example.com' }}
+      RESEND_FROM_NAME: ${{ secrets.RESEND_FROM_NAME || 'Cargo Pilot CI' }}
+      PASSWORD_RESET_FRONTEND_URL: ${{ secrets.PASSWORD_RESET_FRONTEND_URL || 'http://localhost:3001/auth/reset-password' }}
 
     steps:
       - name: Kodu al

--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -28,7 +28,7 @@ services:
       Resend__ApiKey: ${RESEND_API_KEY:-}
       Resend__FromEmail: ${RESEND_FROM_EMAIL:-}
       Resend__FromName: ${RESEND_FROM_NAME:-}
-      Resend__PasswordResetFrontendUrl: ${PASSWORD_RESET_FRONTEND_URL:-}
+      PasswordReset__FrontendResetUrl: ${PASSWORD_RESET_FRONTEND_URL:-}
     ports:
       - "${BACKEND_PORT}:8080"
     depends_on:


### PR DESCRIPTION
## Summary

- `docker-compose.test.yml`: `Resend__PasswordResetFrontendUrl` → `PasswordReset__FrontendResetUrl` düzeltildi
- `test-deploy.yml`: CI deploy job'a Resend env vars eklendi (dummy fallback değerleri)

Önce `dev` → PR #265 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)