### PR TITLE
yükleme planı rapor listeleme endpoint'i eklendi (US-REP-03)

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanRepository.cs
@@ -1,4 +1,5 @@
 using CargoPilot.Application.Common.Models;
+using CargoPilot.Application.Features.Plans.GetLoadingPlanReports;
 using CargoPilot.Application.Features.Plans.GetPlanById;
 using CargoPilot.Application.Features.Plans.GetPlans;
 using CargoPilot.Domain.Entities;
@@ -16,6 +17,16 @@ public interface ILoadingPlanRepository
 
     Task<PlanDetailDto?> GetDetailByIdAsync(
         Guid id,
+        CancellationToken cancellationToken = default);
+
+    Task<PagedResult<LoadingPlanReportDto>> GetPagedReportsAsync(
+        int page,
+        int pageSize,
+        DateTime? startDate,
+        DateTime? endDate,
+        Guid? vehicleId,
+        decimal? minFillRate,
+        decimal? maxFillRate,
         CancellationToken cancellationToken = default);
 
     Task<LoadingPlan?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);

--- a/apps/backend/CargoPilot.Application/Features/Plans/GetLoadingPlanReports/GetLoadingPlanReportsQuery.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/GetLoadingPlanReports/GetLoadingPlanReportsQuery.cs
@@ -1,0 +1,13 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.GetLoadingPlanReports;
+
+public sealed record GetLoadingPlanReportsQuery(
+    DateTime? StartDate,
+    DateTime? EndDate,
+    Guid? VehicleId,
+    decimal? MinFillRate,
+    decimal? MaxFillRate,
+    int Page = 1,
+    int PageSize = 20) : IRequest<Result<PagedResult<LoadingPlanReportDto>>>;

