### PR TITLE
feat: Loading Plan CRUD operasyonlarının (Create, Update, Delete) eklenmesi

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Interfaces/IItemRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/IItemRepository.cs
@@ -6,6 +6,7 @@ namespace CargoPilot.Application.Common.Interfaces;
 public interface IItemRepository
 {
     Task<Item?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<Guid>> GetExistingIdsAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default);
     Task<bool> ExistsBySkuAsync(string sku, CancellationToken cancellationToken = default);
     Task<bool> ExistsBySkuAsync(string sku, Guid excludeItemId, CancellationToken cancellationToken = default);
     Task<bool> IsUsedInActiveLoadingPlanAsync(Guid itemId, CancellationToken cancellationToken = default);

--- a/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanRepository.cs
@@ -22,5 +22,7 @@ public interface ILoadingPlanRepository
 
     void Add(LoadingPlan plan);
 
+    void AddInputItems(IEnumerable<LoadingPlanInputItem> items);
+
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanRepository.cs
@@ -1,6 +1,7 @@
 using CargoPilot.Application.Common.Models;
 using CargoPilot.Application.Features.Plans.GetPlanById;
 using CargoPilot.Application.Features.Plans.GetPlans;
+using CargoPilot.Domain.Entities;
 
 namespace CargoPilot.Application.Common.Interfaces;
 
@@ -16,4 +17,10 @@ public interface ILoadingPlanRepository
     Task<PlanDetailDto?> GetDetailByIdAsync(
         Guid id,
         CancellationToken cancellationToken = default);
