### PR TITLE
logout endpoint eklendi — refresh token cookie iptal edilerek oturum kapatılır

### DIFF
--- a/apps/backend/CargoPilot.Application/Features/Auth/IAuthService.cs
+++ b/apps/backend/CargoPilot.Application/Features/Auth/IAuthService.cs
@@ -59,4 +59,12 @@ public interface IAuthService
         string email,
         string token,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gelen refresh token'a ait oturumu iptal eder.
+    /// Token bulunamazsa veya zaten iptal edilmişse yine başarı döner (idempotent).
+    /// </summary>
+    Task<Result<bool>> LogoutAsync(
+        string refreshToken,
+        CancellationToken cancellationToken = default);
 }

--- a/apps/backend/CargoPilot.Infrastructure/Auth/AuthService.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Auth/AuthService.cs
@@ -283,8 +283,24 @@ internal sealed class AuthService : IAuthService
             .Include(s => s.User)
             .FirstOrDefaultAsync(s => s.Token == refreshToken, cancellationToken);
 
-        if (session is null || session.IsRevoked || session.ExpiresAt <= DateTime.UtcNow)
+        if (session is null || session.User is null)
             return Result<RefreshResponse>.Failure(AuthErrors.InvalidToken);
+
+        // Revoke edilmiş token tekrar sunuluyorsa token çalınmış olabilir — tüm sessionları kapat.
+        if (session.IsRevoked)
+        {
+            var activeSessions = await _context.UserSessions
+                .Where(s => s.UserId == session.UserId && !s.IsRevoked)
+                .ToListAsync(cancellationToken);
+            foreach (var s in activeSessions)
+                s.Revoke();
+            await _context.SaveChangesAsync(cancellationToken);
+            return Result<RefreshResponse>.Failure(AuthErrors.InvalidToken);
+        }
+
+        if (session.ExpiresAt <= DateTime.UtcNow)
+            return Result<RefreshResponse>.Failure(AuthErrors.InvalidToken);
+
 
         session.Revoke();
 

--- a/apps/backend/CargoPilot.Infrastructure/Auth/AuthService.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Auth/AuthService.cs
@@ -299,7 +299,8 @@ internal sealed class AuthService : IAuthService
             token: newRefreshToken,
             expiresAt: sessionExpiry,
             lastUsedAt: now,
-            createdByIp: ipAddress);
+            createdByIp: ipAddress,
+            deviceSummary: session.DeviceSummary);
 
         _context.UserSessions.Add(newSession);
         await _context.SaveChangesAsync(cancellationToken);

--- a/apps/backend/CargoPilot.Infrastructure/Auth/AuthService.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Auth/AuthService.cs
@@ -399,6 +399,22 @@ internal sealed class AuthService : IAuthService
         return Result<bool>.Success(true);
     }
 
+    public async Task<Result<bool>> LogoutAsync(
+        string refreshToken,
+        CancellationToken cancellationToken = default)
+    {
+        var session = await _context.UserSessions
+            .FirstOrDefaultAsync(s => s.Token == refreshToken, cancellationToken);
+
+        if (session is null || session.IsRevoked)
+            return Result<bool>.Success(true);
+
+        session.Revoke();
+        await _context.SaveChangesAsync(cancellationToken);
+
+        return Result<bool>.Success(true);
+    }
+
     public async Task<Result<string>> SecureAccountAsync(
         string email,
         string token,

--- a/apps/backend/CargoPilot.WebAPI/Controllers/AuthController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/AuthController.cs
@@ -135,11 +135,14 @@ public sealed class AuthController : BaseController
     [HttpPost("logout")]
     [Authorize]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> Logout(CancellationToken cancellationToken)
     {
         var refreshToken = Request.Cookies["refreshToken"];
-        if (!string.IsNullOrWhiteSpace(refreshToken))
-            await _authService.LogoutAsync(refreshToken, cancellationToken);
+        if (string.IsNullOrWhiteSpace(refreshToken))
+            return Unauthorized();
+
+        await _authService.LogoutAsync(refreshToken, cancellationToken);
 
         Response.Cookies.Delete("refreshToken", new CookieOptions
         {

--- a/apps/backend/CargoPilot.WebAPI/Controllers/AuthController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/AuthController.cs
@@ -132,6 +132,26 @@ public sealed class AuthController : BaseController
         return HandleResult(result);
     }
 
+    [HttpPost("logout")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> Logout(CancellationToken cancellationToken)
+    {
+        var refreshToken = Request.Cookies["refreshToken"];
+        if (!string.IsNullOrWhiteSpace(refreshToken))
+            await _authService.LogoutAsync(refreshToken, cancellationToken);
+
+        Response.Cookies.Delete("refreshToken", new CookieOptions
+        {
+            Path = "/api/v1/auth",
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.None,
+        });
+
+        return Ok();
+    }
+
     [HttpPost("request-password-reset")]
     [AllowAnonymous]
     [EnableRateLimiting("password-reset")]


### PR DESCRIPTION
## Özet

`POST /api/v1/auth/logout` endpoint'i eklendi. İstek geldiğinde `refreshToken` cookie'sindeki
session DB'de revoke edilir (`IsRevoked = 1`), cookie temizlenir ve `200 OK` döner.
Cookie gelmezse `401` döner — sessiz başarı kaldırıldı.

Refresh token güvenliği de güçlendirildi: zaten revoke edilmiş bir token tekrar sunulursa
token çalınmış kabul edilip kullanıcının tüm aktif sessionları iptal edilir (reuse detection).

## İlgili User Story / Issue

İlgili user story yok

## Değişiklik Tipi

- [x] 🚀 Yeni özellik (feature)
- [x] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x] Manuel test yapıldı

curl ile aşağıdaki akış doğrulandı:
1. Login → `refreshToken` cookie alındı
2. Logout → session `IsRevoked = 1` oldu, cookie temizlendi
3. Refresh → `401` döndü ✅
4. Revoke edilmiş token tekrar sunuldu → tüm sessionlar iptal edildi ✅

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

- `refreshToken` cookie `Path = "/api/v1/auth"` ile set edildiğinden silme işleminde
  aynı path kullanılması zorunludur, aksi hâlde tarayıcı cookie'yi silmez.
- Swagger cookie'leri otomatik göndermez; test için curl + cookie jar (`-c`/`-b`) kullanılmalıdır.
- Access token (JWT) server-side iptal edilemez; kısa ömürlü olduğu için bu beklenen davranıştır.
