### PR TITLE
gereksiz CORS_ALLOWED_ORIGIN_1 kaldırıldı (US-D34)

### DIFF
--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -28,7 +28,6 @@ services:
       OAuth__Google__CallbackUrl: ${GOOGLE_OAUTH_CALLBACK_URL:-}
       OAuth__Google__FrontendCallbackUrl: ${GOOGLE_OAUTH_FRONTEND_CALLBACK_URL:-}
       Cors__AllowedOrigins__0: ${CORS_ALLOWED_ORIGIN_0:-}
-      Cors__AllowedOrigins__1: ${CORS_ALLOWED_ORIGIN_1:-}
       Resend__ApiKey: ${RESEND_API_KEY:-}
       Resend__FromEmail: ${RESEND_FROM_EMAIL:-}
       Resend__FromName: ${RESEND_FROM_NAME:-}


### PR DESCRIPTION
## Özet

- `Cors__AllowedOrigins__1` satırı `docker-compose.test.yml`'den kaldırıldı
- Nginx proxy (PR #440) ve Vite'ın mevcut proxy config'i (`vite.config.ts`) CORS sorununu kökten çözdü — ikinci origin workaround'ına gerek kalmadı

## İlgili User Story / Issue

US-D34

## Değişiklik Tipi

- [x] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x] Manuel test yapıldı

## Dev Doğrulaması

- [x] PR #441 dev'e merge edildi, CI yeşil geçti

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Self-review yapıldı