### PR TITLE
GHCR: sync-base-images eski branch trigger kaldırıldı, tarih etiketi eklendi

### DIFF
--- a/.github/workflows/sync-base-images.yml
+++ b/.github/workflows/sync-base-images.yml
@@ -9,9 +9,6 @@ on:
   schedule:
     - cron: '0 2 * * 0'
   workflow_dispatch:
-  push:
-    branches:
-      - bugfix/INC-003-mcr-rate-limit-fix
 
 jobs:
   sync:
@@ -28,14 +25,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Tarih etiketi belirle
+        id: date
+        run: echo "tag=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
+
       - name: .NET SDK 8.0 imajını senkronize et
         run: |
           docker pull mcr.microsoft.com/dotnet/sdk:8.0
           docker tag mcr.microsoft.com/dotnet/sdk:8.0 ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0
+          docker tag mcr.microsoft.com/dotnet/sdk:8.0 ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0-${{ steps.date.outputs.tag }}
           docker push ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0
+          docker push ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0-${{ steps.date.outputs.tag }}
 
       - name: .NET ASP.NET 8.0 imajını senkronize et
         run: |
           docker pull mcr.microsoft.com/dotnet/aspnet:8.0
           docker tag mcr.microsoft.com/dotnet/aspnet:8.0 ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0
+          docker tag mcr.microsoft.com/dotnet/aspnet:8.0 ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0-${{ steps.date.outputs.tag }}
           docker push ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0
+          docker push ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0-${{ steps.date.outputs.tag }}


### PR DESCRIPTION
## Summary
- Kullanılmayan `bugfix/INC-003-mcr-rate-limit-fix` branch push tetikleyicisi silindi
- Her sync'te `:8.0` floating tag yanında `:8.0-YYYYMMDD` immutable tarih etiketi de push edilir
- Böylece base image'larda da rollback/pin imkânı oluşur

## Test plan
- [ ] Workflow sadece schedule ve workflow_dispatch ile tetikleniyor mu doğrula
- [ ] Manuel tetiklemede GHCR'da hem `:8.0` hem `:8.0-YYYYMMDD` tag'i göründüğünü kontrol et

🤖 Generated with [Claude Code](https://claude.com/claude-code)