### PR TITLE
Feature/vy erp sync settings

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Interfaces/IIntegrationRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/IIntegrationRepository.cs
@@ -1,0 +1,11 @@
+using CargoPilot.Domain.Entities;
+
+namespace CargoPilot.Application.Common.Interfaces;
+
+public interface IIntegrationRepository
+{
+    Task<Integration?> GetByIdAsync(Guid id, Guid companyId, CancellationToken cancellationToken = default);
+    Task<bool> HasAnyRunningSyncAsync(Guid companyId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<Integration>> ListByCompanyAsync(Guid companyId, CancellationToken cancellationToken = default);
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/GetSyncSettings/GetSyncSettingsQuery.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/GetSyncSettings/GetSyncSettingsQuery.cs
@@ -1,0 +1,6 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.GetSyncSettings;
+
+public record GetSyncSettingsQuery(Guid IntegrationId) : IRequest<Result<SyncSettingsResponse>>;

--- a/apps/backend/CargoPilot.Application/Features/Integrations/GetSyncSettings/GetSyncSettingsQueryHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/GetSyncSettings/GetSyncSettingsQueryHandler.cs
@@ -1,0 +1,42 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.GetSyncSettings;
+
+public sealed class GetSyncSettingsQueryHandler : IRequestHandler<GetSyncSettingsQuery, Result<SyncSettingsResponse>>
+{
+    private readonly IIntegrationRepository _integrationRepository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public GetSyncSettingsQueryHandler(
+        IIntegrationRepository integrationRepository,
+        ICurrentUserService currentUserService)
+    {
+        _integrationRepository = integrationRepository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<Result<SyncSettingsResponse>> Handle(GetSyncSettingsQuery request, CancellationToken cancellationToken)
+    {
+        var companyId = _currentUserService.CompanyId;
+        if (companyId is null)
+            return Result<SyncSettingsResponse>.Failure(
+                new Error(ErrorType.Unauthorized, "Auth.NoCompany", "Şirket bağlamı bulunamadı."));
+
+        var integration = await _integrationRepository.GetByIdAsync(request.IntegrationId, companyId.Value, cancellationToken);
+
+        if (integration is null)
+            return Result<SyncSettingsResponse>.Failure(
+                new Error(ErrorType.NotFound, "Integration.NotFound", "Entegrasyon bulunamadı."));
+
+        return Result<SyncSettingsResponse>.Success(new SyncSettingsResponse(
+            integration.Id,
+            integration.SyncFrequency,
+            integration.LastSyncDate,
+            integration.NextScheduledSyncAt,
+            integration.SyncStatus
+        ));
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/GetSyncSettings/SyncSettingsResponse.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/GetSyncSettings/SyncSettingsResponse.cs
@@ -1,0 +1,11 @@
+using CargoPilot.Domain.Enums;
+
+namespace CargoPilot.Application.Features.Integrations.GetSyncSettings;
+
+public record SyncSettingsResponse(
+    Guid IntegrationId,
+    SyncFrequency? SyncFrequency,
+    DateTime? LastSyncAt,
+    DateTime? NextScheduledSyncAt,
+    ErpSyncStatus SyncStatus
+);

--- a/apps/backend/CargoPilot.Application/Features/Integrations/ListIntegrations/ListIntegrationsQuery.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/ListIntegrations/ListIntegrationsQuery.cs
@@ -1,0 +1,8 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.ListIntegrations;
+
+public record ListIntegrationsQuery : IRequest<Result<IReadOnlyList<IntegrationSummary>>>;
+
+public record IntegrationSummary(Guid Id, string SystemName, string ApiEndpoint);

--- a/apps/backend/CargoPilot.Application/Features/Integrations/ListIntegrations/ListIntegrationsQueryHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/ListIntegrations/ListIntegrationsQueryHandler.cs
@@ -1,0 +1,38 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.ListIntegrations;
+
+public sealed class ListIntegrationsQueryHandler : IRequestHandler<ListIntegrationsQuery, Result<IReadOnlyList<IntegrationSummary>>>
+{
+    private readonly IIntegrationRepository _integrationRepository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public ListIntegrationsQueryHandler(
+        IIntegrationRepository integrationRepository,
+        ICurrentUserService currentUserService)
+    {
+        _integrationRepository = integrationRepository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<Result<IReadOnlyList<IntegrationSummary>>> Handle(
+        ListIntegrationsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var companyId = _currentUserService.CompanyId;
+        if (companyId is null)
+            return Result<IReadOnlyList<IntegrationSummary>>.Failure(
+                new Error(ErrorType.Unauthorized, "Auth.NoCompany", "Şirket bağlamı bulunamadı."));
+
+        var integrations = await _integrationRepository.ListByCompanyAsync(companyId.Value, cancellationToken);
+
+        var result = integrations
+            .Select(i => new IntegrationSummary(i.Id, i.SystemName, i.ApiEndpoint))
+            .ToList();
+
+        return Result<IReadOnlyList<IntegrationSummary>>.Success(result);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/TriggerSync/TriggerSyncCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/TriggerSync/TriggerSyncCommand.cs
@@ -1,0 +1,7 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Application.Features.Integrations.GetSyncSettings;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.TriggerSync;
+
+public record TriggerSyncCommand(Guid IntegrationId) : IRequest<Result<SyncSettingsResponse>>;

--- a/apps/backend/CargoPilot.Application/Features/Integrations/TriggerSync/TriggerSyncCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/TriggerSync/TriggerSyncCommandHandler.cs
@@ -1,0 +1,73 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Application.Features.Integrations.GetSyncSettings;
+using CargoPilot.Domain.Enums;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.TriggerSync;
+
+public sealed class TriggerSyncCommandHandler : IRequestHandler<TriggerSyncCommand, Result<SyncSettingsResponse>>
+{
+    private readonly IIntegrationRepository _integrationRepository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public TriggerSyncCommandHandler(
+        IIntegrationRepository integrationRepository,
+        ICurrentUserService currentUserService)
+    {
+        _integrationRepository = integrationRepository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<Result<SyncSettingsResponse>> Handle(TriggerSyncCommand request, CancellationToken cancellationToken)
+    {
+        var companyId = _currentUserService.CompanyId;
+        if (companyId is null)
+            return Result<SyncSettingsResponse>.Failure(
+                new Error(ErrorType.Unauthorized, "Auth.NoCompany", "Şirket bağlamı bulunamadı."));
+
+        // Şirket genelinde çalışan başka bir sync varsa engelle.
+        var hasRunning = await _integrationRepository.HasAnyRunningSyncAsync(companyId.Value, cancellationToken);
+        if (hasRunning)
+            return Result<SyncSettingsResponse>.Failure(
+                new Error(ErrorType.Conflict, "Sync.AlreadyRunning", "Şirket için senkronizasyon zaten çalışıyor."));
+
+        var integration = await _integrationRepository.GetByIdAsync(request.IntegrationId, companyId.Value, cancellationToken);
+
+        if (integration is null)
+            return Result<SyncSettingsResponse>.Failure(
+                new Error(ErrorType.NotFound, "Integration.NotFound", "Entegrasyon bulunamadı."));
+
+        integration.StartSync();
+        await _integrationRepository.SaveChangesAsync(cancellationToken);
+
+        try
+        {
+            await ExecuteSyncAsync();
+
+            var now = DateTime.UtcNow;
+            DateTime? nextScheduledSyncAt = integration.SyncFrequency.HasValue
+                ? now.Add(integration.SyncFrequency.Value.ToTimeSpan())
+                : null;
+
+            integration.CompleteSync(now, nextScheduledSyncAt);
+        }
+        catch (Exception)
+        {
+            integration.FailSync();
+        }
+
+        await _integrationRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<SyncSettingsResponse>.Success(new SyncSettingsResponse(
+            integration.Id,
+            integration.SyncFrequency,
+            integration.LastSyncDate,
+            integration.NextScheduledSyncAt,
+            integration.SyncStatus
+        ));
+    }
+
+    private static Task ExecuteSyncAsync() => Task.CompletedTask;
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/UpdateSyncSettings/UpdateSyncSettingsCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/UpdateSyncSettings/UpdateSyncSettingsCommand.cs
@@ -1,0 +1,11 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Application.Features.Integrations.GetSyncSettings;
+using CargoPilot.Domain.Enums;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.UpdateSyncSettings;
+
+public record UpdateSyncSettingsCommand(
+    Guid IntegrationId,
+    SyncFrequency? SyncFrequency
+) : IRequest<Result<SyncSettingsResponse>>;

--- a/apps/backend/CargoPilot.Application/Features/Integrations/UpdateSyncSettings/UpdateSyncSettingsCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/UpdateSyncSettings/UpdateSyncSettingsCommandHandler.cs
@@ -1,0 +1,65 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Application.Features.Integrations.GetSyncSettings;
+using CargoPilot.Domain.Enums;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.UpdateSyncSettings;
+
+public sealed class UpdateSyncSettingsCommandHandler : IRequestHandler<UpdateSyncSettingsCommand, Result<SyncSettingsResponse>>
+{
+    private readonly IIntegrationRepository _integrationRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IValidator<UpdateSyncSettingsCommand> _validator;
+
+    public UpdateSyncSettingsCommandHandler(
+        IIntegrationRepository integrationRepository,
+        ICurrentUserService currentUserService,
+        IValidator<UpdateSyncSettingsCommand> validator)
+    {
+        _integrationRepository = integrationRepository;
+        _currentUserService = currentUserService;
+        _validator = validator;
+    }
+
+    public async Task<Result<SyncSettingsResponse>> Handle(UpdateSyncSettingsCommand request, CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<SyncSettingsResponse>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var companyId = _currentUserService.CompanyId;
+        if (companyId is null)
+            return Result<SyncSettingsResponse>.Failure(
+                new Error(ErrorType.Unauthorized, "Auth.NoCompany", "Şirket bağlamı bulunamadı."));
+
+        var integration = await _integrationRepository.GetByIdAsync(request.IntegrationId, companyId.Value, cancellationToken);
+
+        if (integration is null)
+            return Result<SyncSettingsResponse>.Failure(
+                new Error(ErrorType.NotFound, "Integration.NotFound", "Entegrasyon bulunamadı."));
+
+        DateTime? nextScheduledSyncAt = request.SyncFrequency.HasValue
+            ? DateTime.UtcNow.Add(request.SyncFrequency.Value.ToTimeSpan())
+            : null;
+
+        integration.UpdateSyncSettings(request.SyncFrequency, nextScheduledSyncAt);
+        await _integrationRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<SyncSettingsResponse>.Success(new SyncSettingsResponse(
+            integration.Id,
+            integration.SyncFrequency,
+            integration.LastSyncDate,
+            integration.NextScheduledSyncAt,
+            integration.SyncStatus
+        ));
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/UpdateSyncSettings/UpdateSyncSettingsCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/UpdateSyncSettings/UpdateSyncSettingsCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Integrations.UpdateSyncSettings;
+
+public sealed class UpdateSyncSettingsCommandValidator : AbstractValidator<UpdateSyncSettingsCommand>
+{
+    public UpdateSyncSettingsCommandValidator()
+    {
+        RuleFor(x => x.IntegrationId).NotEmpty();
+        RuleFor(x => x.SyncFrequency)
+            .IsInEnum()
+            .When(x => x.SyncFrequency.HasValue);
+    }
+}

--- a/apps/backend/CargoPilot.Domain/Entities/AppUser.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/AppUser.cs
@@ -69,4 +69,6 @@ public sealed class AppUser : BaseEntity {
         FirstName = firstName.Trim();
         LastName = lastName.Trim();
     }
+
+    public void AssignToCompany(Guid companyId) => CompanyId = companyId;
 }

--- a/apps/backend/CargoPilot.Domain/Entities/AppUser.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/AppUser.cs
@@ -2,18 +2,48 @@ using CargoPilot.Domain.Enums;
 
 namespace CargoPilot.Domain.Entities;
 
+/// <summary>
+/// Represents an application user in the system.
+/// </summary>
 public sealed class AppUser : BaseEntity {
     private const int _maxFailedAttempts = 5;
     private const int _lockoutDurationMinutes = 15;
 
+    /// <summary>
+    /// Gets the company identifier associated with the user.
+    /// </summary>
     public Guid? CompanyId { get; private set; }
+    /// <summary>
+    /// Gets the user's first name.
+    /// </summary>
     public string FirstName { get; private set; } = null!;
+    /// <summary>
+    /// Gets the user's last name.
+    /// </summary>
     public string LastName { get; private set; } = null!;
+    /// <summary>
+    /// Gets the user's email address.
+    /// </summary>
     public string Email { get; private set; } = null!;
+    /// <summary>
+    /// Gets the user's password hash for local authentication.
+    /// </summary>
     public string? PasswordHash { get; private set; }
+    /// <summary>
+    /// Gets the user type.
+    /// </summary>
     public UserType UserType { get; private set; }
+    /// <summary>
+    /// Gets the user identifier in an external system.
+    /// </summary>
     public string? ExternalSystemId { get; private set; }
+    /// <summary>
+    /// Gets the authentication provider for the user.
+    /// </summary>
     public AuthProvider AuthProvider { get; private set; }
+    /// <summary>
+    /// Gets the number of consecutive failed login attempts.
+    /// </summary>
     public int FailedLoginAttempts { get; private set; }
     public DateTime? LockoutEndUtc { get; private set; }
     public bool TourCompleted { get; private set; }

--- a/apps/backend/CargoPilot.Domain/Entities/AppUser.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/AppUser.cs
@@ -45,18 +45,45 @@ public sealed class AppUser : BaseEntity {
     /// Gets the number of consecutive failed login attempts.
     /// </summary>
     public int FailedLoginAttempts { get; private set; }
+    /// <summary>
+    /// Gets the UTC date and time when the lockout ends.
+    /// </summary>
     public DateTime? LockoutEndUtc { get; private set; }
+    /// <summary>
+    /// Gets a value indicating whether the user completed the onboarding tour.
+    /// </summary>
     public bool TourCompleted { get; private set; }
 
     // EF Core sets navigation properties via materialization.
 #pragma warning disable S1144
+    /// <summary>
+    /// Gets the company navigation property.
+    /// </summary>
     public Company? Company { get; private set; }
 #pragma warning restore S1144
+    /// <summary>
+    /// Gets the user sessions associated with this user.
+    /// </summary>
     public ICollection<UserSession> UserSessions { get; } = [];
+    /// <summary>
+    /// Gets the external login records associated with this user.
+    /// </summary>
     public ICollection<UserLogin> UserLogins { get; } = [];
 
     private AppUser() { }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AppUser"/> class.
+    /// </summary>
+    /// <param name="id">The unique identifier of the user.</param>
+    /// <param name="companyId">The company identifier associated with the user.</param>
+    /// <param name="firstName">The first name of the user.</param>
+    /// <param name="lastName">The last name of the user.</param>
+    /// <param name="email">The email address of the user.</param>
+    /// <param name="passwordHash">The password hash for local authentication.</param>
+    /// <param name="userType">The user type.</param>
+    /// <param name="externalSystemId">The user identifier in an external system.</param>
+    /// <param name="authProvider">The authentication provider.</param>
     public AppUser(
         Guid id,
         Guid? companyId,
@@ -77,28 +104,55 @@ public sealed class AppUser : BaseEntity {
         AuthProvider = authProvider;
     }
 
+    /// <summary>
+    /// Determines whether the user is currently locked out.
+    /// </summary>
+    /// <returns><c>true</c> if the user is locked out; otherwise, <c>false</c>.</returns>
     public bool IsLockedOut() =>
         LockoutEndUtc.HasValue && LockoutEndUtc.Value > DateTime.UtcNow;
 
+    /// <summary>
+    /// Records a failed login attempt and applies lockout when threshold is reached.
+    /// </summary>
     public void RecordFailedLogin() {
         FailedLoginAttempts++;
         if (FailedLoginAttempts >= _maxFailedAttempts)
             LockoutEndUtc = DateTime.UtcNow.AddMinutes(_lockoutDurationMinutes);
     }
 
+    /// <summary>
+    /// Resets failed login attempts and clears lockout state.
+    /// </summary>
     public void ResetLoginAttempts() {
         FailedLoginAttempts = 0;
         LockoutEndUtc = null;
     }
 
+    /// <summary>
+    /// Sets the password hash for local authentication.
+    /// </summary>
+    /// <param name="passwordHash">The password hash value.</param>
     public void SetPassword(string passwordHash) => PasswordHash = passwordHash;
 
+    /// <summary>
+    /// Sets the onboarding tour completion value.
+    /// </summary>
+    /// <param name="value">The completion state to apply.</param>
     public void SetTourCompleted(bool value) => TourCompleted = value;
 
+    /// <summary>
+    /// Updates the first and last name values.
+    /// </summary>
+    /// <param name="firstName">The first name to set.</param>
+    /// <param name="lastName">The last name to set.</param>
     public void UpdateProfile(string firstName, string lastName) {
         FirstName = firstName.Trim();
         LastName = lastName.Trim();
     }
 
+    /// <summary>
+    /// Assigns the user to a company.
+    /// </summary>
+    /// <param name="companyId">The company identifier.</param>
     public void AssignToCompany(Guid companyId) => CompanyId = companyId;
 }

--- a/apps/backend/CargoPilot.Domain/Entities/Integration.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/Integration.cs
@@ -1,3 +1,5 @@
+using CargoPilot.Domain.Enums;
+
 namespace CargoPilot.Domain.Entities;
 
 public sealed class Integration : BaseEntity {
@@ -7,6 +9,9 @@ public sealed class Integration : BaseEntity {
     public string? MappingTable { get; private set; }
     public int? SyncInterval { get; private set; }
     public DateTime? LastSyncDate { get; private set; }
+    public SyncFrequency? SyncFrequency { get; private set; }
+    public DateTime? NextScheduledSyncAt { get; private set; }
+    public ErpSyncStatus SyncStatus { get; private set; } = ErpSyncStatus.Idle;
     public string? AuthCredentials { get; private set; }
 
 #pragma warning disable S1144
@@ -43,4 +48,19 @@ public sealed class Integration : BaseEntity {
     public void UpdateAuthCredentials(string? authCredentials) => AuthCredentials = authCredentials;
 
     public void RecordSync(DateTime syncDate) => LastSyncDate = syncDate;
+
+    public void UpdateSyncSettings(SyncFrequency? frequency, DateTime? nextScheduledSyncAt) {
+        SyncFrequency = frequency;
+        NextScheduledSyncAt = nextScheduledSyncAt;
+    }
+
+    public void StartSync() => SyncStatus = ErpSyncStatus.Running;
+
+    public void CompleteSync(DateTime lastSyncAt, DateTime? nextScheduledSyncAt) {
+        LastSyncDate = lastSyncAt;
+        NextScheduledSyncAt = nextScheduledSyncAt;
+        SyncStatus = ErpSyncStatus.Idle;
+    }
+
+    public void FailSync() => SyncStatus = ErpSyncStatus.Failed;
 }

--- a/apps/backend/CargoPilot.Domain/Enums/ErpSyncStatus.cs
+++ b/apps/backend/CargoPilot.Domain/Enums/ErpSyncStatus.cs
@@ -1,0 +1,7 @@
+namespace CargoPilot.Domain.Enums;
+
+public enum ErpSyncStatus {
+    Idle,
+    Running,
+    Failed
+}

--- a/apps/backend/CargoPilot.Domain/Enums/SyncFrequency.cs
+++ b/apps/backend/CargoPilot.Domain/Enums/SyncFrequency.cs
@@ -1,0 +1,14 @@
+namespace CargoPilot.Domain.Enums;
+
+public enum SyncFrequency {
+    Every4Hours,
+    Daily
+}
+
+public static class SyncFrequencyExtensions {
+    public static TimeSpan ToTimeSpan(this SyncFrequency frequency) => frequency switch {
+        SyncFrequency.Every4Hours => TimeSpan.FromHours(4),
+        SyncFrequency.Daily       => TimeSpan.FromHours(24),
+        _                         => TimeSpan.FromHours(24)
+    };
+}

--- a/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
+++ b/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
@@ -59,6 +59,7 @@ public static class DependencyInjection {
         services.AddScoped<ILoadingPlanRepository, LoadingPlanRepository>();
         services.AddScoped<IOptimizationEngine, NoOpOptimizationEngine>();
         services.AddScoped<IErpConstraintMappingService, ErpConstraintMappingService>();
+        services.AddScoped<IIntegrationRepository, IntegrationRepository>();
         services.AddScoped<IPasswordResetTokenRepository, PasswordResetTokenRepository>();
         services.AddScoped<IUserPasswordHistoryRepository, UserPasswordHistoryRepository>();
         services.AddHttpClient<IEmailService, ResendEmailService>(client =>

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/IntegrationConfiguration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/IntegrationConfiguration.cs
@@ -1,4 +1,5 @@
 using CargoPilot.Domain.Entities;
+using CargoPilot.Domain.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -42,6 +43,14 @@ internal sealed class IntegrationConfiguration : IEntityTypeConfiguration<Integr
         builder.Property(i => i.SyncInterval);
 
         builder.Property(i => i.LastSyncDate);
+
+        builder.Property(i => i.SyncFrequency);
+
+        builder.Property(i => i.NextScheduledSyncAt);
+
+        builder.Property(i => i.SyncStatus)
+            .IsRequired()
+            .HasDefaultValue(ErpSyncStatus.Idle);
 
         builder.Property(i => i.AuthCredentials)
             .HasColumnType("nvarchar(max)");

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260509182435_AddSyncFieldsToIntegration.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260509182435_AddSyncFieldsToIntegration.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260509182435_AddSyncFieldsToIntegration")]
+    partial class AddSyncFieldsToIntegration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260509182435_AddSyncFieldsToIntegration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260509182435_AddSyncFieldsToIntegration.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSyncFieldsToIntegration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "NextScheduledSyncAt",
+                table: "Integrations",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SyncFrequency",
+                table: "Integrations",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SyncStatus",
+                table: "Integrations",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NextScheduledSyncAt",
+                table: "Integrations");
+
+            migrationBuilder.DropColumn(
+                name: "SyncFrequency",
+                table: "Integrations");
+
+            migrationBuilder.DropColumn(
+                name: "SyncStatus",
+                table: "Integrations");
+        }
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/IntegrationRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/IntegrationRepository.cs
@@ -1,0 +1,33 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Domain.Entities;
+using CargoPilot.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace CargoPilot.Infrastructure.Persistence.Repositories;
+
+internal sealed class IntegrationRepository : IIntegrationRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public IntegrationRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<Integration?> GetByIdAsync(Guid id, Guid companyId, CancellationToken cancellationToken = default)
+        => _dbContext.Integrations
+            .FirstOrDefaultAsync(i => i.Id == id && i.CompanyId == companyId, cancellationToken);
+
+    public Task<bool> HasAnyRunningSyncAsync(Guid companyId, CancellationToken cancellationToken = default)
+        => _dbContext.Integrations
+            .AnyAsync(i => i.CompanyId == companyId && i.SyncStatus == ErpSyncStatus.Running, cancellationToken);
+
+    public async Task<IReadOnlyList<Integration>> ListByCompanyAsync(Guid companyId, CancellationToken cancellationToken = default)
+        => await _dbContext.Integrations
+            .AsNoTracking()
+            .Where(i => i.CompanyId == companyId)
+            .ToListAsync(cancellationToken);
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken = default)
+        => _dbContext.SaveChangesAsync(cancellationToken);
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Seeding/DbInitializer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Seeding/DbInitializer.cs
@@ -43,21 +43,36 @@ public sealed class DbInitializer {
             await _context.SaveChangesAsync(cancellationToken);
         }
 
-        var adminExists = await _context.Users
-            .AnyAsync(
-                user => user.Email == DefaultAdminEmail,
-                cancellationToken);
+        var testIntegrationExists = await _context.Integrations
+            .AnyAsync(i => i.CompanyId == company.Id, cancellationToken);
 
-        if (!adminExists) {
-            var defaultAdminPassword = _configuration["Seed:DefaultAdminPassword"];
-            if (string.IsNullOrWhiteSpace(defaultAdminPassword)) {
-                throw new InvalidOperationException(
-                    "Seed:DefaultAdminPassword tanımsız. Seed için varsayılan admin şifresi yapılandırılmalı.");
-            }
-
-            var adminUser = new AppUser(
+        if (!testIntegrationExists) {
+            var integration = new Integration(
                 id: Guid.NewGuid(),
-                companyId: null,
+                companyId: company.Id,
+                systemName: "TestERP",
+                apiEndpoint: "https://erp.test",
+                mappingTable: null,
+                syncInterval: null,
+                authCredentials: null);
+
+            await _context.Integrations.AddAsync(integration, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        var defaultAdminPassword = _configuration["Seed:DefaultAdminPassword"];
+        if (string.IsNullOrWhiteSpace(defaultAdminPassword)) {
+            throw new InvalidOperationException(
+                "Seed:DefaultAdminPassword tanımsız. Seed için varsayılan admin şifresi yapılandırılmalı.");
+        }
+
+        var adminUser = await _context.Users
+            .FirstOrDefaultAsync(u => u.Email == DefaultAdminEmail, cancellationToken);
+
+        if (adminUser is null) {
+            adminUser = new AppUser(
+                id: Guid.NewGuid(),
+                companyId: company.Id,
                 firstName: "System",
                 lastName: "Admin",
                 email: DefaultAdminEmail,
@@ -67,7 +82,10 @@ public sealed class DbInitializer {
                 authProvider: AuthProvider.Local);
 
             await _context.Users.AddAsync(adminUser, cancellationToken);
-            await _context.SaveChangesAsync(cancellationToken);
+        } else if (adminUser.CompanyId is null) {
+            adminUser.AssignToCompany(company.Id);
         }
+
+        await _context.SaveChangesAsync(cancellationToken);
     }
 }

--- a/apps/backend/CargoPilot.WebAPI/Controllers/IntegrationsController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/IntegrationsController.cs
@@ -1,0 +1,99 @@
+using CargoPilot.Application.Features.Integrations.GetSyncSettings;
+using CargoPilot.Application.Features.Integrations.ListIntegrations;
+using CargoPilot.Application.Features.Integrations.TriggerSync;
+using CargoPilot.Application.Features.Integrations.UpdateSyncSettings;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CargoPilot.WebAPI.Controllers;
+
+/// <summary>
+/// ERP entegrasyon yönetimi endpoint'leri.
+/// </summary>
+[Route("api/v1/integrations")]
+[Tags("Integrations")]
+[Authorize(Policy = "CompanyMember")]
+public sealed class IntegrationsController : BaseController
+{
+    private readonly IMediator _mediator;
+
+    public IntegrationsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Şirkete ait entegrasyonları listeler.
+    /// </summary>
+    /// <response code="200">Entegrasyon listesi döner.</response>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> List(CancellationToken cancellationToken = default)
+    {
+        var result = await _mediator.Send(new ListIntegrationsQuery(), cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Entegrasyonun senkronizasyon ayarlarını getirir.
+    /// </summary>
+    /// <param name="id">Entegrasyon ID'si.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Senkronizasyon ayarları döner.</response>
+    /// <response code="404">Entegrasyon bulunamadı.</response>
+    [HttpGet("{id:guid}/sync-settings")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetSyncSettings(
+        [FromRoute] Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _mediator.Send(new GetSyncSettingsQuery(id), cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Entegrasyonun senkronizasyon ayarlarını günceller.
+    /// </summary>
+    /// <param name="id">Entegrasyon ID'si.</param>
+    /// <param name="command">Güncellenecek senkronizasyon ayarları.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Ayarlar güncellendi; güncel senkronizasyon durumu döner.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    /// <response code="404">Entegrasyon bulunamadı.</response>
+    [HttpPut("{id:guid}/sync-settings")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateSyncSettings(
+        [FromRoute] Guid id,
+        [FromBody] UpdateSyncSettingsCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var commandWithId = command with { IntegrationId = id };
+        var result = await _mediator.Send(commandWithId, cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Entegrasyon için senkronizasyonu manuel olarak tetikler.
+    /// Aynı entegrasyon için eş zamanlı ikinci tetikleme engellenir.
+    /// </summary>
+    /// <param name="id">Entegrasyon ID'si.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Senkronizasyon tamamlandı; güncel senkronizasyon durumu döner.</response>
+    /// <response code="404">Entegrasyon bulunamadı.</response>
+    /// <response code="409">Senkronizasyon zaten çalışıyor.</response>
+    [HttpPost("{id:guid}/sync/run-now")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> RunNow(
+        [FromRoute] Guid id,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await _mediator.Send(new TriggerSyncCommand(id), cancellationToken);
+        return HandleResult(result);
+    }
+}


### PR DESCRIPTION
## Özet

   - Integration entity'ye SyncFrequency, NextScheduledSyncAt, SyncStatus alanları eklendi
   - ERP senkronizasyon ayarları eklendi
   - Integration entity'ye SyncFrequency, NextScheduledSyncAt, SyncStatus alanları eklendi
   - GET/PUT sync-settings ve POST run-now endpoint'leri eklendi
   - Şirket genelinde eş zamanlı ikinci senkronizasyon engellendi
   - IntegrationsController ve ilgili handler/repository dosyaları oluşturuldu
   - Migration: AddSyncFieldsToIntegration
   - DbInitializer: admin kullanıcısına şirket atanıyor, test entegrasyonu seed ediliyor

  ERP Senkronizasyon Ayarları

  Bu PR, şirket bazlı ERP entegrasyon kayıtlarına senkronizasyon durumu yönetimi ve manuel tetikleme desteği ekler.

  4 use case

  GET /api/v1/integrations
  Şirkete ait entegrasyon listesini döner. Swagger üzerinden test ederken integration ID'yi bulmak için kullanılır.

  GET /api/v1/integrations/{id}/sync-settings
  Bir entegrasyonun mevcut sync durumunu getirir: frekans, son sync zamanı, bir sonraki planlanan zaman ve anlık durum.
  0 = Every4Hours, 1 = Daily, null = manuel

  PUT /api/v1/integrations/{id}/sync-settings
  Senkronizasyon frekansını günceller. syncFrequency: null gönderilirse manuel moda alınır. Frekans değiştiğinde nextScheduledSyncAt şu andan itibaren
  yeniden hesaplanır.

  POST /api/v1/integrations/{id}/sync/run-now
  Manuel senkronizasyon tetikler. İki önemli kural:
  - Şirket genelinde çalışan başka bir sync varsa 409 Conflict döner (aynı entegrasyon değil, aynı şirkete ait herhangi bir entegrasyon)
  - Tamamlanınca lastSyncAt ve nextScheduledSyncAt güncellenerek response'da döner

  ---
  Infrastructure

  - IntegrationRepository — GetByIdAsync, HasAnyRunningSyncAsync, ListByCompanyAsync metodlarını içerir
  - HasAnyRunningSyncAsync — şirket geneli concurrency kontrolü için: SyncStatus == Running olan herhangi bir integration var mı?
  - Migration 20260509182435_AddSyncFieldsToIntegration — Integrations tablosuna SyncFrequency, NextScheduledSyncAt, SyncStatus kolonları eklendi

  ---
  Seed (DbInitializer)

  - Admin kullanıcısı artık şirketsiz oluşturulmuyor; company.Id ile atanıyor. Mevcut kayıt varsa AssignToCompany() ile güncelleniyor.
  - İlk açılışta şirkete bağlı bir TestERP entegrasyonu oluşturuluyor. Swagger testlerinde ID bulmak için GET /api/v1/integrations yeterli.

  ---
  Test notu

  1. dotnet run ile uygulamayı başlat
  2. POST /auth/login → admin@cargopilot.com
  3. GET /integrations → integration ID'yi al
  4. GET/PUT /integrations/{id}/sync-settings ve POST /integrations/{id}/sync/run-now endpoint'lerini dene

  ---


## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [x ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x ] Manuel test yapıldı

## Kontrol Listesi

- [x ] Kod standartlarına uygun
- [x ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [x ] Linter hataları yok
- [x] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
