### PR TITLE
GHCR: .env.test.example'a GHCR_OWNER ve IMAGE_TAG eklendi

### DIFF
--- a/infra/env/.env.test.example
+++ b/infra/env/.env.test.example
@@ -17,6 +17,13 @@ ENVIRONMENT=test
 BACKEND_PORT=8081
 FRONTEND_PORT=3001
 
+# ─── GHCR Image ──────────────────────────────
+# Docker Compose'un kullanacağı image kaynağı ve etiketi.
+# CI tarafından otomatik doldurulur; local geliştirmede boş bırak (varsayılan: test).
+# Rollback: IMAGE_TAG=test-<7-char-sha> şeklinde belirli bir sürüme dönülebilir.
+GHCR_OWNER=divizyon
+IMAGE_TAG=test
+
 # ─── Frontend API URL (build-time) ───────────
 # Nginx + domain kurulumunda gerçek domain yaz:
 #   VITE_API_BASE_URL=https://cargopilot.divizyon.org

--- a/infra/env/.env.test.example
+++ b/infra/env/.env.test.example
@@ -19,7 +19,8 @@ FRONTEND_PORT=3001
 
 # ─── GHCR Image ──────────────────────────────
 # Docker Compose'un kullanacağı image kaynağı ve etiketi.
-# CI tarafından otomatik doldurulur; local geliştirmede boş bırak (varsayılan: test).
+# Local geliştirmede değiştirmene gerek yok; compose varsayılanları (divizyon / test) geçerlidir.
+# CI bu değerleri deploy sırasında otomatik olarak doldurur.
 # Rollback: IMAGE_TAG=test-<7-char-sha> şeklinde belirli bir sürüme dönülebilir.
 GHCR_OWNER=divizyon
 IMAGE_TAG=test


### PR DESCRIPTION
## Summary
- `GHCR_OWNER` ve `IMAGE_TAG` değişkenleri `.env.test.example`'a dokümante edildi
- CI tarafından otomatik doldurulur; local geliştirmede varsayılan değerler (`divizyon` / `test`) yeterlidir
- Rollback senaryosu için `IMAGE_TAG=test-<sha>` kullanımı açıklandı

## Test plan
- [ ] `.env.test.example`'ı kopyalayıp `.env.test` oluştur
- [ ] `docker compose ... up -d` komutunun hatasız çalıştığını doğrula

🤖 Generated with [Claude Code](https://claude.com/claude-code)