### PR TITLE
fix: MCR rate limit koruması - base imagellar GHCR mirror üzerinden çekiliyor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,9 @@ jobs:
     name: Docker Image Build
     runs-on: ubuntu-latest
     needs: [frontend-ci, backend-ci]
+    permissions:
+      contents: read
+      packages: read
     if: |
       (github.event_name == 'pull_request' && github.base_ref == 'test') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/feature/')) ||
@@ -100,11 +103,22 @@ jobs:
       - name: Kodu al
         uses: actions/checkout@v4
 
+      - name: GHCR'a giriş yap
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Backend Docker image build
         run: |
           for attempt in 1 2 3; do
             echo "==> Backend build, deneme $attempt/3"
-            if docker build -t cargo-pilot-backend:ci ./apps/backend/; then
+            if docker build \
+              --build-arg DOTNET_SDK_IMAGE=ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0 \
+              --build-arg DOTNET_ASPNET_IMAGE=ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0 \
+              -t cargo-pilot-backend:ci \
+              ./apps/backend/; then
               echo "Build başarılı"; break
             fi
             [ $attempt -lt 3 ] && { echo "Başarısız, 20s bekleniyor..."; sleep 20; } \

--- a/.github/workflows/sync-base-images.yml
+++ b/.github/workflows/sync-base-images.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 2 * * 0'
   workflow_dispatch:
+  push:
+    branches:
+      - bugfix/INC-003-mcr-rate-limit-fix
 
 jobs:
   sync:

--- a/.github/workflows/sync-base-images.yml
+++ b/.github/workflows/sync-base-images.yml
@@ -1,0 +1,38 @@
+name: Base Image Sync
+
+# .NET base imagellarını MCR'dan çekip GHCR'a yansıtır.
+# Böylece MCR rate limit veya erişim sorunları build pipeline'ını etkilemez.
+# Tetikleyiciler:
+#   schedule → Her Pazar 02:00 UTC (haftalık yenileme)
+#   workflow_dispatch → Manuel tetikleme (ilk kurulum veya acil güncelleme için)
+on:
+  schedule:
+    - cron: '0 2 * * 0'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    name: .NET Image Sync (MCR → GHCR)
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: GHCR'a giriş yap
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: .NET SDK 8.0 imajını senkronize et
+        run: |
+          docker pull mcr.microsoft.com/dotnet/sdk:8.0
+          docker tag mcr.microsoft.com/dotnet/sdk:8.0 ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0
+          docker push ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0
+
+      - name: .NET ASP.NET 8.0 imajını senkronize et
+        run: |
+          docker pull mcr.microsoft.com/dotnet/aspnet:8.0
+          docker tag mcr.microsoft.com/dotnet/aspnet:8.0 ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0
+          docker push ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -154,23 +154,13 @@ jobs:
       - name: Docker Buildx kur
         uses: docker/setup-buildx-action@v3
 
-      # Sadece test branch'e push'ta GHCR'a login olunur (PR'larda push yapılmaz)
+      # Base image pull için de GHCR auth gerekli; GITHUB_TOKEN her trigger'da geçerli
       - name: GHCR'a giriş yap
-        if: github.event_name == 'push' && github.ref == 'refs/heads/test'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: .NET base image önceden çek (MCR rate limit koruması)
-        run: |
-          for i in 1 2 3; do
-            docker pull mcr.microsoft.com/dotnet/sdk:8.0 && \
-            docker pull mcr.microsoft.com/dotnet/aspnet:8.0 && break
-            echo "Deneme $i başarısız, 15s bekleniyor..."
-            sleep 15
-          done
 
       # push: PR'larda false, test branch push'ta true
       - name: Backend image build ve GHCR push
@@ -180,6 +170,9 @@ jobs:
           file: ./apps/backend/Dockerfile
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/test' }}
           tags: ghcr.io/divizyon/cargo-pilot-backend:test
+          build-args: |
+            DOTNET_SDK_IMAGE=ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0
+            DOTNET_ASPNET_IMAGE=ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0
           cache-from: type=gha,scope=backend-test
           cache-to: type=gha,mode=max,scope=backend-test
 
@@ -198,6 +191,9 @@ jobs:
     name: Deploy (Test)
     runs-on: ubuntu-latest
     needs: [enforce-test-base, migration-check]