--- a/apps/backend/CargoPilot.Application/Features/Plans/GetLoadingPlanReports/GetLoadingPlanReportsQueryHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/GetLoadingPlanReports/GetLoadingPlanReportsQueryHandler.cs
@@ -1,0 +1,48 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.GetLoadingPlanReports;
+
+public sealed class GetLoadingPlanReportsQueryHandler
+    : IRequestHandler<GetLoadingPlanReportsQuery, Result<PagedResult<LoadingPlanReportDto>>>
+{
+    private readonly ILoadingPlanRepository _repository;
+    private readonly IValidator<GetLoadingPlanReportsQuery> _validator;
+
+    public GetLoadingPlanReportsQueryHandler(
+        ILoadingPlanRepository repository,
+        IValidator<GetLoadingPlanReportsQuery> validator)
+    {
+        _repository = repository;
+        _validator = validator;
+    }
+
+    public async Task<Result<PagedResult<LoadingPlanReportDto>>> Handle(
+        GetLoadingPlanReportsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<PagedResult<LoadingPlanReportDto>>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var pagedResult = await _repository.GetPagedReportsAsync(
+            request.Page,
+            request.PageSize,
+            request.StartDate,
+            request.EndDate,
+            request.VehicleId,
+            request.MinFillRate,
+            request.MaxFillRate,
+            cancellationToken);
+
+        return Result<PagedResult<LoadingPlanReportDto>>.Success(pagedResult);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/GetLoadingPlanReports/GetLoadingPlanReportsQueryValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/GetLoadingPlanReports/GetLoadingPlanReportsQueryValidator.cs
@@ -1,0 +1,43 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Plans.GetLoadingPlanReports;
+
+public sealed class GetLoadingPlanReportsQueryValidator : AbstractValidator<GetLoadingPlanReportsQuery>
+{
+    public GetLoadingPlanReportsQueryValidator()
+    {
+        RuleFor(x => x.Page)
+            .GreaterThanOrEqualTo(1)
+                .WithErrorCode("REPORT_LIST_PAGE_MIN")
+                .WithMessage("Sayfa numarası 1'den küçük olamaz.");
+
+        RuleFor(x => x.PageSize)
+            .InclusiveBetween(1, 100)
+                .WithErrorCode("REPORT_LIST_PAGESIZE_RANGE")
+                .WithMessage("Sayfa boyutu 1 ile 100 arasında olmalıdır.");
+
+        RuleFor(x => x.MinFillRate)
+            .InclusiveBetween(0m, 100m)
+                .WithErrorCode("REPORT_LIST_MINFILLRATE_RANGE")
+                .WithMessage("Minimum doluluk oranı 0 ile 100 arasında olmalıdır.")
+            .When(x => x.MinFillRate.HasValue);
+
+        RuleFor(x => x.MaxFillRate)
+            .InclusiveBetween(0m, 100m)
+                .WithErrorCode("REPORT_LIST_MAXFILLRATE_RANGE")
+                .WithMessage("Maksimum doluluk oranı 0 ile 100 arasında olmalıdır.")
+            .When(x => x.MaxFillRate.HasValue);
+
+        RuleFor(x => x)
+            .Must(x => x.MinFillRate is null || x.MaxFillRate is null || x.MinFillRate <= x.MaxFillRate)
+                .WithErrorCode("REPORT_LIST_FILLRATE_ORDER")
+                .WithMessage("Minimum doluluk oranı, maksimumdan büyük olamaz.")
+                .When(x => x.MinFillRate.HasValue && x.MaxFillRate.HasValue);
+
+        RuleFor(x => x)
+            .Must(x => x.StartDate is null || x.EndDate is null || x.StartDate <= x.EndDate)
+                .WithErrorCode("REPORT_LIST_DATE_ORDER")
+                .WithMessage("Başlangıç tarihi, bitiş tarihinden sonra olamaz.")
+                .When(x => x.StartDate.HasValue && x.EndDate.HasValue);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/GetLoadingPlanReports/LoadingPlanReportDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/GetLoadingPlanReports/LoadingPlanReportDto.cs
@@ -1,0 +1,13 @@
+using CargoPilot.Domain.Enums;
+
+namespace CargoPilot.Application.Features.Plans.GetLoadingPlanReports;
+
+public sealed record LoadingPlanReportDto(
+    Guid Id,
+    string PlanName,
+    DateTime CreatedAtUtc,
+    string? VehiclePlate,
+    decimal FillRate,
+    LoadingPlanOptimizationStatus Status,
+    Guid? ReportId,
+    string? DownloadUrl);

--- a/apps/backend/CargoPilot.Domain/Entities/LoadingPlan.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/LoadingPlan.cs
@@ -19,6 +19,8 @@ public sealed class LoadingPlan : BaseEntity {
     public decimal? CenterOfGravityY { get; private set; }
     public decimal? CenterOfGravityZ { get; private set; }
     public Guid? CompanyId { get; private set; }
+    public Guid? ReportId { get; private set; }
+    public string? ReportUrl { get; private set; }
 #pragma warning restore S1144
 
     public Vehicle Vehicle { get; private set; } = null!;

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/LoadingPlanConfiguration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/LoadingPlanConfiguration.cs
@@ -73,6 +73,9 @@ internal sealed class LoadingPlanConfiguration : IEntityTypeConfiguration<Loadin
         builder.Property(plan => plan.CenterOfGravityZ)
             .HasPrecision(18, 4);
 
+        builder.Property(plan => plan.ReportUrl)
+            .HasMaxLength(2048);
+
         builder.Property(plan => plan.CompanyId);
 
         builder.HasOne(plan => plan.Vehicle)

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260507133430_AddReportFieldsToLoadingPlans.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260507133430_AddReportFieldsToLoadingPlans.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260507133430_AddReportFieldsToLoadingPlans")]
+    partial class AddReportFieldsToLoadingPlans
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -175,152 +178,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                     b.ToTable("Companies", (string)null);
                 });
 
-            modelBuilder.Entity("CargoPilot.Domain.Entities.ErpUserMapping", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<Guid>("CargoPilotUserId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime>("CreatedAtUtc")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime2")
-                        .HasDefaultValueSql("GETUTCDATE()");
-
-                    b.Property<Guid?>("CreatedBy")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("DeletedAtUtc")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("ErpUserEmail")
-                        .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
-
-                    b.Property<string>("ErpUserId")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
-
-                    b.Property<Guid>("IntegrationId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("InvalidatedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("InvalidationReason")
-                        .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)");
-
-                    b.Property<bool>("IsActive")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
-                        .HasDefaultValue(true);
-
-                    b.Property<bool>("IsDeleted")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
-                        .HasDefaultValue(false);
-
-                    b.Property<string>("Status")
-                        .IsRequired()
-                        .ValueGeneratedOnAdd()
-                        .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)")
-                        .HasDefaultValue("Active");
-
-                    b.Property<DateTime?>("UpdatedAtUtc")
-                        .HasColumnType("datetime2");
-
-                    b.Property<Guid?>("UpdatedBy")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CargoPilotUserId");
-
-                    b.HasIndex("Status")
-                        .HasDatabaseName("IX_ErpUserMappings_Status");
-
-                    b.HasIndex("IntegrationId", "CargoPilotUserId")
-                        .IsUnique()
-                        .HasDatabaseName("IX_ErpUserMappings_IntegrationId_CargoPilotUserId")
-                        .HasFilter("[IsDeleted] = 0");
-
-                    b.ToTable("ErpUserMappings", (string)null);
-                });
-
-            modelBuilder.Entity("CargoPilot.Domain.Entities.Integration", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<string>("ApiEndpoint")
-                        .IsRequired()
-                        .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)");
-
-                    b.Property<string>("AuthCredentials")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<Guid>("CompanyId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime>("CreatedAtUtc")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime2")
-                        .HasDefaultValueSql("GETUTCDATE()");
-
-                    b.Property<Guid?>("CreatedBy")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("DeletedAtUtc")
-                        .HasColumnType("datetime2");
-
-                    b.Property<bool>("IsActive")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
-                        .HasDefaultValue(true);
-
-                    b.Property<bool>("IsDeleted")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
-                        .HasDefaultValue(false);
-
-                    b.Property<DateTime?>("LastSyncDate")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("MappingTable")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<int?>("SyncInterval")
-                        .HasColumnType("int");
-
-                    b.Property<string>("SystemName")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
-
-                    b.Property<DateTime?>("UpdatedAtUtc")
-                        .HasColumnType("datetime2");
-
-                    b.Property<Guid?>("UpdatedBy")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CompanyId")
-                        .HasDatabaseName("IX_Integrations_CompanyId");
-
-                    b.HasIndex("IsDeleted")
-                        .HasDatabaseName("IX_Integrations_IsDeleted");
-
-                    b.ToTable("Integrations", (string)null);
-                });
-
             modelBuilder.Entity("CargoPilot.Domain.Entities.Item", b =>
                 {
                     b.Property<Guid>("Id")
@@ -337,9 +194,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                     b.Property<int>("Category")
                         .HasColumnType("int");
 
-                    b.Property<Guid?>("CompanyId")
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<DateTime>("CreatedAtUtc")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
@@ -355,10 +209,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                         .HasPrecision(12, 3)
                         .HasColumnType("decimal(12,3)");
 
-                    b.Property<string>("ErpId")
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
-
                     b.Property<int>("FragilityType")
                         .HasColumnType("int");
 
@@ -369,9 +219,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                     b.Property<string>("ImageUrl")
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
-
-                    b.Property<Guid?>("IntegrationId")
-                        .HasColumnType("uniqueidentifier");
 
                     b.Property<bool>("IsActive")
                         .ValueGeneratedOnAdd()
@@ -436,16 +283,10 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("CompanyId")
-                        .HasDatabaseName("IX_Items_CompanyId");
-
-                    b.HasIndex("IntegrationId");
-
                     b.HasIndex("IsDeleted");
 
-                    b.HasIndex("CompanyId", "SKU")
+                    b.HasIndex("SKU")
                         .IsUnique()
-                        .HasDatabaseName("IX_Items_CompanyId_SKU")
                         .HasFilter("[IsDeleted] = 0");
 
                     b.ToTable("Items", (string)null);
@@ -848,70 +689,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                     b.ToTable("PasswordResetTokens", (string)null);
                 });
 
