### PR TITLE
fix(infra): increase MinIO healthcheck start_period to 60s

### DIFF
--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -115,7 +115,7 @@ services:
       interval: 20s
       timeout: 10s
       retries: 10
-      start_period: 20s
+      start_period: 60s
     restart: unless-stopped
     networks:
       - cargo-pilot-test


### PR DESCRIPTION
New MinIO version needs more startup time to initialize with existing volume.

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
