### PR TITLE
feat: Notification Domain Entity and Migration (BE-NTF-01-1)

### DIFF
--- a/apps/backend/CargoPilot.Domain/Entities/Notification.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/Notification.cs
@@ -1,0 +1,44 @@
+using CargoPilot.Domain.Enums;
+
+namespace CargoPilot.Domain.Entities;
+
+public sealed class Notification : BaseEntity
+{
+    public Guid UserId { get; private set; }
+    public Guid? CompanyId { get; private set; }
+    public NotificationType Type { get; private set; }
+    public NotificationSeverity Severity { get; private set; }
+    public string Title { get; private set; } = null!;
+    public string Description { get; private set; } = null!;
+    public string? ActionUrl { get; private set; }
+    public bool IsRead { get; private set; }
+    public DateTime? ReadAt { get; private set; }
+
+    private Notification() { }
+
+    public Notification(
+        Guid id,
+        Guid userId,
+        Guid? companyId,
+        NotificationType type,
+        NotificationSeverity severity,
+        string title,
+        string description,
+        string? actionUrl = null) : base(id)
+    {
+        UserId = userId;
+        CompanyId = companyId;
+        Type = type;
+        Severity = severity;
+        Title = title;
+        Description = description;
+        ActionUrl = actionUrl;
+        IsRead = false;
+    }
+
+    public void MarkAsRead()
+    {
+        IsRead = true;
+        ReadAt = DateTime.UtcNow;
+    }
+}

--- a/apps/backend/CargoPilot.Domain/Enums/NotificationSeverity.cs
+++ b/apps/backend/CargoPilot.Domain/Enums/NotificationSeverity.cs
@@ -1,0 +1,9 @@
+namespace CargoPilot.Domain.Enums;
+
+public enum NotificationSeverity
+{
+    Info,
+    Success,
+    Warning,
+    Error
+}

--- a/apps/backend/CargoPilot.Domain/Enums/NotificationType.cs
+++ b/apps/backend/CargoPilot.Domain/Enums/NotificationType.cs
@@ -1,0 +1,21 @@
+#pragma warning disable CA1707 // Notification type identifiers follow UPPER_SNAKE_CASE by domain convention
+namespace CargoPilot.Domain.Enums;
+
+public enum NotificationType
+{
+    ERP_SYNC_ERROR,
+    REPORT_READY,
+    REPORT_ERROR,
+    OPTIMIZATION_COMPLETE,
+    OPTIMIZATION_FAILED,
+    TRIAL_EXPIRING,
+    TRIAL_EXPIRED,
+    PAYMENT_SUCCESS,
+    PAYMENT_FAILED,
+    SUBSCRIPTION_RENEWED,
+    SUBSCRIPTION_CANCELLED,
+    PLAN_UPGRADED,
+    PLAN_DOWNGRADED,
+    USAGE_LIMIT_WARNING,
+    USAGE_LIMIT_REACHED
+}

