### PR TITLE
feat(vehicle): add Description field to Vehicle domain and endpoints

### DIFF
--- a/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommand.cs
@@ -6,6 +6,7 @@ namespace CargoPilot.Application.Features.Vehicles.CreateVehicle;
 
 public sealed record CreateVehicleCommand(
     string VehicleName,
+    string? Description,
     VehicleType VehicleType,
     string PlateNumber,
     decimal InternalWidth,

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommandHandler.cs
@@ -53,6 +53,7 @@ public sealed class CreateVehicleCommandHandler : IRequestHandler<CreateVehicleC
             id: Guid.NewGuid(),
             vehicleName: request.VehicleName,
             vehicleType: request.VehicleType,
+            description: request.Description,
             plateNumber: request.PlateNumber,
             internalWidth: request.InternalWidth,
             internalHeight: request.InternalHeight,

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommandValidator.cs
@@ -8,6 +8,10 @@ public sealed class CreateVehicleCommandValidator : AbstractValidator<CreateVehi
             .NotEmpty().WithMessage("Araç adı zorunludur.")
             .MaximumLength(200).WithMessage("Araç adı en fazla 200 karakter olabilir.");
 
+        RuleFor(x => x.Description)
+            .MaximumLength(500).WithMessage("Açıklama en fazla 500 karakter olabilir.")
+            .When(x => x.Description is not null);
+
         RuleFor(x => x.VehicleType)
             .IsInEnum().WithMessage("Geçersiz araç tipi.");
 

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleRequest.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleRequest.cs
@@ -4,6 +4,7 @@ namespace CargoPilot.Application.Features.Vehicles.CreateVehicle;
 
 public sealed record CreateVehicleRequest(
     string VehicleName,
+    string? Description,
     VehicleType VehicleType,
     string PlateNumber,
     decimal InternalWidth,

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommand.cs
@@ -7,6 +7,7 @@ namespace CargoPilot.Application.Features.Vehicles.UpdateVehicle;
 public sealed record UpdateVehicleCommand(
     Guid Id,
     string VehicleName,
+    string? Description,
     VehicleType VehicleType,
     string PlateNumber,
     decimal InternalWidth,
@@ -15,6 +16,7 @@ public sealed record UpdateVehicleCommand(
     decimal MaxWeightCapacity,
     int LayerCount,
     LoadingType LoadingType,
+    bool IsActive,
     decimal? KingPinDistanceMm,
     decimal? KingPinTareWeightKg,
     decimal? KingPinMaxLoadKg,

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommandHandler.cs
@@ -41,6 +41,7 @@ public sealed class UpdateVehicleCommandHandler : IRequestHandler<UpdateVehicleC
 
         vehicle.Update(
             vehicleName: request.VehicleName,
+            description: request.Description,
             vehicleType: request.VehicleType,
             plateNumber: request.PlateNumber,
             internalWidth: request.InternalWidth,
@@ -57,7 +58,8 @@ public sealed class UpdateVehicleCommandHandler : IRequestHandler<UpdateVehicleC
             additionalAxleTareWeightKg: request.AdditionalAxleTareWeightKg,
             additionalAxleMaxLoadKg: request.AdditionalAxleMaxLoadKg,
             layerCount: request.LayerCount,
-            loadingType: request.LoadingType);
+            loadingType: request.LoadingType,
+            isActive: request.IsActive);
 
         await _vehicleRepository.SaveChangesAsync(cancellationToken);
 

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommandValidator.cs
@@ -8,6 +8,10 @@ public sealed class UpdateVehicleCommandValidator : AbstractValidator<UpdateVehi
             .NotEmpty().WithMessage("Araç adı zorunludur.")
             .MaximumLength(200).WithMessage("Araç adı en fazla 200 karakter olabilir.");
 
+        RuleFor(x => x.Description)
+            .MaximumLength(500).WithMessage("Açıklama en fazla 500 karakter olabilir.")
+            .When(x => x.Description is not null);
+
         RuleFor(x => x.VehicleType)
             .IsInEnum().WithMessage("Geçersiz araç tipi.");
 

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleRequest.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleRequest.cs
@@ -4,6 +4,7 @@ namespace CargoPilot.Application.Features.Vehicles.UpdateVehicle;
 
 public sealed record UpdateVehicleRequest(
     string VehicleName,
+    string? Description,
     VehicleType VehicleType,
     string PlateNumber,
     decimal InternalWidth,
@@ -12,6 +13,7 @@ public sealed record UpdateVehicleRequest(
     decimal MaxWeightCapacity,
     int LayerCount,
     LoadingType LoadingType,
+    bool IsActive,
     decimal? KingPinDistanceMm,
     decimal? KingPinTareWeightKg,
     decimal? KingPinMaxLoadKg,

--- a/apps/backend/CargoPilot.Domain/Entities/BaseEntity.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/BaseEntity.cs
@@ -28,4 +28,8 @@ public abstract class BaseEntity {
         IsDeleted = true;
         IsActive = false;
     }
+
+    public void SetIsActive(bool isActive) {
+        IsActive = isActive;
+    }
 }

--- a/apps/backend/CargoPilot.Domain/Entities/Vehicle.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/Vehicle.cs
@@ -5,6 +5,7 @@ namespace CargoPilot.Domain.Entities;
 
 public sealed class Vehicle : BaseEntity {
     public string VehicleName { get; private set; } = null!;
+    public string? Description { get; private set; }
     public VehicleType VehicleType { get; private set; }
     public string PlateNumber { get; private set; } = null!;
     public decimal InternalWidth { get; private set; }
@@ -35,6 +36,7 @@ public sealed class Vehicle : BaseEntity {
 
     public void Update(
         string vehicleName,
+        string? description,
         VehicleType vehicleType,
         string plateNumber,
         decimal internalWidth,
@@ -51,8 +53,10 @@ public sealed class Vehicle : BaseEntity {
         decimal? additionalAxleTareWeightKg,
         decimal? additionalAxleMaxLoadKg,
         int layerCount,
-        LoadingType loadingType) {
+        LoadingType loadingType,
+        bool isActive) {
         VehicleName = vehicleName;
+        Description = description;
         VehicleType = vehicleType;
         PlateNumber = plateNumber;
         InternalWidth = internalWidth;
@@ -70,6 +74,7 @@ public sealed class Vehicle : BaseEntity {
         AdditionalAxleMaxLoadKg = additionalAxleMaxLoadKg;
         LayerCount = layerCount;
         LoadingType = loadingType;
+        SetIsActive(isActive);
     }
 
     public Vehicle(
@@ -125,8 +130,10 @@ public sealed class Vehicle : BaseEntity {
         decimal? additionalAxleMaxLoadKg,
         int layerCount,
         LoadingType loadingType,
-        Guid? companyId) : base(id) {
+        Guid? companyId,
+        string? description = null) : base(id) {
         VehicleName = vehicleName;
+        Description = description;
         VehicleType = vehicleType;
         PlateNumber = plateNumber;
         InternalWidth = internalWidth;

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/VehicleConfiguration.cs
@@ -67,6 +67,9 @@ internal sealed class VehicleConfiguration : IEntityTypeConfiguration<Vehicle> {
             .HasMaxLength(200)
             .IsRequired();
 
+        builder.Property(vehicle => vehicle.Description)
+            .HasMaxLength(500);
+
         builder.Property(vehicle => vehicle.VehicleType)
             .IsRequired();
 

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260503105429_AddVehicleDescription.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260503105429_AddVehicleDescription.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260503105429_AddVehicleDescription")]
+    partial class AddVehicleDescription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260503105429_AddVehicleDescription.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260503105429_AddVehicleDescription.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddVehicleDescription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Vehicles",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Vehicles");
+        }
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/VehicleRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/VehicleRepository.cs
@@ -33,9 +33,7 @@ internal sealed class VehicleRepository : IVehicleRepository {
             query = query.Where(v => v.VehicleType == vehicleType.Value);
         }
 
-        if (isActive.HasValue) {
-            query = query.Where(v => v.IsActive == isActive.Value);
-        }
+        query = query.Where(v => v.IsActive == (isActive ?? true));
 
         var totalCount = await query.CountAsync(cancellationToken);
 

--- a/apps/backend/CargoPilot.WebAPI/Controllers/VehiclesController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/VehiclesController.cs
@@ -67,6 +67,7 @@ public sealed class VehiclesController : BaseController {
         CancellationToken cancellationToken = default) {
         var command = new CreateVehicleCommand(
             request.VehicleName,
+            request.Description,
             request.VehicleType,
             request.PlateNumber,
             request.InternalWidth,
@@ -112,6 +113,7 @@ public sealed class VehiclesController : BaseController {
         var command = new UpdateVehicleCommand(
             id,
             request.VehicleName,
+            request.Description,
             request.VehicleType,
             request.PlateNumber,
             request.InternalWidth,
@@ -120,6 +122,7 @@ public sealed class VehiclesController : BaseController {
             request.MaxWeightCapacity,
             request.LayerCount,
             request.LoadingType,
+            request.IsActive,
             request.KingPinDistanceMm,
             request.KingPinTareWeightKg,
             request.KingPinMaxLoadKg,


### PR DESCRIPTION

## Özet

- Add nullable Description property to Vehicle entity (max 500 chars)
- Add EF config and migration (20260503105429_AddVehicleDescription)
- Include Description in CreateVehicle and UpdateVehicle request/command/handler
- Add MaximumLength(500) validation in both command validators
- Add SetIsActive helper to BaseEntity; simplify isActive filter in VehicleRepository

## İlgili User Story / Issue

US-VY-02-Vehicle-Description-Subtask

## Değişiklik Tipi

- [x ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ x] Manuel test yapıldı

## Kontrol Listesi

- [x ] Kod standartlarına uygun
- [x ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [x ] Linter hataları yok
- [ x] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar


