### PR TITLE
fix: test-deploy.yml YAML parse hatası düzeltildi

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Kodu al
         uses: actions/checkout@v4
 
-      - name: Image tag belirle (immutable: test-{short-sha})
+      - name: "Image tag belirle (immutable: test-{short-sha})"
         id: sha
         run: echo "tag=test-$(echo '${{ github.sha }}' | cut -c1-7)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- Step name içindeki `(immutable: test-{short-sha})` ifadesindeki `: ` YAML parser tarafından mapping separator olarak yorumlanıyordu
- Workflow file issue hatası ile run başlatılamıyordu (#1461)
- Step name tırnak içine alınarak düzeltildi

## Root Cause
YAML'da parantez içinde bile `key: value` formatındaki string, tırnaksız yazıldığında parse hatası verir.

```yaml
# ❌ Bozuk
- name: Image tag belirle (immutable: test-{short-sha})

# ✅ Düzgün
- name: "Image tag belirle (immutable: test-{short-sha})"
```

## Test plan
- [ ] CI'ın workflow file issue hatası vermeden başladığını doğrula

🤖 Generated with [Claude Code](https://claude.com/claude-code)