### PR TITLE
nginx api proxy ve frontend api base url ayarı güncellendi

### DIFF
--- a/apps/frontend/nginx.conf
+++ b/apps/frontend/nginx.conf
@@ -4,6 +4,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    location /api {
+        proxy_pass http://backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -56,10 +56,9 @@ services:
       context: ../../apps/frontend
       dockerfile: Dockerfile
       args:
-        # VITE_API_BASE_URL: .env.test'te tanımla (nginx + domain için)
-        # Örnek: VITE_API_BASE_URL=https://cargopilot.divizyon.org
-        # Tanımlanmazsa local fallback kullanılır.
-        VITE_API_BASE_URL: ${VITE_API_BASE_URL:-http://${SERVER_HOST:-localhost}:${BACKEND_PORT}}
+        # VITE_API_BASE_URL: Boş bırakılırsa nginx /api proxy devreye girer (CORS yok).
+        # Domain için: VITE_API_BASE_URL=https://cargopilot.divizyon.org
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL-}
         VITE_APP_VERSION: ${APP_VERSION:-dev}
         VITE_APP_ENV: test
         VITE_OAUTH_GOOGLE_URL: ${VITE_OAUTH_GOOGLE_URL:-}


### PR DESCRIPTION
## Özet

- `apps/frontend/nginx.conf` — `/api` location bloğu eklendi; frontend container içindeki Nginx, API isteklerini `backend:8080`'e proxy eder (CORS yok)
- `infra/compose/docker-compose.test.yml` — `VITE_API_BASE_URL` build arg `:-` yerine `-` ile set edildi; değer tanımlanmadığında boş geçer, frontend relative URL ile nginx proxy'yi devreye sokar

## İlgili User Story / Issue

US-D34

## Değişiklik Tipi

- [x] 🚀 Yeni özellik (feature)

## Test Edildi mi?

- [x] Manuel test yapıldı

## Dev Doğrulaması

- [x] PR #439 dev'e merge edildi, CI yeşil geçti

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Self-review yapıldı