### PR TITLE
Feature/us vy 23 vehicle delete endpoint

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Interfaces/IVehicleRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/IVehicleRepository.cs
@@ -21,6 +21,8 @@ public interface IVehicleRepository {
 
     Task<bool> ExistsByPlateNumberAsync(string plateNumber, Guid? companyId, Guid excludeId, CancellationToken cancellationToken = default);
 
+    Task<bool> IsUsedInActiveLoadingPlanAsync(Guid vehicleId, CancellationToken cancellationToken = default);
+
     void Add(Vehicle vehicle);
 
     Task SaveChangesAsync(CancellationToken cancellationToken = default);

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/DeleteVehicle/DeleteVehicleCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/DeleteVehicle/DeleteVehicleCommand.cs
@@ -1,0 +1,6 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Vehicles.DeleteVehicle;
+
+public sealed record DeleteVehicleCommand(Guid Id) : IRequest<Result<Guid>>;

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/DeleteVehicle/DeleteVehicleCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/DeleteVehicle/DeleteVehicleCommandHandler.cs
@@ -1,0 +1,38 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Vehicles.DeleteVehicle;
+
+public sealed class DeleteVehicleCommandHandler : IRequestHandler<DeleteVehicleCommand, Result<Guid>>
+{
+    private readonly IVehicleRepository _vehicleRepository;
+
+    public DeleteVehicleCommandHandler(IVehicleRepository vehicleRepository)
+    {
+        _vehicleRepository = vehicleRepository;
+    }
+
+    public async Task<Result<Guid>> Handle(DeleteVehicleCommand request, CancellationToken cancellationToken)
+    {
+        var vehicle = await _vehicleRepository.GetByIdAsync(request.Id, cancellationToken);
+        if (vehicle is null)
+        {
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "Vehicle.NotFound", "Araç bulunamadı."));
+        }
+
+        var isUsedInActivePlan = await _vehicleRepository.IsUsedInActiveLoadingPlanAsync(request.Id, cancellationToken);
+        if (isUsedInActivePlan)
+        {
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Conflict, "Vehicle.UsedInActiveLoadingPlan",
+                    "Bu araç aktif bir yükleme planında kullanıldığı için arşivlenemez."));
+        }
+
+        vehicle.MarkAsDeleted();
+        await _vehicleRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<Guid>.Success(vehicle.Id);
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/VehicleRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/VehicleRepository.cs
@@ -74,7 +74,7 @@ internal sealed class VehicleRepository : IVehicleRepository {
 
     public async Task<bool> IsUsedInActiveLoadingPlanAsync(Guid vehicleId, CancellationToken cancellationToken = default) {
         return await _context.LoadingPlans
-            .AnyAsync(p => p.VehicleId == vehicleId && !p.IsDeleted, cancellationToken);
+            .AnyAsync(p => p.VehicleId == vehicleId && p.OptimizationStatus == LoadingPlanOptimizationStatus.Draft, cancellationToken);
     }
 
     public void Add(Vehicle vehicle) {

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/VehicleRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/VehicleRepository.cs
@@ -72,6 +72,11 @@ internal sealed class VehicleRepository : IVehicleRepository {
             .AnyAsync(v => v.PlateNumber == plateNumber && v.CompanyId == companyId && v.Id != excludeId, cancellationToken);
     }
 
+    public async Task<bool> IsUsedInActiveLoadingPlanAsync(Guid vehicleId, CancellationToken cancellationToken = default) {
+        return await _context.LoadingPlans
+            .AnyAsync(p => p.VehicleId == vehicleId && !p.IsDeleted, cancellationToken);
+    }
+
     public void Add(Vehicle vehicle) {
         _context.Vehicles.Add(vehicle);
     }

--- a/apps/backend/CargoPilot.WebAPI/Controllers/VehiclesController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/VehiclesController.cs
@@ -1,5 +1,6 @@
 using CargoPilot.Application.Features.Vehicles.AddVehicleFavorite;
 using CargoPilot.Application.Features.Vehicles.CreateVehicle;
+using CargoPilot.Application.Features.Vehicles.DeleteVehicle;
 using CargoPilot.Application.Features.Vehicles.DuplicateVehicle;
 using CargoPilot.Application.Features.Vehicles.RemoveVehicleFavorite;
 using CargoPilot.Application.Features.Vehicles.SearchVehicles;
@@ -143,6 +144,26 @@ public sealed class VehiclesController : BaseController {
             request.AdditionalAxleDistanceMm,
             request.AdditionalAxleTareWeightKg,
             request.AdditionalAxleMaxLoadKg);
+        var result = await _mediator.Send(command, cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Bir aracı arşivler (soft delete). Aktif yükleme planında kullanılan araç arşivlenemez.
+    /// </summary>
+    /// <param name="id">Arşivlenecek araç ID'si.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Araç arşivlendi; ID döner.</response>
+    /// <response code="404">Araç bulunamadı.</response>
+    /// <response code="409">Araç aktif bir yükleme planında kullanılıyor.</response>
+    [HttpDelete("{id:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Delete(
+        [FromRoute] Guid id,
+        CancellationToken cancellationToken = default) {
+        var command = new DeleteVehicleCommand(id);
         var result = await _mediator.Send(command, cancellationToken);
         return HandleResult(result);
     }


### PR DESCRIPTION
## Özet

DeleteVehicleCommand ve handler eklendi
Aktif yükleme planında kullanılan araç için 409 Conflict engeli
IVehicleRepository'e IsUsedInActiveLoadingPlanAsync eklendi
VehicleRepository'e implementasyon eklendi
DELETE /api/v1/vehicles/{id} endpoint'i eklendi
!p.IsDeleted kaldırıldı (global query filter zaten hallediyor)
p.OptimizationStatus == LoadingPlanOptimizationStatus.Draft eklendi.Artık yalnızca Draft planlar engel teşkil eder; Calculated veya Failed durumundaki planlar arşivlemeyi bloklamaz.

## İlgili User Story / Issue

us vy 23 vehicle delete endpoint

## Değişiklik Tipi

- [ x] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x ] Manuel test yapıldı

## Kontrol Listesi

- [x ] Kod standartlarına uygun
- [ x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ x] Linter hataları yok
- [x ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
