### PR TITLE
feature/US-VY-24-bypass-destegi

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Interfaces/IVehicleRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/IVehicleRepository.cs
@@ -1,0 +1,14 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Entities;
+
+namespace CargoPilot.Application.Common.Interfaces;
+
+public interface IVehicleRepository
+{
+    Task<PagedResult<Vehicle>> SearchAsync(
+        string? searchTerm,
+        int page,
+        int pageSize,
+        bool isExport,
+        CancellationToken cancellationToken = default);
+}

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/SearchVehicles/SearchVehiclesQuery.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/SearchVehicles/SearchVehiclesQuery.cs
@@ -1,0 +1,10 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Vehicles.SearchVehicles;
+
+public sealed record SearchVehiclesQuery(
+    string? SearchTerm,
+    int Page = 1,
+    int PageSize = 20,
+    bool IsExport = false) : IRequest<Result<PagedResult<VehicleSummaryDto>>>;

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/SearchVehicles/SearchVehiclesQueryHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/SearchVehicles/SearchVehiclesQueryHandler.cs
@@ -1,0 +1,62 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Vehicles.SearchVehicles;
+
+public sealed class SearchVehiclesQueryHandler : IRequestHandler<SearchVehiclesQuery, Result<PagedResult<VehicleSummaryDto>>>
+{
+    private readonly IVehicleRepository _vehicleRepository;
+    private readonly IValidator<SearchVehiclesQuery> _validator;
+
+    public SearchVehiclesQueryHandler(
+        IVehicleRepository vehicleRepository,
+        IValidator<SearchVehiclesQuery> validator)
+    {
+        _vehicleRepository = vehicleRepository;
+        _validator = validator;
+    }
+
+    public async Task<Result<PagedResult<VehicleSummaryDto>>> Handle(
+        SearchVehiclesQuery request,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<PagedResult<VehicleSummaryDto>>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var pagedVehicles = await _vehicleRepository.SearchAsync(
+            request.SearchTerm,
+            request.Page,
+            request.PageSize,
+            request.IsExport,
+            cancellationToken);
+
+        var dto = new PagedResult<VehicleSummaryDto>(
+            pagedVehicles.Items.Select(v => new VehicleSummaryDto(
+                v.Id,
+                v.VehicleName,
+                v.VehicleType,
+                v.PlateNumber,
+                v.InternalWidth,
+                v.InternalHeight,
+                v.InternalLength,
+                v.MaxWeightCapacity,
+                v.LayerCount,
+                v.LoadingType,
+                v.CompanyId,
+                v.Volume)).ToList(),
+            pagedVehicles.TotalCount,
+            pagedVehicles.Page,
+            pagedVehicles.PageSize);
+
+        return Result<PagedResult<VehicleSummaryDto>>.Success(dto);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/SearchVehicles/SearchVehiclesQueryValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/SearchVehicles/SearchVehiclesQueryValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Vehicles.SearchVehicles;
+
+public sealed class SearchVehiclesQueryValidator : AbstractValidator<SearchVehiclesQuery>
+{
+    public SearchVehiclesQueryValidator()
+    {
+        RuleFor(x => x.Page)
+            .GreaterThanOrEqualTo(1)
+                .WithErrorCode("VEHICLE_SEARCH_PAGE_MIN")
+                .WithMessage("Sayfa numarası 1'den küçük olamaz.");
+
+        RuleFor(x => x.PageSize)
+            .InclusiveBetween(1, 100)
+                .WithErrorCode("VEHICLE_SEARCH_PAGESIZE_RANGE")
+                .WithMessage("Sayfa boyutu 1 ile 100 arasında olmalıdır.")
+            .When(x => !x.IsExport);
+
+        RuleFor(x => x.SearchTerm)
+            .MaximumLength(200)
+                .WithErrorCode("VEHICLE_SEARCH_TERM_TOO_LONG")
+                .WithMessage("Arama terimi en fazla 200 karakter olabilir.")
+            .When(x => x.SearchTerm is not null);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/SearchVehicles/VehicleSummaryDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/SearchVehicles/VehicleSummaryDto.cs
@@ -1,0 +1,17 @@
+using CargoPilot.Domain.Enums;
+
+namespace CargoPilot.Application.Features.Vehicles.SearchVehicles;
+
+public sealed record VehicleSummaryDto(
+    Guid Id,
+    string VehicleName,
+    VehicleType VehicleType,
+    string PlateNumber,
+    decimal InternalWidth,
+    decimal InternalHeight,
+    decimal InternalLength,
+    decimal MaxWeightCapacity,
+    int LayerCount,
+    LoadingType LoadingType,
+    Guid? CompanyId,
+    decimal Volume);

--- a/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
+++ b/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
@@ -53,6 +53,7 @@ public static class DependencyInjection {
         services.AddScoped<IJwtTokenService, JwtTokenService>();
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<IItemRepository, ItemRepository>();
+        services.AddScoped<IVehicleRepository, VehicleRepository>();
         services.AddScoped<IPasswordResetTokenRepository, PasswordResetTokenRepository>();
         services.AddScoped<IUserPasswordHistoryRepository, UserPasswordHistoryRepository>();
         services.AddHttpClient<IEmailService, ResendEmailService>(client =>

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/VehicleRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/VehicleRepository.cs
@@ -1,0 +1,50 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CargoPilot.Infrastructure.Persistence.Repositories;
+
+internal sealed class VehicleRepository : IVehicleRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public VehicleRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<PagedResult<Vehicle>> SearchAsync(
+        string? searchTerm,
+        int page,
+        int pageSize,
+        bool isExport,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.Vehicles.AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(searchTerm))
+        {
+            var term = searchTerm.Trim();
+            query = query.Where(v => v.VehicleName.Contains(term) || v.PlateNumber.Contains(term));
+        }
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        IQueryable<Vehicle> ordered = query.OrderBy(v => v.VehicleName);
+
+        List<Vehicle> vehicles;
+        if (isExport)
+        {
+            vehicles = await ordered.ToListAsync(cancellationToken);
+            return new PagedResult<Vehicle>(vehicles, totalCount, 1, totalCount == 0 ? 1 : totalCount);
+        }
+
+        vehicles = await ordered
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return new PagedResult<Vehicle>(vehicles, totalCount, page, pageSize);
+    }
+}

--- a/apps/backend/CargoPilot.WebAPI/Controllers/VehiclesController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/VehiclesController.cs
@@ -1,0 +1,47 @@
+using CargoPilot.Application.Features.Vehicles.SearchVehicles;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CargoPilot.WebAPI.Controllers;
+
+/// <summary>
+/// Araç (vehicle) yönetimi endpoint'leri.
+/// </summary>
+[Route("api/v1/vehicles")]
+[Tags("Vehicles")]
+[Authorize]
+public sealed class VehiclesController : BaseController
+{
+    private readonly IMediator _mediator;
+
+    public VehiclesController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Araçları arar ve sayfalı döndürür. isExport=true ile tüm kayıtlar pagination olmadan döner.
+    /// </summary>
+    /// <param name="searchTerm">Araç adı veya plaka arama terimi (opsiyonel).</param>
+    /// <param name="page">Sayfa numarası (varsayılan: 1).</param>
+    /// <param name="pageSize">Sayfa boyutu, 1-100 arası (varsayılan: 20). isExport=true ise göz ardı edilir.</param>
+    /// <param name="isExport">Tüm kayıtları pagination olmadan döndürmek için true geçin.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Arama sonuçları döner.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Search(
+        [FromQuery] string? searchTerm,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        [FromQuery] bool isExport = false,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new SearchVehiclesQuery(searchTerm, page, pageSize, isExport);
+        var result = await _mediator.Send(query, cancellationToken);
+        return HandleResult(result);
+    }
+}


### PR DESCRIPTION
Özellik: Araç Arama Fonksiyonuna Export Desteği
Açıklama:
Araç listeleme endpoint'ine (/api/v1/vehicles), tüm verilerin tek seferde çekilebilmesini sağlayan isExport parametresi eklendi. Bu özellik ile raporlama veya dışa aktarım işlemleri için sayfalama limitleri devre dışı bırakılabilmektedir.
Neden Yapıldı?

İstemci taraflı Excel/CSV export işlemlerini hızlandırmak.

Sayfalama (pagination) sınırlarına takılmadan tüm veri setine ihtiyaç duyan entegrasyonları desteklemek.

Notlar:

isExport=true gönderildiğinde PageSize zorunluluğu kaldırılmıştır.

Performans açısından büyük veri setlerinde (binlerce araç) dikkatli kullanılmalıdır.

Neden Bu Yöntem Doğru?
Bu değişiklik, projenin Clean Architecture prensiplerine uygunluğunu koruyor çünkü:

Validator'ı bozmadın: isExport kontrolünü validatöre koyarak validation kurallarını dinamik hale getirdin.

Repository'i ezmedin: Sadece mevcut metodun yeteneklerini genişlettin.

Controller'ı kirletmedin: İş mantığını (business logic) Handler ve Repository katmanlarına dağıtarak API'yi temiz tuttun.