+    permissions:
+      contents: read
+      packages: read
     if: |
       always() &&
       (needs.enforce-test-base.result == 'success' || needs.enforce-test-base.result == 'skipped') &&
@@ -237,17 +233,16 @@ jobs:
       - name: Docker Buildx kur
         uses: docker/setup-buildx-action@v3
 
+      # Base image pull için GHCR auth; GITHUB_TOKEN her trigger'da geçerli
+      - name: GHCR'a giriş yap
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Deploy kendi image'larını inline build eder; build job ile aynı GHA cache
       # scope'u kullanıldığı için, build job da koştuysa ikinci build cache'ten döner.
-      - name: .NET base image önceden çek (MCR rate limit koruması)
-        run: |
-          for i in 1 2 3; do
-            docker pull mcr.microsoft.com/dotnet/sdk:8.0 && \
-            docker pull mcr.microsoft.com/dotnet/aspnet:8.0 && break
-            echo "Deneme $i başarısız, 15s bekleniyor..."
-            sleep 15
-          done
-
       # Tag'ler docker-compose.test.yml'deki image: alanlarıyla eşleşmeli.
       # load: true → image'ı local Docker daemon'a yükle (no push)
       - name: Backend image build (deploy için)
@@ -258,6 +253,9 @@ jobs:
           push: false
           load: true
           tags: ghcr.io/divizyon/cargo-pilot-backend:test
+          build-args: |
+            DOTNET_SDK_IMAGE=ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0
+            DOTNET_ASPNET_IMAGE=ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0
           cache-from: type=gha,scope=backend-test
           cache-to: type=gha,mode=max,scope=backend-test
 

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG DOTNET_SDK_IMAGE=mcr.microsoft.com/dotnet/sdk:8.0
+FROM ${DOTNET_SDK_IMAGE} AS build
 WORKDIR /src
 
 # Copy full backend tree so solution/csproj discovery works for monorepo layouts.
@@ -18,7 +19,8 @@ RUN set -e; \
     dotnet publish "$project" -c Release -o /app/publish /p:UseAppHost=false; \
     basename "$project" .csproj > /app/publish/.entry-dll
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+ARG DOTNET_ASPNET_IMAGE=mcr.microsoft.com/dotnet/aspnet:8.0
+FROM ${DOTNET_ASPNET_IMAGE} AS final
 WORKDIR /app
 
 # Health check için curl (aspnet:8.0 Debian Bookworm tabanlı, curl yüklü değil)

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,4 +1,5 @@
 ARG DOTNET_SDK_IMAGE=mcr.microsoft.com/dotnet/sdk:8.0
+ARG DOTNET_ASPNET_IMAGE=mcr.microsoft.com/dotnet/aspnet:8.0
 FROM ${DOTNET_SDK_IMAGE} AS build
 WORKDIR /src
 
@@ -19,7 +20,6 @@ RUN set -e; \
     dotnet publish "$project" -c Release -o /app/publish /p:UseAppHost=false; \
     basename "$project" .csproj > /app/publish/.entry-dll
 
-ARG DOTNET_ASPNET_IMAGE=mcr.microsoft.com/dotnet/aspnet:8.0
 FROM ${DOTNET_ASPNET_IMAGE} AS final
 WORKDIR /app
 


### PR DESCRIPTION
## Özet
- Backend `Dockerfile`'a `ARG` desteği eklendi: CI'da GHCR mirror kullanılır, lokal build MCR'ı korur
- `test-deploy.yml` ve `ci.yml` workflow'larında MCR pre-pull kaldırıldı, GHCR login + `build-args` eklendi
- Haftalık `sync-base-images.yml` workflow eklendi: .NET base imagelları MCR'dan GHCR'a yansıtır

## Neden
GitHub Actions runner IP'lerinden MCR'a gelen istekler `403 Forbidden` ile reddediliyor. GHCR mirror ile MCR bağımlılığı kırıldı.

## Dev Doğrulaması
PR #413 dev'e merge edildi, tüm check'ler yeşil ✅

## Test
- `Deploy (Test)` job yeşil ✅
- `Docker Image Build` job yeşil ✅
- `Backend CI` + `Frontend CI` yeşil ✅

## Notlar
- `ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0` ve `ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0` GHCR'da mevcut, `cargo-pilot` repo'suna bağlı
- Sync workflow her Pazar 02:00 UTC otomatik çalışır