--- a/apps/backend/CargoPilot.Domain/Enums/NotificationType.cs
+++ b/apps/backend/CargoPilot.Domain/Enums/NotificationType.cs
@@ -1,21 +1,20 @@
-#pragma warning disable CA1707 // Notification type identifiers follow UPPER_SNAKE_CASE by domain convention
 namespace CargoPilot.Domain.Enums;
 
 public enum NotificationType
 {
-    ERP_SYNC_ERROR,
-    REPORT_READY,
-    REPORT_ERROR,
-    OPTIMIZATION_COMPLETE,
-    OPTIMIZATION_FAILED,
-    TRIAL_EXPIRING,
-    TRIAL_EXPIRED,
-    PAYMENT_SUCCESS,
-    PAYMENT_FAILED,
-    SUBSCRIPTION_RENEWED,
-    SUBSCRIPTION_CANCELLED,
-    PLAN_UPGRADED,
-    PLAN_DOWNGRADED,
-    USAGE_LIMIT_WARNING,
-    USAGE_LIMIT_REACHED
+    ErpSyncError,
+    ReportReady,
+    ReportError,
+    OptimizationComplete,
+    OptimizationFailed,
+    TrialExpiring,
+    TrialExpired,
+    PaymentSuccess,
+    PaymentFailed,
+    SubscriptionRenewed,
+    SubscriptionCancelled,
+    PlanUpgraded,
+    PlanDowngraded,
+    UsageLimitWarning,
+    UsageLimitReached
 }

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContext.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContext.cs
@@ -30,6 +30,7 @@ public class AppDbContext : DbContext {
     public DbSet<Integration> Integrations => Set<Integration>();
     public DbSet<SyncLog> SyncLogs => Set<SyncLog>();
     public DbSet<ErpUserMapping> ErpUserMappings => Set<ErpUserMapping>();
+    public DbSet<Notification> Notifications => Set<Notification>();
 
     public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) {
         ApplyAuditFields();
@@ -59,6 +60,7 @@ public class AppDbContext : DbContext {
         modelBuilder.ApplyConfiguration(new IntegrationConfiguration());
         modelBuilder.ApplyConfiguration(new SyncLogConfiguration());
         modelBuilder.ApplyConfiguration(new ErpUserMappingConfiguration());
+        modelBuilder.ApplyConfiguration(new NotificationConfiguration());
     }
 
     private void ApplyAuditFields() {

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/NotificationConfiguration.cs
@@ -1,0 +1,67 @@
+using CargoPilot.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CargoPilot.Infrastructure.Persistence.Configurations;
+
+internal sealed class NotificationConfiguration : IEntityTypeConfiguration<Notification>
+{
+    public void Configure(EntityTypeBuilder<Notification> builder)
+    {
+        builder.ToTable("Notifications");
+        builder.HasKey(n => n.Id);
+
+        builder.Property(n => n.CreatedAtUtc)
+            .IsRequired()
+            .HasDefaultValueSql("GETUTCDATE()");
+
+        builder.Property(n => n.CreatedBy);
+        builder.Property(n => n.UpdatedAtUtc);
+        builder.Property(n => n.UpdatedBy);
+
+        builder.Property(n => n.IsDeleted)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(n => n.IsActive)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(n => n.UserId)
+            .IsRequired();
+
+        builder.Property(n => n.CompanyId);
+
+        builder.Property(n => n.Type)
+            .IsRequired()
+            .HasMaxLength(64)
+            .HasConversion<string>();
+
+        builder.Property(n => n.Severity)
+            .IsRequired()
+            .HasMaxLength(32)
+            .HasConversion<string>();
+
+        builder.Property(n => n.Title)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(n => n.Description)
+            .IsRequired()
+            .HasMaxLength(1000);
+
+        builder.Property(n => n.ActionUrl)
+            .HasMaxLength(500);
+
+        builder.Property(n => n.IsRead)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(n => n.ReadAt);
+
+        builder.HasIndex(n => new { n.UserId, n.IsDeleted });
+        builder.HasIndex(n => new { n.CompanyId, n.Type, n.CreatedAtUtc });
+
+        builder.HasQueryFilter(n => !n.IsDeleted);
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260509085606_AddNotificationTable.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260509085606_AddNotificationTable.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260509085606_AddNotificationTable")]
+    partial class AddNotificationTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260509085606_AddNotificationTable.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260509085606_AddNotificationTable.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNotificationTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Notifications",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CompanyId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Type = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    Severity = table.Column<string>(type: "nvarchar(32)", maxLength: 32, nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: false),
+                    ActionUrl = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: true),
+                    IsRead = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    ReadAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    DeletedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false, defaultValue: true),
+                    CreatedBy = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Notifications", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_CompanyId_Type_CreatedAtUtc",
+                table: "Notifications",
+                columns: new[] { "CompanyId", "Type", "CreatedAtUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notifications_UserId_IsDeleted",
+                table: "Notifications",
+                columns: new[] { "UserId", "IsDeleted" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Notifications");
+        }
+    }
+}


### PR DESCRIPTION
Özet
Bu PR, Cargo Pilot sistemine eklenecek olan Bildirim (Notification) modülünün temel Domain modellerini ve veritabanı altyapısını (Migration) içerir.

NotificationType (15 farklı tip) ve NotificationSeverity (Info, Success, Warning, Error) enum'ları oluşturuldu.

BaseEntity'den türeyen Notification entity'si yazıldı.

NotificationConfiguration üzerinden EF Core ayarları yapılarak, Enum'ların veritabanında string olarak tutulması sağlandı. İlgili nvarchar kısıtlamaları ve okuma performansını artıracak composite index'ler eklendi.

İlgili User Story / Issue
Task: BE-NTF-01-1 — Notification Domain Modeli ve Migration

Değişiklik Tipi
[x] 🚀 Yeni özellik (feature)

[ ] 🐛 Bug düzeltme (bugfix)

Test Edildi mi?
[x] Manuel test yapıldı
(SSMS üzerinden CargoPilotTest veritabanında kontroller yapıldı. Tablo şemasındaki nvarchar sınırlarının doğruluğu, BaseEntity alanlarının geldiği, indexlerin oluştuğu teyit edildi. Ayrıca manuel INSERT sorgusu atılarak enum değerlerinin ('REPORT_READY', 'Success' vb.) veritabanına sorunsuz bir şekilde string olarak kaydedildiği doğrulandı.)

Kontrol Listesi
[x] Kod standartlarına uygun

[x] Commit mesajları [commit kurallarına](https://www.google.com/search?q=docs/conventions/COMMITS.md) uygun

[x] Linter hataları yok

[x] Self-review yapıldı

[x ] Dokümantasyon güncellendi (gerekiyorsa)