### PR TITLE
fix(ci): deploy-test-server yeni image GHCR'a push edilmeden önce çekiyordu

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -337,11 +337,12 @@ jobs:
   deploy-test-server:
     name: Deploy (Test Server)
     runs-on: ubuntu-latest
-    needs: [enforce-test-base, migration-check]
+    needs: [enforce-test-base, migration-check, build]
     if: |
       always() &&
       (needs.enforce-test-base.result == 'success' || needs.enforce-test-base.result == 'skipped') &&
       (needs.migration-check.result == 'success') &&
+      (needs.build.result == 'success') &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/test'
 


### PR DESCRIPTION
## Problem

`deploy-test-server` job'u `build` job'una bağımlı değildi. İkisi paralel başlıyordu:

- `build` → yeni image'ı GHCR'a push ediyor (~3-4 dk)
- `deploy-test-server` → `migration-check` bitince başlıyordu (~1 dk)

Sonuç: sunucu GHCR'dan pull yaparken yeni image henüz hazır değil → **eski image deploy oluyor**, canlıda değişiklik görünmüyor.

## Fix

`needs` listesine `build` eklendi → sunucu deploy'u ancak yeni image GHCR'a push edildikten sonra başlıyor.

## Test plan

- [ ] `test` branch'ine merge sonrası `Deploy (Test Server)` job'unun `Image Build` bittikten sonra başladığını doğrula
- [ ] Canlı sitede merge edilen değişikliklerin göründüğünü doğrula

🤖 Generated with [Claude Code](https://claude.com/claude-code)