### PR TITLE
Feature/us 3 d 23 liste arama filtreleme performans

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -31,6 +34,7 @@
         "@react-three/fiber": "^8.18.0",
         "@tanstack/react-query": "^5.99.2",
         "@tanstack/react-query-devtools": "^5.99.2",
+        "@tanstack/react-virtual": "^3.13.24",
         "axios": "^1.15.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -121,6 +125,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -359,27 +364,58 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "optional": true,
+      "peer": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2271,6 +2307,7 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
       "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.26.7",
@@ -2687,6 +2724,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.6.tgz",
       "integrity": "sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.100.6"
       },
@@ -2713,6 +2751,33 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.100.6",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tweenjs/tween.js": {
@@ -2846,6 +2911,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2867,6 +2933,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2878,6 +2945,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2902,6 +2970,7 @@
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.162.0.tgz",
       "integrity": "sha512-0j5yZcVukVIhrhSIC7+LmBPkkMoMuEJ1AfYBZfgNytdYqYREMuiyXWhYOMeZLBElTEAlJIZn7r2W3vqTIgjWlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tweenjs/tween.js": "~23.1.1",
         "@types/stats.js": "*",
@@ -2957,6 +3026,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -3324,6 +3394,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3649,6 +3720,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4360,6 +4432,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5110,6 +5183,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -5160,6 +5234,7 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -5316,6 +5391,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6256,6 +6332,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6499,6 +6576,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6523,6 +6601,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6545,6 +6624,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
       "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -6587,7 +6667,8 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-reconciler": {
       "version": "0.27.0",
@@ -6619,6 +6700,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6826,7 +6908,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7276,6 +7359,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7342,7 +7426,8 @@
       "version": "0.162.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.162.0.tgz",
       "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.7.8",
@@ -7549,6 +7634,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7726,6 +7812,7 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8086,6 +8173,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -52,6 +52,9 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
@@ -74,6 +77,7 @@
     "@react-three/fiber": "^8.18.0",
     "@tanstack/react-query": "^5.99.2",
     "@tanstack/react-query-devtools": "^5.99.2",
+    "@tanstack/react-virtual": "^3.13.24",
     "axios": "^1.15.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/frontend/src/components/ui/dropdown-menu.tsx
+++ b/apps/frontend/src/components/ui/dropdown-menu.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { Check } from 'lucide-react';
 import { cn } from '@/lib/utils/cn';
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
@@ -54,11 +55,37 @@ function DropdownMenuLabel({
   );
 }
 
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      className={cn(
+        'relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="h-3.5 w-3.5" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
 export {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuCheckboxItem,
   DropdownMenuLabel,
   DropdownMenuGroup,
   DropdownMenuPortal,

--- a/apps/frontend/src/features/planning/components/PlanLeftPanel.tsx
+++ b/apps/frontend/src/features/planning/components/PlanLeftPanel.tsx
@@ -303,7 +303,10 @@ function StoreItemRow({
 
 // ─── SortableStoreItemRow ─────────────────────────────────────────────────────
 
-interface SortableStoreItemRowProps extends Omit<StoreItemRowProps, 'dragHandleRef' | 'dragHandleListeners' | 'dragHandleAttributes'> {
+interface SortableStoreItemRowProps extends Omit<
+  StoreItemRowProps,
+  'dragHandleRef' | 'dragHandleListeners' | 'dragHandleAttributes'
+> {
   id: string;
 }
 

--- a/apps/frontend/src/features/planning/components/PlanLeftPanel.tsx
+++ b/apps/frontend/src/features/planning/components/PlanLeftPanel.tsx
@@ -1,4 +1,22 @@
-import { useState, useRef, useEffect, type ElementType } from 'react';
+import { useState, useRef, useEffect, useMemo, type ElementType, type HTMLAttributes } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   AlertTriangle,
   ArrowDownToLine,
@@ -10,22 +28,38 @@ import {
   Flame,
   FlipHorizontal,
   FolderPlus,
+  GripVertical,
   Layers,
   Loader2,
   Package,
   PackageMinus,
   Pencil,
   Plus,
+  Search,
+  SlidersHorizontal,
   Trash2,
+  X,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
+import { Input } from '@/components/ui/input';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils/cn';
 import { usePlanStore } from '@/lib/store/usePlanStore';
 import { useSceneStore } from '@/lib/store/useSceneStore';
 import { SCENE } from '@/lib/config/scene-config';
 import { useItems } from '@/lib/api/useItems';
 import { AddItemModal } from './AddItemModal';
 import type { Item } from '@/lib/types/item';
+
+// Minimum item count to switch from DnD to virtual list rendering
+const VIRTUAL_THRESHOLD = 100;
 
 // ─── Constraint metadata ──────────────────────────────────────────────────────
 
@@ -49,6 +83,21 @@ function getConstraints(item: Item): string[] {
   return k;
 }
 
+function itemMatchesFilters(
+  item: Item,
+  query: string,
+  activeConstraints: ReadonlySet<string>,
+): boolean {
+  if (query && !item.name.toLowerCase().includes(query.toLowerCase())) return false;
+  if (activeConstraints.size > 0) {
+    const constraints = new Set(getConstraints(item));
+    for (const k of activeConstraints) {
+      if (!constraints.has(k)) return false;
+    }
+  }
+  return true;
+}
+
 // ─── StoreItemRow ─────────────────────────────────────────────────────────────
 
 interface StoreItemRowProps {
@@ -58,6 +107,9 @@ interface StoreItemRowProps {
   isHidden: boolean;
   canPlace: boolean;
   indent?: boolean;
+  dragHandleRef?: (el: HTMLElement | null) => void;
+  dragHandleListeners?: Record<string, unknown>;
+  dragHandleAttributes?: Record<string, unknown>;
   onTogglePlace: () => void;
   onSelect: () => void;
   onToggleHide: () => void;
@@ -72,6 +124,9 @@ function StoreItemRow({
   isHidden,
   canPlace,
   indent = false,
+  dragHandleRef,
+  dragHandleListeners,
+  dragHandleAttributes,
   onTogglePlace,
   onSelect,
   onToggleHide,
@@ -87,7 +142,7 @@ function StoreItemRow({
     <div
       title={!canPlace && !isPlaced ? 'Yük eklemek için önce bir konteyner seçin' : undefined}
       className={cn(
-        'flex items-center gap-2.5 px-3 py-2 rounded-lg transition-colors group/item',
+        'flex items-center gap-2 px-3 py-2 rounded-lg transition-colors group/item',
         clickable ? 'cursor-pointer' : 'cursor-not-allowed opacity-50',
         isSelected
           ? 'bg-zinc-900 text-white'
@@ -104,6 +159,23 @@ function StoreItemRow({
         if (!isPlaced) onTogglePlace();
       }}
     >
+      {/* Drag handle */}
+      {dragHandleRef && (
+        <button
+          ref={dragHandleRef}
+          {...(dragHandleListeners as HTMLAttributes<HTMLButtonElement>)}
+          {...(dragHandleAttributes as HTMLAttributes<HTMLButtonElement>)}
+          className={cn(
+            'shrink-0 w-4 flex items-center justify-center cursor-grab active:cursor-grabbing touch-none',
+            isSelected ? 'text-zinc-500 hover:text-zinc-300' : 'text-zinc-200 hover:text-zinc-400',
+          )}
+          title="Sırasını değiştir"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <GripVertical className="w-3.5 h-3.5" />
+        </button>
+      )}
+
       {/* Tip ikonu */}
       <TypeIcon
         className={cn('w-4 h-4 shrink-0', isSelected ? 'text-white' : 'text-zinc-400')}
@@ -229,6 +301,39 @@ function StoreItemRow({
   );
 }
 
+// ─── SortableStoreItemRow ─────────────────────────────────────────────────────
+
+interface SortableStoreItemRowProps extends Omit<StoreItemRowProps, 'dragHandleRef' | 'dragHandleListeners' | 'dragHandleAttributes'> {
+  id: string;
+}
+
+function SortableStoreItemRow({ id, ...rowProps }: SortableStoreItemRowProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(isDragging && 'opacity-40 z-50 relative')}
+    >
+      <StoreItemRow
+        {...rowProps}
+        dragHandleRef={setActivatorNodeRef}
+        dragHandleListeners={listeners as Record<string, unknown>}
+        dragHandleAttributes={attributes as unknown as Record<string, unknown>}
+      />
+    </div>
+  );
+}
+
 // ─── PlanLeftPanel ────────────────────────────────────────────────────────────
 
 export function PlanLeftPanel() {
@@ -238,6 +343,8 @@ export function PlanLeftPanel() {
   const [ungroupedIds, setUngroupedIds] = useState<string[]>([]);
   const [showItemModal, setShowItemModal] = useState(false);
   const [editingItemId, setEditingItemId] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [activeConstraints, setActiveConstraints] = useState<Set<string>>(new Set());
 
   const { data: itemsPage, isLoading: itemsLoading } = useItems({ pageSize: 100 });
   const apiItems = itemsPage?.items ?? [];
@@ -250,6 +357,7 @@ export function PlanLeftPanel() {
   const removeItem = usePlanStore((s) => s.removeItem);
   const togglePlacement = usePlanStore((s) => s.togglePlacement);
   const initItems = usePlanStore((s) => s.initItems);
+  const reorderItems = usePlanStore((s) => s.reorderItems);
   const mockPlacements = usePlanStore((s) => s.mockPlacements);
   const setPlacements = usePlanStore((s) => s.setPlacements);
 
@@ -275,7 +383,6 @@ export function PlanLeftPanel() {
         apiItems.map((item) => ({ item, quantity: 1 })),
         colorMap,
       );
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setUngroupedIds(apiItems.map((item) => item.id));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -288,13 +395,58 @@ export function PlanLeftPanel() {
   const allKnownIds = new Set([...groupedIds, ...ungroupedIds]);
   const extraItems = selectedItems.filter((si) => !allKnownIds.has(si.item.id));
 
+  // Filtered lists — name search + constraint toggles
+  const filteredUngroupedIds = useMemo(() => {
+    const hasFilter = search.trim() || activeConstraints.size > 0;
+    if (!hasFilter) return ungroupedIds;
+    return ungroupedIds.filter((id) => {
+      const entry = selectedItems.find((si) => si.item.id === id);
+      return entry ? itemMatchesFilters(entry.item, search, activeConstraints) : false;
+    });
+  }, [ungroupedIds, selectedItems, search, activeConstraints]);
+
+  const filteredExtraItems = useMemo(() => {
+    const hasFilter = search.trim() || activeConstraints.size > 0;
+    if (!hasFilter) return extraItems;
+    return extraItems.filter((si) => itemMatchesFilters(si.item, search, activeConstraints));
+  }, [extraItems, search, activeConstraints]);
+
+  // Virtual list — activated when ungrouped count reaches threshold
+  const shouldVirtualize = filteredUngroupedIds.length >= VIRTUAL_THRESHOLD;
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const rowVirtualizer = useVirtualizer({
+    count: shouldVirtualize ? filteredUngroupedIds.length : 0,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 52,
+    overscan: 5,
+  });
+
+  // DnD sensors
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const activeId = active.id as string;
+    const overId = over.id as string;
+    setUngroupedIds((ids) => {
+      const oldIndex = ids.indexOf(activeId);
+      const newIndex = ids.indexOf(overId);
+      return arrayMove(ids, oldIndex, newIndex);
+    });
+    reorderItems(activeId, overId);
+  }
+
   function lookupEntry(id: string) {
     return selectedItems.find((si) => si.item.id === id);
   }
 
   function toggleGroup(groupId: string, itemIds: string[]) {
     setGroups((prev) => prev.map((g) => (g.id === groupId ? { ...g, acik: !g.acik } : g)));
-    // Aynı grup zaten fokuslanmışsa fokus kaldır, değilse bu grubu fokusla
     const isSameFocus =
       focusedGroupItemIds !== null &&
       focusedGroupItemIds.length === itemIds.length &&
@@ -318,6 +470,23 @@ export function PlanLeftPanel() {
   const editingEntry = editingItemId
     ? selectedItems.find((si) => si.item.id === editingItemId)
     : undefined;
+
+  const commonRowProps = (id: string) => {
+    const entry = lookupEntry(id);
+    if (!entry) return null;
+    return {
+      storeEntry: entry,
+      isPlaced: placedIds.has(id),
+      isSelected: selectedItemId === id,
+      isHidden: hiddenItemIds.includes(id),
+      canPlace,
+      onTogglePlace: () => togglePlacement(id),
+      onSelect: () => setSelectedItemId(selectedItemId === id ? null : id),
+      onToggleHide: () => toggleHiddenItem(id),
+      onEdit: () => openEdit(id),
+      onDelete: () => handleDelete(id),
+    };
+  };
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
@@ -349,6 +518,88 @@ export function PlanLeftPanel() {
         </div>
       </div>
 
+      {/* Search + constraint filter */}
+      <div className="px-2 pt-2 pb-1 shrink-0 flex items-center gap-1.5">
+        <div className="relative flex-1">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-400 pointer-events-none" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Ürün adı ile ara…"
+            className="h-7 pl-8 pr-7 text-xs bg-zinc-50 border-zinc-200 focus-visible:ring-1 focus-visible:ring-zinc-300"
+          />
+          {search && (
+            <button
+              onClick={() => setSearch('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          )}
+        </div>
+
+        {/* Constraint type filter */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              title="Kısıt tipine göre filtrele"
+              className={cn(
+                'h-7 w-7 shrink-0 border-zinc-200',
+                activeConstraints.size > 0
+                  ? 'bg-zinc-900 text-white border-zinc-900 hover:bg-zinc-700 hover:border-zinc-700'
+                  : 'bg-zinc-50 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-100',
+              )}
+            >
+              <SlidersHorizontal className="w-3.5 h-3.5" />
+              {activeConstraints.size > 0 && (
+                <span className="sr-only">{activeConstraints.size} filtre aktif</span>
+              )}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-44">
+            <DropdownMenuLabel className="text-[10px] font-semibold text-zinc-500 uppercase tracking-wide py-1">
+              Kısıt Tipi
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {Object.entries(KISIT_META).map(([key, meta]) => {
+              const Icon = meta.icon;
+              return (
+                <DropdownMenuCheckboxItem
+                  key={key}
+                  checked={activeConstraints.has(key)}
+                  onCheckedChange={(checked: boolean) => {
+                    setActiveConstraints((prev) => {
+                      const next = new Set(prev);
+                      if (checked) next.add(key);
+                      else next.delete(key);
+                      return next;
+                    });
+                  }}
+                  onSelect={(e: Event) => e.preventDefault()}
+                  className="text-xs gap-2"
+                >
+                  <Icon className="w-3.5 h-3.5 text-zinc-500" />
+                  {meta.label}
+                </DropdownMenuCheckboxItem>
+              );
+            })}
+            {activeConstraints.size > 0 && (
+              <>
+                <DropdownMenuSeparator />
+                <button
+                  onClick={() => setActiveConstraints(new Set())}
+                  className="w-full text-[10px] text-zinc-400 hover:text-zinc-700 px-2 py-1.5 text-left transition-colors"
+                >
+                  Filtreleri temizle
+                </button>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
       {/* Scrollable area */}
       <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto p-2 flex flex-col gap-0.5">
         {itemsLoading && (
@@ -357,11 +608,16 @@ export function PlanLeftPanel() {
             Ürünler yükleniyor…
           </div>
         )}
+
         {/* Groups */}
         {groups.map((g) => {
           const groupEntries = g.itemIdler
             .map(lookupEntry)
             .filter((e): e is { item: Item; quantity: number } => e !== undefined);
+          const hasFilter = search.trim() || activeConstraints.size > 0;
+          const filteredGroupEntries = hasFilter
+            ? groupEntries.filter((e) => itemMatchesFilters(e.item, search, activeConstraints))
+            : groupEntries;
           const groupTotal = groupEntries.reduce((s, e) => s + e.quantity, 0);
           const isFocused =
             focusedGroupItemIds !== null &&
@@ -402,45 +658,92 @@ export function PlanLeftPanel() {
               </button>
 
               {g.acik &&
-                g.itemIdler.map((id) => {
-                  const entry = lookupEntry(id);
-                  if (!entry) return null;
-                  return (
-                    <StoreItemRow
-                      key={id}
-                      storeEntry={entry}
-                      isPlaced={placedIds.has(id)}
-                      isSelected={selectedItemId === id}
-                      isHidden={hiddenItemIds.includes(id)}
-                      canPlace={canPlace}
-                      indent
-                      onTogglePlace={() => togglePlacement(id)}
-                      onSelect={() => setSelectedItemId(selectedItemId === id ? null : id)}
-                      onToggleHide={() => toggleHiddenItem(id)}
-                      onEdit={() => openEdit(id)}
-                      onDelete={() => handleDelete(id)}
-                    />
-                  );
+                filteredGroupEntries.map((entry) => {
+                  const id = entry.item.id;
+                  const props = commonRowProps(id);
+                  if (!props) return null;
+                  return <StoreItemRow key={id} {...props} indent />;
                 })}
             </div>
           );
         })}
 
-        {/* Ungrouped */}
-        {ungroupedIds.length > 0 && (
+        {/* Ungrouped — virtual list when >= VIRTUAL_THRESHOLD, DnD otherwise */}
+        {filteredUngroupedIds.length > 0 && (
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2 px-3 py-1.5">
               <span className="text-[10px] font-semibold text-zinc-400 uppercase tracking-wide">
                 Grupsuz
+                {search && ` · ${filteredUngroupedIds.length} sonuç`}
               </span>
             </div>
-            {ungroupedIds.map((id) => {
-              const entry = lookupEntry(id);
-              if (!entry) return null;
+
+            {shouldVirtualize ? (
+              // Virtual list mode — no DnD (impractical at this scale)
+              <div
+                style={{
+                  height: `${rowVirtualizer.getTotalSize()}px`,
+                  position: 'relative',
+                }}
+              >
+                {rowVirtualizer.getVirtualItems().map((virtualItem) => {
+                  const id = filteredUngroupedIds[virtualItem.index];
+                  const props = commonRowProps(id);
+                  if (!props) return null;
+                  return (
+                    <div
+                      key={virtualItem.key}
+                      data-index={virtualItem.index}
+                      ref={rowVirtualizer.measureElement}
+                      style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        width: '100%',
+                        transform: `translateY(${virtualItem.start}px)`,
+                      }}
+                    >
+                      <StoreItemRow {...props} />
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              // DnD mode — drag handle on each row
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={filteredUngroupedIds}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {filteredUngroupedIds.map((id) => {
+                    const props = commonRowProps(id);
+                    if (!props) return null;
+                    return <SortableStoreItemRow key={id} id={id} {...props} />;
+                  })}
+                </SortableContext>
+              </DndContext>
+            )}
+          </div>
+        )}
+
+        {/* New items added via form (not in any group yet) */}
+        {filteredExtraItems.length > 0 && (
+          <div className="flex flex-col gap-0.5">
+            <div className="flex items-center gap-2 px-3 py-1.5">
+              <span className="text-[10px] font-semibold text-zinc-400 uppercase tracking-wide">
+                Manuel Eklenen
+              </span>
+            </div>
+            {filteredExtraItems.map((si) => {
+              const id = si.item.id;
               return (
                 <StoreItemRow
                   key={id}
-                  storeEntry={entry}
+                  storeEntry={si}
                   isPlaced={placedIds.has(id)}
                   isSelected={selectedItemId === id}
                   isHidden={hiddenItemIds.includes(id)}
@@ -456,33 +759,18 @@ export function PlanLeftPanel() {
           </div>
         )}
 
-        {/* New items added via form (not in any group yet) */}
-        {extraItems.length > 0 && (
-          <div className="flex flex-col gap-0.5">
-            <div className="flex items-center gap-2 px-3 py-1.5">
-              <span className="text-[10px] font-semibold text-zinc-400 uppercase tracking-wide">
-                Manuel Eklenen
-              </span>
+        {/* No results */}
+        {(search || activeConstraints.size > 0) &&
+          filteredUngroupedIds.length === 0 &&
+          filteredExtraItems.length === 0 &&
+          !itemsLoading && (
+            <div className="flex flex-col items-center justify-center py-8 text-center gap-1.5">
+              <Search className="w-5 h-5 text-zinc-200" />
+              <p className="text-xs text-zinc-400">
+                {search ? `"${search}" için` : 'Seçili kısıt filtresine göre'} sonuç bulunamadı
+              </p>
             </div>
-            {extraItems.map((si) => (
-              <StoreItemRow
-                key={si.item.id}
-                storeEntry={si}
-                isPlaced={placedIds.has(si.item.id)}
-                isSelected={selectedItemId === si.item.id}
-                isHidden={hiddenItemIds.includes(si.item.id)}
-                canPlace={canPlace}
-                onTogglePlace={() => togglePlacement(si.item.id)}
-                onSelect={() =>
-                  setSelectedItemId(selectedItemId === si.item.id ? null : si.item.id)
-                }
-                onToggleHide={() => toggleHiddenItem(si.item.id)}
-                onEdit={() => openEdit(si.item.id)}
-                onDelete={() => handleDelete(si.item.id)}
-              />
-            ))}
-          </div>
-        )}
+          )}
       </div>
 
       {/* Dev-only stres testi (US-OPT-14): InstancedMesh render path FPS ölçümü için. */}

--- a/apps/frontend/src/features/planning/components/PlanRightPanel.tsx
+++ b/apps/frontend/src/features/planning/components/PlanRightPanel.tsx
@@ -1,4 +1,21 @@
-import { useMemo, useState, useEffect, useRef } from 'react';
+import { useMemo, useState, useEffect, useRef, type HTMLAttributes } from 'react';
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -6,23 +23,45 @@ import {
   Box,
   ChevronLeft,
   ChevronRight,
+  Container,
+  GripVertical,
   Loader2,
   Package2,
   Pencil,
   Plus,
+  Search,
+  SlidersHorizontal,
   Truck,
   X,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { cn } from '@/lib/utils';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils/cn';
 import { usePlanStore } from '@/lib/store/usePlanStore';
 import { useSceneStore } from '@/lib/store/useSceneStore';
-import { VehicleType, type Vehicle } from '@/lib/types/vehicle';
+import { useDebounce } from '@/lib/utils/useDebounce';
+import { VehicleType, type Vehicle, type VehicleType as VehicleTypeValue } from '@/lib/types/vehicle';
 import { useVehicles } from '@/lib/api/useVehicles';
 import { AddVehicleModal } from './AddVehicleModal';
 import { SelectedBoxPanel } from './SelectedBoxPanel';
+
+// ─── Vehicle type filter metadata ────────────────────────────────────────────
+
+const VEHICLE_TYPE_META: Record<VehicleTypeValue, { label: string; icon: typeof Truck }> = {
+  [VehicleType.Tir]: { label: 'Tır', icon: Truck },
+  [VehicleType.Kamyon]: { label: 'Kamyon', icon: Truck },
+  [VehicleType.Kamposet]: { label: 'Kamposet', icon: Truck },
+  [VehicleType.Konteyner]: { label: 'Konteyner', icon: Container },
+};
 
 // ─── Vehicle edit schema ──────────────────────────────────────────────────────
 
@@ -35,13 +74,14 @@ const vehicleEditSchema = z.object({
 
 type VehicleEditValues = z.infer<typeof vehicleEditSchema>;
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
 // ─── VehicleListItem ──────────────────────────────────────────────────────────
 
 interface VehicleListItemProps {
   vehicle: Vehicle;
   isSelected: boolean;
+  dragHandleRef?: (el: HTMLElement | null) => void;
+  dragHandleListeners?: Record<string, unknown>;
+  dragHandleAttributes?: Record<string, unknown>;
   onSelect: (v: Vehicle) => void;
   onEdit: (v: Vehicle) => void;
   onDelete: (id: string) => void;
@@ -50,6 +90,9 @@ interface VehicleListItemProps {
 function VehicleListItem({
   vehicle,
   isSelected,
+  dragHandleRef,
+  dragHandleListeners,
+  dragHandleAttributes,
   onSelect,
   onEdit,
   onDelete,
@@ -60,10 +103,27 @@ function VehicleListItem({
   return (
     <div
       className={cn(
-        'group/item flex items-center gap-2.5 px-3 py-2.5 rounded-lg transition-colors',
+        'group/item flex items-center gap-2 px-3 py-2.5 rounded-lg transition-colors',
         isSelected ? 'bg-zinc-900 text-white' : 'hover:bg-zinc-50 text-zinc-700',
       )}
     >
+      {/* Drag handle */}
+      {dragHandleRef && (
+        <button
+          ref={dragHandleRef}
+          {...(dragHandleListeners as HTMLAttributes<HTMLButtonElement>)}
+          {...(dragHandleAttributes as HTMLAttributes<HTMLButtonElement>)}
+          className={cn(
+            'shrink-0 w-4 flex items-center justify-center cursor-grab active:cursor-grabbing touch-none',
+            isSelected ? 'text-zinc-500 hover:text-zinc-300' : 'text-zinc-200 hover:text-zinc-400',
+          )}
+          title="Sırasını değiştir"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <GripVertical className="w-3.5 h-3.5" />
+        </button>
+      )}
+
       <button
         onClick={() => onSelect(vehicle)}
         className="flex items-center gap-2.5 flex-1 min-w-0 text-left"
@@ -117,6 +177,39 @@ function VehicleListItem({
   );
 }
 
+// ─── SortableVehicleListItem ──────────────────────────────────────────────────
+
+interface SortableVehicleListItemProps extends Omit<VehicleListItemProps, 'dragHandleRef' | 'dragHandleListeners' | 'dragHandleAttributes'> {
+  id: string;
+}
+
+function SortableVehicleListItem({ id, ...itemProps }: SortableVehicleListItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(isDragging && 'opacity-40 z-50 relative')}
+    >
+      <VehicleListItem
+        {...itemProps}
+        dragHandleRef={setActivatorNodeRef}
+        dragHandleListeners={listeners as Record<string, unknown>}
+        dragHandleAttributes={attributes as unknown as Record<string, unknown>}
+      />
+    </div>
+  );
+}
+
 // ─── PlanSummaryPanel ─────────────────────────────────────────────────────────
 
 function PlanSummaryPanel() {
@@ -124,17 +217,20 @@ function PlanSummaryPanel() {
   const placements = usePlanStore((s) => s.placements);
   const selectedItems = usePlanStore((s) => s.selectedItems);
 
+  // AC4: debounce 200ms so rapid quantity changes don't cause jank
+  const debouncedPlacements = useDebounce(placements, 200);
+
   const stats = useMemo(() => {
     if (!selectedVehicle) return null;
     const vehicleVol = selectedVehicle.width * selectedVehicle.height * selectedVehicle.length;
     const weightMap = new Map(selectedItems.map(({ item }) => [item.id, item.weight]));
-    const cargoVolCm3 = placements.reduce((s, p) => s + p.width * p.height * p.depth, 0);
-    const totalWeight = placements.reduce((s, p) => s + (weightMap.get(p.itemId) ?? 0), 0);
+    const cargoVolCm3 = debouncedPlacements.reduce((s, p) => s + p.width * p.height * p.depth, 0);
+    const totalWeight = debouncedPlacements.reduce((s, p) => s + (weightMap.get(p.itemId) ?? 0), 0);
     const volumePct =
       vehicleVol > 0 ? Math.min(100, Math.round((cargoVolCm3 / vehicleVol) * 100)) : 0;
     const remainingM3 = parseFloat(Math.max(0, (vehicleVol - cargoVolCm3) / 1_000_000).toFixed(2));
-    return { volumePct, totalWeight, remainingM3, placedCount: placements.length };
-  }, [placements, selectedVehicle, selectedItems]);
+    return { volumePct, totalWeight, remainingM3, placedCount: debouncedPlacements.length };
+  }, [debouncedPlacements, selectedVehicle, selectedItems]);
 
   if (!stats) {
     return (
@@ -304,6 +400,56 @@ export function PlanRightPanel({ vehiclesOpen = true, onToggleVehicles }: PlanRi
   const [showVehicleModal, setShowVehicleModal] = useState(false);
   const [editingVehicleId, setEditingVehicleId] = useState<string | null>(null);
   const hasAutoClosedRef = useRef(false);
+  const [vehicleSearch, setVehicleSearch] = useState('');
+  const [activeVehicleTypes, setActiveVehicleTypes] = useState<Set<VehicleTypeValue>>(new Set());
+  // Local order state for drag-and-drop (server order is the initial order)
+  const [vehicleOrder, setVehicleOrder] = useState<string[]>([]);
+
+  // Initialize local order when vehicles load; keep in sync when server adds/removes vehicles
+  useEffect(() => {
+    if (vehicles.length === 0) return;
+    const serverIds = vehicles.map((v) => v.id);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setVehicleOrder((prev) => {
+      if (prev.length === 0) return serverIds;
+      const prevSet = new Set(prev);
+      const newIds = serverIds.filter((id) => !prevSet.has(id));
+      const retained = prev.filter((id) => serverIds.includes(id));
+      return [...retained, ...newIds];
+    });
+  }, [vehicles]);
+
+  // Sorted + filtered vehicle list
+  const displayedVehicles = useMemo(() => {
+    const ordered =
+      vehicleOrder.length > 0
+        ? vehicleOrder
+            .map((id) => vehicles.find((v) => v.id === id))
+            .filter((v): v is Vehicle => v !== undefined)
+        : vehicles;
+    return ordered.filter((v) => {
+      if (vehicleSearch.trim() && !v.name.toLowerCase().includes(vehicleSearch.toLowerCase()))
+        return false;
+      if (activeVehicleTypes.size > 0 && !activeVehicleTypes.has(v.vehicleType)) return false;
+      return true;
+    });
+  }, [vehicles, vehicleOrder, vehicleSearch, activeVehicleTypes]);
+
+  // DnD sensors
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleVehicleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setVehicleOrder((ids) => {
+      const oldIndex = ids.indexOf(active.id as string);
+      const newIndex = ids.indexOf(over.id as string);
+      return arrayMove(ids, oldIndex, newIndex);
+    });
+  }
 
   useEffect(() => {
     if (!pendingSelectIdRef.current) return;
@@ -338,6 +484,7 @@ export function PlanRightPanel({ vehiclesOpen = true, onToggleVehicles }: PlanRi
 
   function handleDeleteVehicle(id: string) {
     if (selectedVehicle?.id === id) setVehicle(null);
+    setVehicleOrder((prev) => prev.filter((oid) => oid !== id));
   }
 
   function handleUpdateVehicle(v: Vehicle) {
@@ -345,9 +492,15 @@ export function PlanRightPanel({ vehiclesOpen = true, onToggleVehicles }: PlanRi
     setEditingVehicleId(null);
   }
 
+  // DnD items list (use vehicleOrder IDs for SortableContext)
+  const sortableIds = useMemo(() => {
+    if (vehicleSearch.trim()) return displayedVehicles.map((v) => v.id);
+    return vehicleOrder.length > 0 ? vehicleOrder : vehicles.map((v) => v.id);
+  }, [vehicleOrder, vehicles, vehicleSearch, displayedVehicles]);
+
   return (
     <div className="h-full flex flex-col gap-3">
-      {/* ── Kutu 1: Araçlar — wrapper+toggle birlikte kayar, kutu biraz daha ileri gider */}
+      {/* ── Kutu 1: Araçlar — wrapper+toggle birlikte kayar */}
       <div
         className={cn(
           'relative flex-1 min-h-0',
@@ -355,7 +508,7 @@ export function PlanRightPanel({ vehiclesOpen = true, onToggleVehicles }: PlanRi
           !vehiclesOpen && 'translate-x-[calc(100%-0.75rem)]',
         )}
       >
-        {/* Toggle butonu — wrapper ile kayar, ekranın sağ kenarına oturur */}
+        {/* Toggle butonu */}
         {onToggleVehicles && (
           <button
             onClick={onToggleVehicles}
@@ -393,11 +546,101 @@ export function PlanRightPanel({ vehiclesOpen = true, onToggleVehicles }: PlanRi
             </Button>
           </div>
 
+          {/* Vehicle search + type filter */}
+          <div className="px-2 pt-2 pb-1 shrink-0 flex items-center gap-1.5">
+            <div className="relative flex-1">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-400 pointer-events-none" />
+              <Input
+                value={vehicleSearch}
+                onChange={(e) => setVehicleSearch(e.target.value)}
+                placeholder="Araç adı ile ara…"
+                className="h-7 pl-8 pr-7 text-xs bg-zinc-50 border-zinc-200 focus-visible:ring-1 focus-visible:ring-zinc-300"
+              />
+              {vehicleSearch && (
+                <button
+                  onClick={() => setVehicleSearch('')}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600"
+                >
+                  <X className="w-3 h-3" />
+                </button>
+              )}
+            </div>
+
+            {/* Vehicle type filter */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  title="Araç tipine göre filtrele"
+                  className={cn(
+                    'h-7 w-7 shrink-0 border-zinc-200',
+                    activeVehicleTypes.size > 0
+                      ? 'bg-zinc-900 text-white border-zinc-900 hover:bg-zinc-700 hover:border-zinc-700'
+                      : 'bg-zinc-50 text-zinc-500 hover:text-zinc-800 hover:bg-zinc-100',
+                  )}
+                >
+                  <SlidersHorizontal className="w-3.5 h-3.5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                <DropdownMenuLabel className="text-[10px] font-semibold text-zinc-500 uppercase tracking-wide py-1">
+                  Araç Tipi
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                {(Object.entries(VEHICLE_TYPE_META) as [VehicleTypeValue, { label: string; icon: typeof Truck }][]).map(
+                  ([key, meta]) => {
+                    const Icon = meta.icon;
+                    return (
+                      <DropdownMenuCheckboxItem
+                        key={key}
+                        checked={activeVehicleTypes.has(key)}
+                        onCheckedChange={(checked: boolean) => {
+                          setActiveVehicleTypes((prev) => {
+                            const next = new Set(prev);
+                            if (checked) next.add(key);
+                            else next.delete(key);
+                            return next;
+                          });
+                        }}
+                        onSelect={(e: Event) => e.preventDefault()}
+                        className="text-xs gap-2"
+                      >
+                        <Icon className="w-3.5 h-3.5 text-zinc-500" />
+                        {meta.label}
+                      </DropdownMenuCheckboxItem>
+                    );
+                  },
+                )}
+                {activeVehicleTypes.size > 0 && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <button
+                      onClick={() => setActiveVehicleTypes(new Set())}
+                      className="w-full text-[10px] text-zinc-400 hover:text-zinc-700 px-2 py-1.5 text-left transition-colors"
+                    >
+                      Filtreleri temizle
+                    </button>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
           <div className="flex-1 min-h-0 overflow-y-auto p-2 flex flex-col gap-0.5">
             {vehiclesLoading ? (
               <div className="flex items-center justify-center py-8 text-zinc-400 text-xs">
                 <Loader2 className="w-4 h-4 animate-spin mr-2" />
                 Araçlar yükleniyor…
+              </div>
+            ) : displayedVehicles.length === 0 && (vehicleSearch || activeVehicleTypes.size > 0) ? (
+              <div className="flex flex-col items-center justify-center py-8 text-center gap-2">
+                <Search className="w-6 h-6 text-zinc-200" />
+                <p className="text-xs text-zinc-400">
+                  {vehicleSearch
+                    ? `"${vehicleSearch}" için araç bulunamadı`
+                    : 'Seçili araç tipinde sonuç yok'}
+                </p>
               </div>
             ) : vehicles.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-8 text-center gap-2">
@@ -405,16 +648,25 @@ export function PlanRightPanel({ vehiclesOpen = true, onToggleVehicles }: PlanRi
                 <p className="text-xs text-zinc-400">Henüz araç eklenmemiş</p>
               </div>
             ) : (
-              vehicles.map((v) => (
-                <VehicleListItem
-                  key={v.id}
-                  vehicle={v}
-                  isSelected={selectedVehicle?.id === v.id}
-                  onSelect={handleSelectVehicle}
-                  onEdit={handleEditVehicle}
-                  onDelete={handleDeleteVehicle}
-                />
-              ))
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleVehicleDragEnd}
+              >
+                <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+                  {displayedVehicles.map((v) => (
+                    <SortableVehicleListItem
+                      key={v.id}
+                      id={v.id}
+                      vehicle={v}
+                      isSelected={selectedVehicle?.id === v.id}
+                      onSelect={handleSelectVehicle}
+                      onEdit={handleEditVehicle}
+                      onDelete={handleDeleteVehicle}
+                    />
+                  ))}
+                </SortableContext>
+              </DndContext>
             )}
           </div>
         </div>

--- a/apps/frontend/src/features/planning/components/PlanRightPanel.tsx
+++ b/apps/frontend/src/features/planning/components/PlanRightPanel.tsx
@@ -49,7 +49,11 @@ import { cn } from '@/lib/utils/cn';
 import { usePlanStore } from '@/lib/store/usePlanStore';
 import { useSceneStore } from '@/lib/store/useSceneStore';
 import { useDebounce } from '@/lib/utils/useDebounce';
-import { VehicleType, type Vehicle, type VehicleType as VehicleTypeValue } from '@/lib/types/vehicle';
+import {
+  VehicleType,
+  type Vehicle,
+  type VehicleType as VehicleTypeValue,
+} from '@/lib/types/vehicle';
 import { useVehicles } from '@/lib/api/useVehicles';
 import { AddVehicleModal } from './AddVehicleModal';
 import { SelectedBoxPanel } from './SelectedBoxPanel';
@@ -179,7 +183,10 @@ function VehicleListItem({
 
 // ─── SortableVehicleListItem ──────────────────────────────────────────────────
 
-interface SortableVehicleListItemProps extends Omit<VehicleListItemProps, 'dragHandleRef' | 'dragHandleListeners' | 'dragHandleAttributes'> {
+interface SortableVehicleListItemProps extends Omit<
+  VehicleListItemProps,
+  'dragHandleRef' | 'dragHandleListeners' | 'dragHandleAttributes'
+> {
   id: string;
 }
 
@@ -588,30 +595,33 @@ export function PlanRightPanel({ vehiclesOpen = true, onToggleVehicles }: PlanRi
                   Araç Tipi
                 </DropdownMenuLabel>
                 <DropdownMenuSeparator />
-                {(Object.entries(VEHICLE_TYPE_META) as [VehicleTypeValue, { label: string; icon: typeof Truck }][]).map(
-                  ([key, meta]) => {
-                    const Icon = meta.icon;
-                    return (
-                      <DropdownMenuCheckboxItem
-                        key={key}
-                        checked={activeVehicleTypes.has(key)}
-                        onCheckedChange={(checked: boolean) => {
-                          setActiveVehicleTypes((prev) => {
-                            const next = new Set(prev);
-                            if (checked) next.add(key);
-                            else next.delete(key);
-                            return next;
-                          });
-                        }}
-                        onSelect={(e: Event) => e.preventDefault()}
-                        className="text-xs gap-2"
-                      >
-                        <Icon className="w-3.5 h-3.5 text-zinc-500" />
-                        {meta.label}
-                      </DropdownMenuCheckboxItem>
-                    );
-                  },
-                )}
+                {(
+                  Object.entries(VEHICLE_TYPE_META) as [
+                    VehicleTypeValue,
+                    { label: string; icon: typeof Truck },
+                  ][]
+                ).map(([key, meta]) => {
+                  const Icon = meta.icon;
+                  return (
+                    <DropdownMenuCheckboxItem
+                      key={key}
+                      checked={activeVehicleTypes.has(key)}
+                      onCheckedChange={(checked: boolean) => {
+                        setActiveVehicleTypes((prev) => {
+                          const next = new Set(prev);
+                          if (checked) next.add(key);
+                          else next.delete(key);
+                          return next;
+                        });
+                      }}
+                      onSelect={(e: Event) => e.preventDefault()}
+                      className="text-xs gap-2"
+                    >
+                      <Icon className="w-3.5 h-3.5 text-zinc-500" />
+                      {meta.label}
+                    </DropdownMenuCheckboxItem>
+                  );
+                })}
                 {activeVehicleTypes.size > 0 && (
                   <>
                     <DropdownMenuSeparator />

--- a/apps/frontend/src/lib/store/usePlanStore.ts
+++ b/apps/frontend/src/lib/store/usePlanStore.ts
@@ -369,7 +369,8 @@ export const usePlanStore = create<PlanStore>((set) => ({
       const newIdx = items.findIndex((si) => si.item.id === overId);
       if (oldIdx === -1 || newIdx === -1) return {};
       const [removed] = items.splice(oldIdx, 1);
-      items.splice(newIdx, 0, removed);
+      const insertIdx = oldIdx < newIdx ? newIdx - 1 : newIdx;
+      items.splice(insertIdx, 0, removed);
       return { selectedItems: items };
     }),
 

--- a/apps/frontend/src/lib/store/usePlanStore.ts
+++ b/apps/frontend/src/lib/store/usePlanStore.ts
@@ -166,6 +166,7 @@ interface PlanStore {
    */
   mockPlacements: (count: number) => void;
   updatePlacementPosition: (idx: number, x: number, y: number, z: number) => void;
+  reorderItems: (activeId: string, overId: string) => void;
   setPreview: (itemId: string, item: Item, qty: number, color: string) => void;
   clearPreview: () => void;
   reset: () => void;
@@ -359,6 +360,17 @@ export const usePlanStore = create<PlanStore>((set) => ({
         i === idx ? { ...p, positionX: x, positionY: y, positionZ: z } : p,
       );
       return { placements: computeViolations(next) };
+    }),
+
+  reorderItems: (activeId, overId) =>
+    set((s) => {
+      const items = [...s.selectedItems];
+      const oldIdx = items.findIndex((si) => si.item.id === activeId);
+      const newIdx = items.findIndex((si) => si.item.id === overId);
+      if (oldIdx === -1 || newIdx === -1) return {};
+      const [removed] = items.splice(oldIdx, 1);
+      items.splice(newIdx, 0, removed);
+      return { selectedItems: items };
     }),
 
   setPreview: (itemId, item, qty, color) =>

--- a/apps/frontend/src/lib/utils/useDebounce.ts
+++ b/apps/frontend/src/lib/utils/useDebounce.ts
@@ -1,0 +1,10 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+  return debouncedValue;
+}


### PR DESCRIPTION
 ## Özet                                                             

  Ürün ve araç listelerine isim bazlı arama çubuğu, kısıt/tip filtresi, drag-and-drop sıralama ve                  
  100+ öğe için virtual list altyapısı eklendi. Plan özeti göstergeleri debounce ile güncelleniyor.
                                                                                                                   
  ## İlgili User Story / Issue                           

  US-3D-23

  ## Değişiklik Tipi

  - [x] 🚀 Yeni özellik (feature)

  ## Test Edildi mi?

  - [x] Manuel test yapıldı

  ## Kontrol Listesi

  - [x] Kod standartlarına uygun
  - [x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
  - [x] Linter hataları yok
  - [x] Self-review yapıldı
  - [ ] Dokümantasyon güncellendi (gerekiyorsa)

  ## Ek Notlar

  **Ürün listesi (PlanLeftPanel)**
  - Arama çubuğu yalnızca ürün adını arar
  - Kısıt filtresi (`SlidersHorizontal` butonu) → Kırılgan, Tehlikeli Mad., Yan Yükleme, Alt Katman — çoklu seçim
  destekli, aktif olunca buton siyahlaşıyor
  - Her karta drag handle eklendi (`@dnd-kit/sortable`), sıra `usePlanStore.reorderItems` ile persist ediliyor
  - 100+ ürün durumunda `@tanstack/react-virtual` devreye giriyor, `VIRTUAL_THRESHOLD` sabitini chapter lead
  belirler

  **Araç listesi (PlanRightPanel)**
  - Aynı arama + filtre yapısı araçlar için de eklendi; filtre seçenekleri: Tır, Kamyon, Kamposet, Konteyner
  - Araç sırası local state ile yönetiliyor (server state'i bozmamak için)
  - Plan Özeti hacim/ağırlık değerleri `useDebounce(200ms)` ile güncelleniyor

  **Yeni bağımlılıklar:** `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities`, `@tanstack/react-virtual`

  **Yeni dosya:** `lib/utils/useDebounce.ts`

  **Güncellenen shared bileşen:** `dropdown-menu.tsx` — `DropdownMenuCheckboxItem` shadcn standardında eklendi