### PR TITLE
GHCR: docker-compose.prod.yml'e image referansı eklendi

### DIFF
--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -2,6 +2,7 @@ name: cargo-pilot-prod
 
 services:
   backend:
+    image: ghcr.io/${GHCR_OWNER:-divizyon}/cargo-pilot-backend:${IMAGE_TAG:-prod}
     build:
       context: ../../apps/backend
       dockerfile: Dockerfile
@@ -28,6 +29,7 @@ services:
       - cargo-pilot-prod
 
   frontend:
+    image: ghcr.io/${GHCR_OWNER:-divizyon}/cargo-pilot-frontend:${IMAGE_TAG:-prod}
     build:
       context: ../../apps/frontend
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- `backend` ve `frontend` servislerine `image: ghcr.io/{GHCR_OWNER}/cargo-pilot-{service}:{IMAGE_TAG}` eklendi
- `IMAGE_TAG` varsayılanı `prod`; `GHCR_OWNER` varsayılanı `divizyon`
- `build:` alanı local build fallback olarak korundu
- Prod pipeline hazır olduğunda `docker compose pull` ile GHCR'dan çekilebilir hale getirildi

## Test plan
- [ ] `docker compose -f docker-compose.prod.yml config` ile interpolasyon hatası olmadığını doğrula
- [ ] Prod pipeline kurulduğunda `IMAGE_TAG=prod-{sha}` ile pull/up akışını test et

🤖 Generated with [Claude Code](https://claude.com/claude-code)