+
+    Task<LoadingPlan?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    void Add(LoadingPlan plan);
+
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/apps/backend/CargoPilot.Application/Common/Interfaces/IOptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/IOptimizationEngine.cs
@@ -1,0 +1,6 @@
+namespace CargoPilot.Application.Common.Interfaces;
+
+public interface IOptimizationEngine
+{
+    Task RunOptimizationAsync(Guid planId, CancellationToken cancellationToken = default);
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommand.cs
@@ -1,0 +1,12 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.CreatePlan;
+
+public sealed record CreatePlanCommand(
+    string PlanName,
+    Guid VehicleId,
+    IReadOnlyList<CreatePlanItemRequest> Items,
+    LoadingPlanOptimizationCriteria OptimizationCriteria = LoadingPlanOptimizationCriteria.VolumeFirst)
+    : IRequest<Result<Guid>>;

--- a/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandHandler.cs
@@ -1,0 +1,62 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Entities;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.CreatePlan;
+
+public sealed class CreatePlanCommandHandler : IRequestHandler<CreatePlanCommand, Result<Guid>>
+{
+    private readonly ILoadingPlanRepository _planRepository;
+    private readonly IVehicleRepository _vehicleRepository;
+    private readonly IOptimizationEngine _optimizationEngine;
+    private readonly IValidator<CreatePlanCommand> _validator;
+
+    public CreatePlanCommandHandler(
+        ILoadingPlanRepository planRepository,
+        IVehicleRepository vehicleRepository,
+        IOptimizationEngine optimizationEngine,
+        IValidator<CreatePlanCommand> validator)
+    {
+        _planRepository = planRepository;
+        _vehicleRepository = vehicleRepository;
+        _optimizationEngine = optimizationEngine;
+        _validator = validator;
+    }
+
+    public async Task<Result<Guid>> Handle(CreatePlanCommand request, CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var vehicle = await _vehicleRepository.GetByIdAsync(request.VehicleId, cancellationToken);
+        if (vehicle is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "Vehicle.NotFound", "Araç bulunamadı."));
+
+        var inputTotalQuantity = request.Items.Sum(i => i.Quantity);
+
+        var plan = new LoadingPlan(
+            id: Guid.NewGuid(),
+            planName: request.PlanName,
+            vehicleId: request.VehicleId,
+            optimizationCriteria: request.OptimizationCriteria,
+            inputTotalQuantity: inputTotalQuantity,
+            companyId: vehicle.CompanyId);
+
+        _planRepository.Add(plan);
+        await _planRepository.SaveChangesAsync(cancellationToken);
+
+        await _optimizationEngine.RunOptimizationAsync(plan.Id, cancellationToken);
+
+        return Result<Guid>.Success(plan.Id);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandHandler.cs
@@ -10,17 +10,20 @@ public sealed class CreatePlanCommandHandler : IRequestHandler<CreatePlanCommand
 {
     private readonly ILoadingPlanRepository _planRepository;
     private readonly IVehicleRepository _vehicleRepository;
+    private readonly IItemRepository _itemRepository;
     private readonly IOptimizationEngine _optimizationEngine;
     private readonly IValidator<CreatePlanCommand> _validator;
 
     public CreatePlanCommandHandler(
         ILoadingPlanRepository planRepository,
         IVehicleRepository vehicleRepository,
+        IItemRepository itemRepository,
         IOptimizationEngine optimizationEngine,
         IValidator<CreatePlanCommand> validator)
     {
         _planRepository = planRepository;
         _vehicleRepository = vehicleRepository;
+        _itemRepository = itemRepository;
         _optimizationEngine = optimizationEngine;
         _validator = validator;
     }
@@ -42,17 +45,35 @@ public sealed class CreatePlanCommandHandler : IRequestHandler<CreatePlanCommand
             return Result<Guid>.Failure(
                 new Error(ErrorType.NotFound, "Vehicle.NotFound", "Araç bulunamadı."));
 
+        var requestedItemIds = request.Items.Select(i => i.ItemId).Distinct().ToList();
+        var existingItemIds = await _itemRepository.GetExistingIdsAsync(requestedItemIds, cancellationToken);
+        var missingIds = requestedItemIds.Except(existingItemIds).ToList();
+        if (missingIds.Count > 0)
+        {
+            var failures = missingIds
+                .Select(id => new ValidationFailure("Items", $"Item bulunamadı: {id}"))
+                .ToList();
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "Items.NotFound", "Bir veya daha fazla item bulunamadı.", failures));
+        }
+
         var inputTotalQuantity = request.Items.Sum(i => i.Quantity);
+        var planId = Guid.NewGuid();
 
         var plan = new LoadingPlan(
-            id: Guid.NewGuid(),
+            id: planId,
             planName: request.PlanName,
             vehicleId: request.VehicleId,
             optimizationCriteria: request.OptimizationCriteria,
             inputTotalQuantity: inputTotalQuantity,
             companyId: vehicle.CompanyId);
 
+        var inputItems = request.Items
+            .Select(i => new LoadingPlanInputItem(Guid.NewGuid(), planId, i.ItemId, i.Quantity))
+            .ToList();
+
         _planRepository.Add(plan);
+        _planRepository.AddInputItems(inputItems);
         await _planRepository.SaveChangesAsync(cancellationToken);
 
         await _optimizationEngine.RunOptimizationAsync(plan.Id, cancellationToken);

--- a/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandValidator.cs
@@ -1,0 +1,28 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Plans.CreatePlan;
+
+public sealed class CreatePlanCommandValidator : AbstractValidator<CreatePlanCommand>
+{
+    public CreatePlanCommandValidator()
+    {
+        RuleFor(x => x.PlanName)
+            .NotEmpty().WithMessage("Plan adı boş olamaz.")
+            .MaximumLength(100).WithMessage("Plan adı en fazla 100 karakter olabilir.");
+
+        RuleFor(x => x.VehicleId)
+            .NotEmpty().WithMessage("Araç ID'si boş olamaz.");
+
+        RuleFor(x => x.Items)
+            .NotEmpty().WithMessage("İtem listesi boş olamaz.");
+
+        RuleForEach(x => x.Items).ChildRules(item =>
+        {
+            item.RuleFor(i => i.ItemId)
+                .NotEmpty().WithMessage("İtem ID'si boş olamaz.");
+
+            item.RuleFor(i => i.Quantity)
+                .GreaterThan(0).WithMessage("Miktar 0'dan büyük olmalıdır.");
+        });
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanItemRequest.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanItemRequest.cs
@@ -1,0 +1,3 @@
+namespace CargoPilot.Application.Features.Plans.CreatePlan;
+
+public sealed record CreatePlanItemRequest(Guid ItemId, int Quantity);

--- a/apps/backend/CargoPilot.Application/Features/Plans/DeletePlan/DeletePlanCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/DeletePlan/DeletePlanCommand.cs
@@ -1,0 +1,6 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.DeletePlan;
+
+public sealed record DeletePlanCommand(Guid Id) : IRequest<Result<Guid>>;

--- a/apps/backend/CargoPilot.Application/Features/Plans/DeletePlan/DeletePlanCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/DeletePlan/DeletePlanCommandHandler.cs
@@ -1,0 +1,28 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.DeletePlan;
+
+public sealed class DeletePlanCommandHandler : IRequestHandler<DeletePlanCommand, Result<Guid>>
+{
+    private readonly ILoadingPlanRepository _planRepository;
+
+    public DeletePlanCommandHandler(ILoadingPlanRepository planRepository)
+    {
+        _planRepository = planRepository;
+    }
+
+    public async Task<Result<Guid>> Handle(DeletePlanCommand request, CancellationToken cancellationToken)
+    {
+        var plan = await _planRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (plan is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "Plan.NotFound", "Yükleme planı bulunamadı."));
+
+        plan.MarkAsDeleted();
+        await _planRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<Guid>.Success(plan.Id);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/InputItemDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/InputItemDto.cs
@@ -1,0 +1,3 @@
+namespace CargoPilot.Application.Features.Plans.GetPlanById;
+
+public sealed record InputItemDto(Guid Id, Guid ItemId, int Quantity, ItemInPlanDto Item);

--- a/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/PlanDetailDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/PlanDetailDto.cs
@@ -21,4 +21,5 @@ public sealed record PlanDetailDto(
     VehicleInPlanDto Vehicle,
     IReadOnlyList<PlacementDto> Placements,
     IReadOnlyList<UnplacedItemDto> UnplacedItems,
-    IReadOnlyList<WarningDto> Warnings);
+    IReadOnlyList<WarningDto> Warnings,
+    IReadOnlyList<InputItemDto> InputItems);

--- a/apps/backend/CargoPilot.Application/Features/Plans/UpdatePlanName/UpdatePlanNameCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/UpdatePlanName/UpdatePlanNameCommand.cs
@@ -1,0 +1,6 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.UpdatePlanName;
+
+public sealed record UpdatePlanNameCommand(Guid Id, string PlanName) : IRequest<Result<Guid>>;

--- a/apps/backend/CargoPilot.Application/Features/Plans/UpdatePlanName/UpdatePlanNameCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/UpdatePlanName/UpdatePlanNameCommandHandler.cs
@@ -1,0 +1,43 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.UpdatePlanName;
+
+public sealed class UpdatePlanNameCommandHandler : IRequestHandler<UpdatePlanNameCommand, Result<Guid>>
+{
+    private readonly ILoadingPlanRepository _planRepository;
+    private readonly IValidator<UpdatePlanNameCommand> _validator;
+
+    public UpdatePlanNameCommandHandler(
+        ILoadingPlanRepository planRepository,
+        IValidator<UpdatePlanNameCommand> validator)
+    {
+        _planRepository = planRepository;
+        _validator = validator;
+    }
+
+    public async Task<Result<Guid>> Handle(UpdatePlanNameCommand request, CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var plan = await _planRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (plan is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "Plan.NotFound", "Yükleme planı bulunamadı."));
+
+        plan.UpdatePlanName(request.PlanName);
+        await _planRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<Guid>.Success(plan.Id);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/UpdatePlanName/UpdatePlanNameCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/UpdatePlanName/UpdatePlanNameCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Plans.UpdatePlanName;
+
+public sealed class UpdatePlanNameCommandValidator : AbstractValidator<UpdatePlanNameCommand>
+{
+    public UpdatePlanNameCommandValidator()
+    {
+        RuleFor(x => x.PlanName)
+            .NotEmpty().WithMessage("Plan adı boş olamaz.")
+            .MaximumLength(100).WithMessage("Plan adı en fazla 100 karakter olabilir.");
+    }
+}

--- a/apps/backend/CargoPilot.Domain/Entities/LoadingPlan.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/LoadingPlan.cs
@@ -28,6 +28,8 @@ public sealed class LoadingPlan : BaseEntity {
 
     private LoadingPlan() { }
 
+    public void UpdatePlanName(string planName) => PlanName = planName;
+
     public LoadingPlan(
         Guid id,
         string planName,

--- a/apps/backend/CargoPilot.Domain/Entities/LoadingPlanInputItem.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/LoadingPlanInputItem.cs
@@ -1,0 +1,22 @@
+namespace CargoPilot.Domain.Entities;
+
+public sealed class LoadingPlanInputItem : BaseEntity
+{
+#pragma warning disable S1144
+    public Guid LoadingPlanId { get; private set; }
+    public Guid ItemId { get; private set; }
+    public int Quantity { get; private set; }
+#pragma warning restore S1144
+
+    public LoadingPlan LoadingPlan { get; private set; } = null!;
+    public Item Item { get; private set; } = null!;
+
+    private LoadingPlanInputItem() { }
+
+    public LoadingPlanInputItem(Guid id, Guid loadingPlanId, Guid itemId, int quantity) : base(id)
+    {
+        LoadingPlanId = loadingPlanId;
+        ItemId = itemId;
+        Quantity = quantity;
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
+++ b/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
@@ -56,6 +56,7 @@ public static class DependencyInjection {
         services.AddScoped<IVehicleRepository, VehicleRepository>();
         services.AddScoped<IUserVehicleFavoriteRepository, UserVehicleFavoriteRepository>();
         services.AddScoped<ILoadingPlanRepository, LoadingPlanRepository>();
+        services.AddScoped<IOptimizationEngine, NoOpOptimizationEngine>();
         services.AddScoped<IPasswordResetTokenRepository, PasswordResetTokenRepository>();
         services.AddScoped<IUserPasswordHistoryRepository, UserPasswordHistoryRepository>();
         services.AddHttpClient<IEmailService, ResendEmailService>(client =>

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContext.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContext.cs
@@ -23,6 +23,7 @@ public class AppDbContext : DbContext {
     public DbSet<Vehicle> Vehicles => Set<Vehicle>();
     public DbSet<UserVehicleFavorite> UserVehicleFavorites => Set<UserVehicleFavorite>();
     public DbSet<LoadingPlan> LoadingPlans => Set<LoadingPlan>();
+    public DbSet<LoadingPlanInputItem> LoadingPlanInputItems => Set<LoadingPlanInputItem>();
     public DbSet<LoadingPlanPlacement> LoadingPlanPlacements => Set<LoadingPlanPlacement>();
     public DbSet<LoadingPlanUnplacedItem> LoadingPlanUnplacedItems => Set<LoadingPlanUnplacedItem>();
     public DbSet<LoadingPlanWarning> LoadingPlanWarnings => Set<LoadingPlanWarning>();
@@ -48,6 +49,7 @@ public class AppDbContext : DbContext {
         modelBuilder.ApplyConfiguration(new VehicleConfiguration());
         modelBuilder.ApplyConfiguration(new UserVehicleFavoriteConfiguration());
         modelBuilder.ApplyConfiguration(new LoadingPlanConfiguration());
+        modelBuilder.ApplyConfiguration(new LoadingPlanInputItemConfiguration());
         modelBuilder.ApplyConfiguration(new LoadingPlanPlacementConfiguration());
         modelBuilder.ApplyConfiguration(new LoadingPlanUnplacedItemConfiguration());
         modelBuilder.ApplyConfiguration(new LoadingPlanWarningConfiguration());

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/LoadingPlanInputItemConfiguration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/LoadingPlanInputItemConfiguration.cs
@@ -1,0 +1,49 @@
+using CargoPilot.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CargoPilot.Infrastructure.Persistence.Configurations;
+
+internal sealed class LoadingPlanInputItemConfiguration : IEntityTypeConfiguration<LoadingPlanInputItem>
+{
+    public void Configure(EntityTypeBuilder<LoadingPlanInputItem> builder)
+    {
+        builder.ToTable("LoadingPlanInputItems", tableBuilder =>
+            tableBuilder.HasCheckConstraint(
+                "CK_LoadingPlanInputItems_Quantity_Positive",
+                "[Quantity] > 0"));
+
+        builder.HasKey(i => i.Id);
+
+        builder.Property(i => i.CreatedAtUtc).IsRequired().HasDefaultValueSql("GETUTCDATE()");
+        builder.Property(i => i.CreatedBy);
+        builder.Property(i => i.UpdatedAtUtc);
+        builder.Property(i => i.UpdatedBy);
+        builder.Property(i => i.DeletedAtUtc);
+
+        builder.Property(i => i.IsDeleted).IsRequired().HasDefaultValue(false);
+        builder.Property(i => i.IsActive).IsRequired().HasDefaultValue(true);
+
+        builder.Property(i => i.LoadingPlanId).IsRequired();
+        builder.Property(i => i.ItemId).IsRequired();
+        builder.Property(i => i.Quantity).IsRequired();
+
+        builder.HasOne(i => i.LoadingPlan)
+            .WithMany()
+            .HasForeignKey(i => i.LoadingPlanId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(i => i.Item)
+            .WithMany()
+            .HasForeignKey(i => i.ItemId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(i => i.LoadingPlanId)
+            .HasDatabaseName("IX_LoadingPlanInputItems_LoadingPlanId");
+
+        builder.HasIndex(i => i.IsDeleted)
+            .HasDatabaseName("IX_LoadingPlanInputItems_IsDeleted");
+
+        builder.HasQueryFilter(i => !i.IsDeleted);
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260505175253_AddLoadingPlanInputItemsTable.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260505175253_AddLoadingPlanInputItemsTable.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505175253_AddLoadingPlanInputItemsTable")]
+    partial class AddLoadingPlanInputItemsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260505175253_AddLoadingPlanInputItemsTable.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260505175253_AddLoadingPlanInputItemsTable.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLoadingPlanInputItemsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LoadingPlanInputItems",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    LoadingPlanId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ItemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Quantity = table.Column<int>(type: "int", nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    DeletedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false, defaultValue: true),
+                    CreatedBy = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LoadingPlanInputItems", x => x.Id);
+                    table.CheckConstraint("CK_LoadingPlanInputItems_Quantity_Positive", "[Quantity] > 0");
+                    table.ForeignKey(
+                        name: "FK_LoadingPlanInputItems_Items_ItemId",
+                        column: x => x.ItemId,
+                        principalTable: "Items",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_LoadingPlanInputItems_LoadingPlans_LoadingPlanId",
+                        column: x => x.LoadingPlanId,
+                        principalTable: "LoadingPlans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LoadingPlanInputItems_IsDeleted",
+                table: "LoadingPlanInputItems",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LoadingPlanInputItems_ItemId",
+                table: "LoadingPlanInputItems",
+                column: "ItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LoadingPlanInputItems_LoadingPlanId",
+                table: "LoadingPlanInputItems",
+                column: "LoadingPlanId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LoadingPlanInputItems");
+        }
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/ItemRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/ItemRepository.cs
@@ -20,6 +20,18 @@ internal sealed class ItemRepository : IItemRepository
             .FirstOrDefaultAsync(i => i.Id == id, cancellationToken);
     }
 
+    public async Task<IReadOnlyList<Guid>> GetExistingIdsAsync(
+        IEnumerable<Guid> ids,
+        CancellationToken cancellationToken = default)
+    {
+        var idList = ids.ToList();
+        return await _dbContext.Items
+            .AsNoTracking()
+            .Where(i => idList.Contains(i.Id))
+            .Select(i => i.Id)
+            .ToListAsync(cancellationToken);
+    }
+
     public Task<bool> ExistsBySkuAsync(string sku, CancellationToken cancellationToken = default)
     {
         return _dbContext.Items

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
@@ -171,6 +171,9 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
 
     public void Add(LoadingPlan plan) => _context.LoadingPlans.Add(plan);
 
+    public void AddInputItems(IEnumerable<LoadingPlanInputItem> items) =>
+        _context.LoadingPlanInputItems.AddRange(items);
+
     public Task SaveChangesAsync(CancellationToken cancellationToken = default)
         => _context.SaveChangesAsync(cancellationToken);
 

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
@@ -165,6 +165,15 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
             warningDtos);
     }
 
+    public async Task<LoadingPlan?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+        => await _context.LoadingPlans
+            .FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+
+    public void Add(LoadingPlan plan) => _context.LoadingPlans.Add(plan);
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken = default)
+        => _context.SaveChangesAsync(cancellationToken);
+
     private static ItemInPlanDto ToItemInPlanDto(Item item) =>
         new(item.Id, item.SKU, item.Name, item.Width, item.Height, item.Length, item.Weight, item.ImageUrl);
 }

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
@@ -95,14 +95,21 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
             .Where(w => w.LoadingPlanId == id)
             .ToListAsync(cancellationToken);
 
-        return MapToDetailDto(plan, placements, unplacedItems, warnings);
+        var inputItems = await _context.LoadingPlanInputItems
+            .AsNoTracking()
+            .Include(i => i.Item)
+            .Where(i => i.LoadingPlanId == id)
+            .ToListAsync(cancellationToken);
+
+        return MapToDetailDto(plan, placements, unplacedItems, warnings, inputItems);
     }
 
     private static PlanDetailDto MapToDetailDto(
         LoadingPlan plan,
         List<LoadingPlanPlacement> placements,
         List<LoadingPlanUnplacedItem> unplacedItems,
-        List<LoadingPlanWarning> warnings)
+        List<LoadingPlanWarning> warnings,
+        List<LoadingPlanInputItem> inputItems)
     {
         var vehicleDto = new VehicleInPlanDto(
             plan.Vehicle.Id,
@@ -143,6 +150,14 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
                 w.RelatedPlacementId))
             .ToList();
 
+        var inputItemDtos = inputItems
+            .Select(i => new InputItemDto(
+                i.Id,
+                i.ItemId,
+                i.Quantity,
+                ToItemInPlanDto(i.Item)))
+            .ToList();
+
         return new PlanDetailDto(
             plan.Id,
             plan.PlanName,
@@ -162,7 +177,8 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
             vehicleDto,
             placementDtos,
             unplacedItemDtos,
-            warningDtos);
+            warningDtos,
+            inputItemDtos);
     }
 
     public async Task<LoadingPlan?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)

--- a/apps/backend/CargoPilot.Infrastructure/Services/NoOpOptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/NoOpOptimizationEngine.cs
@@ -1,0 +1,9 @@
+using CargoPilot.Application.Common.Interfaces;
+
+namespace CargoPilot.Infrastructure.Services;
+
+internal sealed class NoOpOptimizationEngine : IOptimizationEngine
+{
+    public Task RunOptimizationAsync(Guid planId, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
@@ -1,5 +1,8 @@
+using CargoPilot.Application.Features.Plans.CreatePlan;
+using CargoPilot.Application.Features.Plans.DeletePlan;
 using CargoPilot.Application.Features.Plans.GetPlanById;
 using CargoPilot.Application.Features.Plans.GetPlans;
+using CargoPilot.Application.Features.Plans.UpdatePlanName;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -65,4 +68,70 @@ public sealed class PlansController : BaseController
         var result = await _mediator.Send(new GetPlanByIdQuery(id), cancellationToken);
         return HandleResult(result);
     }
+
+    /// <summary>
+    /// Yeni bir yükleme planı oluşturur ve optimizasyon motorunu tetikler.
+    /// </summary>
+    /// <param name="command">Plan adı, araç ID'si ve item listesi.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="201">Plan oluşturuldu; yeni planın ID'si döner.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    /// <response code="404">Araç bulunamadı.</response>
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CreatePlan(
+        [FromBody] CreatePlanCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _mediator.Send(command, cancellationToken);
+        if (!result.IsSuccess) return HandleResult(result);
+        return CreatedAtAction(nameof(GetById), new { id = result.Data }, result);
+    }
+
+    /// <summary>
+    /// Yükleme planının adını günceller.
+    /// </summary>
+    /// <param name="id">Güncellenecek planın ID'si.</param>
+    /// <param name="request">Yeni plan adı.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Plan adı güncellendi.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    /// <response code="404">Plan bulunamadı.</response>
+    [HttpPatch("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdatePlanName(
+        [FromRoute] Guid id,
+        [FromBody] UpdatePlanNameRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _mediator.Send(new UpdatePlanNameCommand(id, request.PlanName), cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Yükleme planını soft-delete ile siler.
+    /// </summary>
+    /// <param name="id">Silinecek planın ID'si.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Plan silindi.</response>
+    /// <response code="404">Plan bulunamadı.</response>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeletePlan(
+        [FromRoute] Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _mediator.Send(new DeletePlanCommand(id), cancellationToken);
+        return HandleResult(result);
+    }
 }
+
+/// <summary>
+/// PATCH /api/v1/loading-plans/{id} için request body.
+/// </summary>
+public sealed record UpdatePlanNameRequest(string PlanName);

--- a/apps/backend/docs/user-story-tracker.md
+++ b/apps/backend/docs/user-story-tracker.md
@@ -311,7 +311,7 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 - `CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs`
 - `CargoPilot.Infrastructure/DependencyInjection.cs`
 - `CargoPilot.WebAPI/Controllers/PlansController.cs`
-## 12) US-AUTH-12: Yeni Cihaz Girisi Bildirimi
+## 13) US-AUTH-12: Yeni Cihaz Girisi Bildirimi
 **Story:** Backend Chapter Lead olarak, kullanicinin hesabina daha once giris yapilmamis bir cihazdan/tarayicidan erisim saglandiginda e-posta bildirimi gonderilmesini ve kullanicinin tek tikla tum oturumlarini sonlandirip sifre sifirlama akisina yonlendirilmesini isterim.
 
 **Genel Durum:** `✅ Tamamlandi`
@@ -347,3 +347,41 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 - `CargoPilot.WebAPI/Controllers/AuthController.cs`
 - `CargoPilot.WebAPI/appsettings.json`
 - `CargoPilot.WebAPI/appsettings.Development.json`
+
+---
+
+## 14) Loading Plan CRUD Endpoint'leri (Oluştur / İsim Güncelle / Sil)
+**Story:** Backend geliştirici olarak, yükleme planı oluşturabilmek, plan adını güncelleyebilmek ve planı soft-delete ile silebilmek için CRUD endpoint'lerinin hazır olmasını isterim.
+
+**Genel Durum:** `✅ Tamamlandi`
+
+### Alt İşler
+- `✅` `IOptimizationEngine` interface'ini tanımla (`CargoPilot.Application/Common/Interfaces/IOptimizationEngine.cs`)
+- `✅` `NoOpOptimizationEngine` mock implementasyonu yaz (`CargoPilot.Infrastructure/Services/NoOpOptimizationEngine.cs`)
+- `✅` `IOptimizationEngine` DI kaydı eklendi (`DependencyInjection.cs`)
+- `✅` `CreatePlanItemRequest` record tanımla (ItemId, Quantity)
+- `✅` `CreatePlanCommand` tanımla (PlanName, VehicleId, Items, OptimizationCriteria)
+- `✅` `CreatePlanCommandValidator` yaz (PlanName max 100, VehicleId NotEmpty, Items NotEmpty, her item Quantity > 0)
+- `✅` `CreatePlanCommandHandler` yaz (Vehicle 404 kontrolü, inputTotalQuantity hesabı, LoadingPlan oluştur, Add + SaveChanges + RunOptimizationAsync)
+- `✅` `UpdatePlanNameCommand` tanımla (Id, PlanName)
+- `✅` `UpdatePlanNameCommandValidator` yaz (PlanName max 100)
+- `✅` `UpdatePlanNameCommandHandler` yaz (GetByIdAsync 404 kontrolü, plan.UpdatePlanName, SaveChanges)
+- `✅` `LoadingPlan.UpdatePlanName(string)` domain metodu eklendi (`private set` koruması için)
+- `✅` `DeletePlanCommand` tanımla (Id)
+- `✅` `DeletePlanCommandHandler` yaz (GetByIdAsync 404 kontrolü, plan.MarkAsDeleted, SaveChanges)
+- `✅` `ILoadingPlanRepository` genişletildi (GetByIdAsync, Add, SaveChangesAsync)
+- `✅` `LoadingPlanRepository` implementasyonları eklendi (GetByIdAsync tracking olmadan, Add, SaveChangesAsync)
+- `✅` `PlansController` güncellendi — POST 201, PATCH 200, DELETE 200; XML summary'ler eklendi
+- `✅` Build: 0 hata doğrulandı; uygulama `http://localhost:8081` adresinde hatasız ayağa kalktı
+
+### Kanıtlar
+- `CargoPilot.Application/Common/Interfaces/IOptimizationEngine.cs`
+- `CargoPilot.Application/Features/Plans/CreatePlan/` (Command, ItemRequest, Validator, Handler)
+- `CargoPilot.Application/Features/Plans/UpdatePlanName/` (Command, Validator, Handler)
+- `CargoPilot.Application/Features/Plans/DeletePlan/` (Command, Handler)
+- `CargoPilot.Application/Common/Interfaces/ILoadingPlanRepository.cs`
+- `CargoPilot.Infrastructure/Services/NoOpOptimizationEngine.cs`
+- `CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs`
+- `CargoPilot.Infrastructure/DependencyInjection.cs`
+- `CargoPilot.Domain/Entities/LoadingPlan.cs`
+- `CargoPilot.WebAPI/Controllers/PlansController.cs`


### PR DESCRIPTION
Özet
Bu PR, Cargo Pilot projesi için Yükleme Planı (Loading Plan) modülünün temel CRUD operasyonlarını (Create, Update, Delete) sisteme ekler.

POST: Yeni plan oluşturur, veritabanına kaydeder ve optimizasyon motorunu senkron olarak tetikler.

PATCH: Var olan bir planın sadece adını (PlanName) güvenli bir şekilde günceller.

DELETE: Veri kaybını önlemek amacıyla fiziksel silme yerine Soft-Delete (IsDeleted = true, DeletedAtUtc) desenini uygular.

İlgili User Story / Issue
Yükleme Planı CRUD Operasyonlarının Geliştirilmesi

Değişiklik Tipi
[x] 🚀 Yeni özellik (feature)

[ ] 🐛 Bug düzeltme (bugfix)

Test Edildi mi?
[x] Manuel test yapıldı

Kontrol Listesi
[x] Kod standartlarına uygun

[x] Commit mesajları [commit kurallarına](https://www.google.com/search?q=docs/conventions/COMMITS.md) uygun

[x] Linter hataları yok

[x] Self-review yapıldı

[x] Dokümantasyon güncellendi (gerekiyorsa)


