### PR TITLE
fix(frontend): TooltipProvider app root'una eklendi

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RouterProvider } from 'react-router-dom';
 import { Toaster } from '@/components/ui/sonner';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { GlobalSpinner } from '@/components/shared/GlobalSpinner';
 import { NotificationBridge } from '@/components/shared/NotificationBridge';
@@ -17,13 +18,15 @@ export function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ErrorBoundary>
-        <RouterProvider router={router} />
-        <GlobalSpinner />
-        <NotificationBridge />
-        <Toaster />
-        {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
-      </ErrorBoundary>
+      <TooltipProvider>
+        <ErrorBoundary>
+          <RouterProvider router={router} />
+          <GlobalSpinner />
+          <NotificationBridge />
+          <Toaster />
+          {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+        </ErrorBoundary>
+      </TooltipProvider>
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Problem

`/vehicles` sayfası (ve `Tooltip` kullanan tüm sayfalar) crash ediyordu:
```
Error: `Tooltip` must be used within `TooltipProvider`
```

`App.tsx`'te hiç `TooltipProvider` yoktu. Bazı component'ler (`ProductForm`, `SelectedBoxPanel`, `LevelControls`) kendi içinde local olarak sarıyordu ama yeni eklenen component'ler (vehicles sayfası) sarmıyordu.

## Fix

`TooltipProvider` → `App.tsx` root'una `QueryClientProvider` altına eklendi. Artık uygulama genelinde tüm `Tooltip` kullanımları çalışır.

## Test plan

- [ ] `/vehicles` sayfasının açıldığını doğrula
- [ ] Diğer sayfalardaki Tooltip'lerin hâlâ çalıştığını doğrula

🤖 Generated with [Claude Code](https://claude.com/claude-code)