-            modelBuilder.Entity("CargoPilot.Domain.Entities.SyncLog", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("CompletedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<DateTime>("CreatedAtUtc")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("datetime2")
-                        .HasDefaultValueSql("GETUTCDATE()");
-
-                    b.Property<Guid?>("CreatedBy")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<DateTime?>("DeletedAtUtc")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("ErrorMessage")
-                        .HasMaxLength(2000)
-                        .HasColumnType("nvarchar(2000)");
-
-                    b.Property<Guid>("IntegrationId")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.Property<bool>("IsActive")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
-                        .HasDefaultValue(true);
-
-                    b.Property<bool>("IsDeleted")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
-                        .HasDefaultValue(false);
-
-                    b.Property<DateTime>("StartedAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<string>("Status")
-                        .IsRequired()
-                        .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
-
-                    b.Property<int>("SyncedRecordCount")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasDefaultValue(0);
-
-                    b.Property<DateTime?>("UpdatedAtUtc")
-                        .HasColumnType("datetime2");
-
-                    b.Property<Guid?>("UpdatedBy")
-                        .HasColumnType("uniqueidentifier");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("IntegrationId")
-                        .HasDatabaseName("IX_SyncLogs_IntegrationId");
-
-                    b.ToTable("SyncLogs", (string)null);
-                });
-
             modelBuilder.Entity("CargoPilot.Domain.Entities.UserLogin", b =>
                 {
                     b.Property<Guid>("Id")
@@ -1107,13 +884,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                         .HasMaxLength(500)
                         .HasColumnType("nvarchar(500)");
 
-                    b.Property<string>("ErpId")
-                        .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
-
-                    b.Property<Guid?>("IntegrationId")
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<decimal>("InternalHeight")
                         .HasPrecision(18, 4)
                         .HasColumnType("decimal(18,4)");
@@ -1200,8 +970,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                     b.HasIndex("CompanyId")
                         .HasDatabaseName("IX_Vehicles_CompanyId");
 
-                    b.HasIndex("IntegrationId");
-
                     b.HasIndex("IsDeleted")
                         .HasDatabaseName("IX_Vehicles_IsDeleted");
 
@@ -1250,53 +1018,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                         .OnDelete(DeleteBehavior.Restrict);
 
                     b.Navigation("Company");
-                });
-
-            modelBuilder.Entity("CargoPilot.Domain.Entities.ErpUserMapping", b =>
-                {
-                    b.HasOne("CargoPilot.Domain.Entities.AppUser", "CargoPilotUser")
-                        .WithMany()
-                        .HasForeignKey("CargoPilotUserId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.HasOne("CargoPilot.Domain.Entities.Integration", "Integration")
-                        .WithMany("ErpUserMappings")
-                        .HasForeignKey("IntegrationId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("CargoPilotUser");
-
-                    b.Navigation("Integration");
-                });
-
-            modelBuilder.Entity("CargoPilot.Domain.Entities.Integration", b =>
-                {
-                    b.HasOne("CargoPilot.Domain.Entities.Company", "Company")
-                        .WithMany("Integrations")
-                        .HasForeignKey("CompanyId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("Company");
-                });
-
-            modelBuilder.Entity("CargoPilot.Domain.Entities.Item", b =>
-                {
-                    b.HasOne("CargoPilot.Domain.Entities.Company", "Company")
-                        .WithMany("Items")
-                        .HasForeignKey("CompanyId")
-                        .OnDelete(DeleteBehavior.Restrict);
-
-                    b.HasOne("CargoPilot.Domain.Entities.Integration", "Integration")
-                        .WithMany()
-                        .HasForeignKey("IntegrationId")
-                        .OnDelete(DeleteBehavior.SetNull);
-
-                    b.Navigation("Company");
-
-                    b.Navigation("Integration");
                 });
 
             modelBuilder.Entity("CargoPilot.Domain.Entities.LoadingPlan", b =>
@@ -1411,17 +1132,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                     b.Navigation("User");
                 });
 
-            modelBuilder.Entity("CargoPilot.Domain.Entities.SyncLog", b =>
-                {
-                    b.HasOne("CargoPilot.Domain.Entities.Integration", "Integration")
-                        .WithMany("SyncLogs")
-                        .HasForeignKey("IntegrationId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.Navigation("Integration");
-                });
-
             modelBuilder.Entity("CargoPilot.Domain.Entities.UserLogin", b =>
                 {
                     b.HasOne("CargoPilot.Domain.Entities.AppUser", "User")
@@ -1477,14 +1187,7 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                         .HasForeignKey("CompanyId")
                         .OnDelete(DeleteBehavior.Restrict);
 
-                    b.HasOne("CargoPilot.Domain.Entities.Integration", "Integration")
-                        .WithMany()
-                        .HasForeignKey("IntegrationId")
-                        .OnDelete(DeleteBehavior.SetNull);
-
                     b.Navigation("Company");
-
-                    b.Navigation("Integration");
                 });
 
             modelBuilder.Entity("CargoPilot.Domain.Entities.AppUser", b =>
@@ -1496,20 +1199,9 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
 
             modelBuilder.Entity("CargoPilot.Domain.Entities.Company", b =>
                 {
-                    b.Navigation("Integrations");
-
-                    b.Navigation("Items");
-
                     b.Navigation("Users");
 
                     b.Navigation("Vehicles");
-                });
-
-            modelBuilder.Entity("CargoPilot.Domain.Entities.Integration", b =>
-                {
-                    b.Navigation("ErpUserMappings");
-
-                    b.Navigation("SyncLogs");
                 });
 #pragma warning restore 612, 618
         }

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260507133430_AddReportFieldsToLoadingPlans.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260507133430_AddReportFieldsToLoadingPlans.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReportFieldsToLoadingPlans : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ReportId",
+                table: "LoadingPlans",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ReportUrl",
+                table: "LoadingPlans",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ReportId",
+                table: "LoadingPlans");
+
+            migrationBuilder.DropColumn(
+                name: "ReportUrl",
+                table: "LoadingPlans");
+        }
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260508090402_FixReportUrlMaxLength.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260508090402_FixReportUrlMaxLength.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260508090402_FixReportUrlMaxLength")]
+    partial class FixReportUrlMaxLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260508090402_FixReportUrlMaxLength.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260508090402_FixReportUrlMaxLength.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixReportUrlMaxLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ReportUrl",
+                table: "LoadingPlans",
+                type: "nvarchar(2048)",
+                maxLength: 2048,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ReportUrl",
+                table: "LoadingPlans",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(2048)",
+                oldMaxLength: 2048,
+                oldNullable: true);
+        }
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
@@ -1,5 +1,6 @@
 using CargoPilot.Application.Common.Interfaces;
 using CargoPilot.Application.Common.Models;
