### PR TITLE
revert(infra): revert MinIO image to RELEASE.2022-01-08

### DIFF
--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -99,7 +99,7 @@ services:
       - cargo-pilot-test
 
   minio:
-    image: quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z
+    image: quay.io/minio/minio:RELEASE.2022-01-08T03-11-54Z
     container_name: cargo-pilot-minio-test
     command: server /data --console-address ":9001"
     environment:
@@ -115,7 +115,7 @@ services:
       interval: 20s
       timeout: 10s
       retries: 10
-      start_period: 60s
+      start_period: 20s
     restart: unless-stopped
     networks:
       - cargo-pilot-test


### PR DESCRIPTION
Server CPU does not support x86-64-v2 required by newer MinIO builds. Reverted image and healthcheck start_period to original values.

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