+using CargoPilot.Application.Features.Plans.GetLoadingPlanReports;
 using CargoPilot.Application.Features.Plans.GetPlanById;
 using CargoPilot.Application.Features.Plans.GetPlans;
 using CargoPilot.Domain.Entities;
@@ -59,6 +60,56 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
             .ToListAsync(cancellationToken);
 
         return new PagedResult<PlanSummaryDto>(items, totalCount, page, pageSize);
+    }
+
+    public async Task<PagedResult<LoadingPlanReportDto>> GetPagedReportsAsync(
+        int page,
+        int pageSize,
+        DateTime? startDate,
+        DateTime? endDate,
+        Guid? vehicleId,
+        decimal? minFillRate,
+        decimal? maxFillRate,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _context.LoadingPlans
+            .AsNoTracking()
+            .Include(p => p.Vehicle)
+            .AsQueryable();
+
+        if (startDate.HasValue)
+            query = query.Where(p => p.CreatedAtUtc >= startDate.Value);
+
+        if (endDate.HasValue)
+            query = query.Where(p => p.CreatedAtUtc <= endDate.Value);
+
+        if (vehicleId.HasValue)
+            query = query.Where(p => p.VehicleId == vehicleId.Value);
+
+        if (minFillRate.HasValue)
+            query = query.Where(p => p.FillRate >= minFillRate.Value);
+
+        if (maxFillRate.HasValue)
+            query = query.Where(p => p.FillRate <= maxFillRate.Value);
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .OrderByDescending(p => p.CreatedAtUtc)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(p => new LoadingPlanReportDto(
+                p.Id,
+                p.PlanName,
+                p.CreatedAtUtc,
+                p.Vehicle.PlateNumber,
+                p.FillRate,
+                p.OptimizationStatus,
+                p.ReportId,
+                p.ReportUrl))
+            .ToListAsync(cancellationToken);
+
+        return new PagedResult<LoadingPlanReportDto>(items, totalCount, page, pageSize);
     }
 
     public async Task<PlanDetailDto?> GetDetailByIdAsync(

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
@@ -74,7 +74,6 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
     {
         var query = _context.LoadingPlans
             .AsNoTracking()
-            .Include(p => p.Vehicle)
             .AsQueryable();
 
         if (startDate.HasValue)

--- a/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
@@ -116,7 +116,13 @@ public sealed class PlansController : BaseController
     /// <summary>
     /// Geçmiş yükleme planı raporlarını filtreli ve sayfalı listeler.
     /// </summary>
-    /// <param name="query">Tarih aralığı, araç, doluluk oranı ve sayfalama parametreleri.</param>
+    /// <param name="startDate">Başlangıç tarihi (UTC, opsiyonel).</param>
+    /// <param name="endDate">Bitiş tarihi (UTC, opsiyonel).</param>
+    /// <param name="vehicleId">Araç ID filtresi (opsiyonel).</param>
+    /// <param name="minFillRate">Minimum doluluk oranı, 0-100 arası (opsiyonel).</param>
+    /// <param name="maxFillRate">Maksimum doluluk oranı, 0-100 arası (opsiyonel).</param>
+    /// <param name="page">Sayfa numarası (varsayılan: 1).</param>
+    /// <param name="pageSize">Sayfa boyutu, 1-100 arası (varsayılan: 20).</param>
     /// <param name="cancellationToken">İptal token'ı.</param>
     /// <response code="200">Rapor listesi sayfalı döner; sonuç yoksa boş liste ile totalCount=0 döner.</response>
     /// <response code="400">Doğrulama hatası.</response>
@@ -124,9 +130,16 @@ public sealed class PlansController : BaseController
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetReports(
-        [FromQuery] GetLoadingPlanReportsQuery query,
+        [FromQuery] DateTime? startDate = null,
+        [FromQuery] DateTime? endDate = null,
+        [FromQuery] Guid? vehicleId = null,
+        [FromQuery] decimal? minFillRate = null,
+        [FromQuery] decimal? maxFillRate = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
         CancellationToken cancellationToken = default)
     {
+        var query = new GetLoadingPlanReportsQuery(startDate, endDate, vehicleId, minFillRate, maxFillRate, page, pageSize);
         var result = await _mediator.Send(query, cancellationToken);
         return HandleResult(result);
     }

--- a/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
@@ -1,5 +1,6 @@
 using CargoPilot.Application.Features.Plans.CreatePlan;
 using CargoPilot.Application.Features.Plans.DeletePlan;
+using CargoPilot.Application.Features.Plans.GetLoadingPlanReports;
 using CargoPilot.Application.Features.Plans.GetPlanById;
 using CargoPilot.Application.Features.Plans.GetPlans;
 using CargoPilot.Application.Features.Plans.UpdatePlanName;
@@ -109,6 +110,24 @@ public sealed class PlansController : BaseController
         CancellationToken cancellationToken = default)
     {
         var result = await _mediator.Send(new UpdatePlanNameCommand(id, request.PlanName), cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Geçmiş yükleme planı raporlarını filtreli ve sayfalı listeler.
+    /// </summary>
+    /// <param name="query">Tarih aralığı, araç, doluluk oranı ve sayfalama parametreleri.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Rapor listesi sayfalı döner; sonuç yoksa boş liste ile totalCount=0 döner.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    [HttpGet("reports")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetReports(
+        [FromQuery] GetLoadingPlanReportsQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _mediator.Send(query, cancellationToken);
         return HandleResult(result);
     }
 

--- a/apps/backend/docs/user-story-tracker.md
+++ b/apps/backend/docs/user-story-tracker.md
@@ -385,3 +385,40 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 - `CargoPilot.Infrastructure/DependencyInjection.cs`
 - `CargoPilot.Domain/Entities/LoadingPlan.cs`
 - `CargoPilot.WebAPI/Controllers/PlansController.cs`
+
+---
+
+## 15) US-REP-03: Yükleme Planı Rapor Listesi Endpoint'i
+**Story:** Rapor sayfası geliştirici olarak, geçmiş yükleme planı raporlarını filtreli ve sayfalı listeleyebilmek için backend endpoint'inin hazır olmasını isterim.
+
+**Genel Durum:** `✅ Tamamlandi`
+
+### Kabul Kriterleri
+- AC1: Rapor listesi `CreatedAtUtc` desc sıralı döner; her satırda `planName`, `createdAt`, `vehiclePlate`, `fillRate`, `status`, `reportId`, `downloadUrl` alanları bulunur.
+- AC2: Tarih aralığı (`startDate`/`endDate`), araç (`vehicleId`), doluluk oranı aralığı (`minFillRate`/`maxFillRate`) filtreleri ve sayfalama (`page`/`pageSize`) desteklenir.
+- AC3: Her satırda PDF indirme bilgisi (`reportId`/`downloadUrl`) endpoint'ten döner; frontend bu URL ile indirme yapabilir.
+- AC4: Kayıt yoksa `items=[]`, `totalCount=0` döner; frontend empty state gösterebilir.
+
+### Alt İşler
+- `✅` `LoadingPlanReportDto` record tanımla (`Id`, `PlanName`, `CreatedAtUtc`, `VehiclePlate`, `FillRate`, `Status`, `ReportId`, `DownloadUrl`)
+- `✅` `GetLoadingPlanReportsQuery` record tanımla (`StartDate`, `EndDate`, `VehicleId`, `MinFillRate`, `MaxFillRate`, `Page`, `PageSize`)
+- `✅` `GetLoadingPlanReportsQueryValidator` yaz (Page ≥ 1, PageSize 1–100, FillRate 0–100, MinFillRate ≤ MaxFillRate, StartDate ≤ EndDate)
+- `✅` `GetLoadingPlanReportsQueryHandler` yaz (validasyon + repository çağrısı, `Result.Success` ile dön)
+- `✅` `LoadingPlan` entity'sine `ReportId (Guid?)` ve `ReportUrl (string?)` alanları eklendi
+- `✅` `ILoadingPlanRepository` arayüzüne `GetPagedReportsAsync` metodu eklendi
+- `✅` `LoadingPlanRepository`'e `GetPagedReportsAsync` implementasyonu yazıldı (5 dinamik filtre, `OrderByDescending CreatedAtUtc`, `Skip/Take`)
+- `✅` `PlansController`'a `GET /api/v1/loading-plans/reports` endpoint'i eklendi
+- `✅` `AddReportFieldsToLoadingPlans` migration'i oluşturuldu ve `dotnet ef database update` ile uygulandı; sütunlar SQL sorgusuyla doğrulandı
+- `✅` Swagger üzerinden filtreleme, sıralama ve validasyon (0–100 doluluk kontrolü) senaryoları test edildi
+- `✅` Branch `dev`'e rebase edildi, build 0 hata ile doğrulandı
+
+### Kanıtlar
+- `CargoPilot.Application/Features/Plans/GetLoadingPlanReports/LoadingPlanReportDto.cs`
+- `CargoPilot.Application/Features/Plans/GetLoadingPlanReports/GetLoadingPlanReportsQuery.cs`
+- `CargoPilot.Application/Features/Plans/GetLoadingPlanReports/GetLoadingPlanReportsQueryValidator.cs`
+- `CargoPilot.Application/Features/Plans/GetLoadingPlanReports/GetLoadingPlanReportsQueryHandler.cs`
+- `CargoPilot.Application/Common/Interfaces/ILoadingPlanRepository.cs`
+- `CargoPilot.Domain/Entities/LoadingPlan.cs`
+- `CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs`
+- `CargoPilot.Infrastructure/Persistence/Migrations/20260507133430_AddReportFieldsToLoadingPlans.cs`
+- `CargoPilot.WebAPI/Controllers/PlansController.cs`


### PR DESCRIPTION
## Yükleme planı rapor listesi endpoint'i eklendi (US-REP-03)

`GET /api/v1/loading-plans/reports` endpoint'i eklendi. Tarih aralığı, araç ve doluluk oranı filtreleriyle sayfalı rapor listesi döner. LoadingPlan entity'sine ReportId/ReportUrl alanları eklenerek migration uygulandı.

## İlgili User Story / Issue

US-REP-03

## Değişiklik Tipi

- [x] 🚀 Yeni özellik (feature)

## Test Edildi mi?

- [x] Manuel test yapıldı

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

- Filtreleme: `startDate`, `endDate`, `vehicleId`, `minFillRate`, `maxFillRate`
- Validasyon: page ≥ 1, pageSize 1–100, fillRate 0–100, min ≤ max, startDate ≤ endDate
- Kayıt yoksa `items=[]`, `totalCount=0` döner

