### PR TITLE
Feature/us vy 35 erp item sync

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Erp/ErpProductDto.cs
+++ b/apps/backend/CargoPilot.Application/Common/Erp/ErpProductDto.cs
@@ -1,0 +1,17 @@
+namespace CargoPilot.Application.Common.Erp;
+
+public sealed record ErpProductDto(
+    string ErpId,
+    string Sku,
+    string Name,
+    string ProductType,
+    decimal Width,
+    decimal Height,
+    decimal Length,
+    decimal Weight,
+    string? Category,
+    string? Warehouse,
+    string? Barcode,
+    decimal? Diameter,
+    IReadOnlyDictionary<string, string?> ErpConstraints,
+    string RawDataJson);

--- a/apps/backend/CargoPilot.Application/Common/Interfaces/IErpProductFetcher.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/IErpProductFetcher.cs
@@ -1,0 +1,13 @@
+using CargoPilot.Application.Common.Erp;
+
+namespace CargoPilot.Application.Common.Interfaces;
+
+public interface IErpProductFetcher
+{
+    Task<IReadOnlyList<ErpProductDto>> FetchAsync(
+        string apiEndpoint,
+        string? authCredentialsJson,
+        string? categoryFilter,
+        string? warehouseFilter,
+        CancellationToken cancellationToken = default);
+}

--- a/apps/backend/CargoPilot.Application/Common/Interfaces/IIntegrationRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/IIntegrationRepository.cs
@@ -4,9 +4,9 @@ namespace CargoPilot.Application.Common.Interfaces;
 
 public interface IIntegrationRepository
 {
-    Task<Integration?> GetByIdAsync(Guid id, Guid companyId, CancellationToken cancellationToken = default);
+    Task<Integration?> GetByIdAsync(Guid id, Guid? companyId, CancellationToken cancellationToken = default);
     Task<bool> HasAnyRunningSyncAsync(Guid companyId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<Integration>> ListByCompanyAsync(Guid companyId, CancellationToken cancellationToken = default);
-    void AddSyncLog(SyncLog log);
+    void AddSyncLog(SyncLog syncLog);
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/apps/backend/CargoPilot.Application/Common/Interfaces/IItemRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/IItemRepository.cs
@@ -8,6 +8,7 @@ public interface IItemRepository
     Task<Item?> GetByIdAsync(Guid id, Guid? companyId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<Guid>> GetExistingIdsAsync(IEnumerable<Guid> ids, Guid? companyId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<Item>> GetByIdsAsync(IEnumerable<Guid> ids, Guid? companyId, CancellationToken cancellationToken = default);
+    Task<Item?> GetBySkuAsync(string sku, Guid? companyId, CancellationToken cancellationToken = default);
     Task<bool> ExistsBySkuAsync(string sku, Guid? companyId, CancellationToken cancellationToken = default);
     Task<bool> ExistsBySkuAsync(string sku, Guid excludeItemId, Guid? companyId, CancellationToken cancellationToken = default);
     Task<bool> IsUsedInActiveLoadingPlanAsync(Guid itemId, CancellationToken cancellationToken = default);

--- a/apps/backend/CargoPilot.Application/Common/Interfaces/IPendingItemMappingRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/IPendingItemMappingRepository.cs
@@ -1,0 +1,17 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Entities;
+using CargoPilot.Domain.Enums;
+
+namespace CargoPilot.Application.Common.Interfaces;
+
+public interface IPendingItemMappingRepository
+{
+    Task<PendingItemMapping?> GetByIdAsync(Guid id, Guid integrationId, CancellationToken cancellationToken = default);
+    Task<PendingItemMapping?> GetByErpIdAsync(Guid integrationId, string erpId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<PendingItemMapping>> GetApprovedByIntegrationAsync(Guid integrationId, CancellationToken cancellationToken = default);
+    Task<PagedResult<PendingItemMapping>> GetPagedAsync(Guid integrationId, PendingItemMappingStatus? status, int page, int pageSize, CancellationToken cancellationToken = default);
+    void Add(PendingItemMapping mapping);
+    void Update(PendingItemMapping mapping);
+    void Remove(PendingItemMapping mapping);
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/ApprovePendingItemMappingCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/ApprovePendingItemMappingCommand.cs
@@ -1,0 +1,9 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.PendingItemMappings;
+
+public sealed record ApprovePendingItemMappingCommand(
+    Guid IntegrationId,
+    Guid MappingId,
+    Guid CargoPilotItemId) : IRequest<Result<bool>>;

--- a/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/ApprovePendingItemMappingCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/ApprovePendingItemMappingCommandHandler.cs
@@ -1,0 +1,75 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.PendingItemMappings;
+
+public sealed class ApprovePendingItemMappingCommandHandler
+    : IRequestHandler<ApprovePendingItemMappingCommand, Result<bool>>
+{
+    private readonly IPendingItemMappingRepository _repository;
+    private readonly IIntegrationRepository _integrationRepository;
+    private readonly IItemRepository _itemRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IValidator<ApprovePendingItemMappingCommand> _validator;
+
+    public ApprovePendingItemMappingCommandHandler(
+        IPendingItemMappingRepository repository,
+        IIntegrationRepository integrationRepository,
+        IItemRepository itemRepository,
+        ICurrentUserService currentUserService,
+        IValidator<ApprovePendingItemMappingCommand> validator)
+    {
+        _repository = repository;
+        _integrationRepository = integrationRepository;
+        _itemRepository = itemRepository;
+        _currentUserService = currentUserService;
+        _validator = validator;
+    }
+
+    public async Task<Result<bool>> Handle(
+        ApprovePendingItemMappingCommand request,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<bool>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var companyId = _currentUserService.CompanyId;
+
+        var integration = await _integrationRepository.GetByIdAsync(request.IntegrationId, companyId, cancellationToken);
+        if (integration is null)
+        {
+            return Result<bool>.Failure(
+                new Error(ErrorType.NotFound, "Integration.NotFound", "Entegrasyon bulunamadı."));
+        }
+
+        var mapping = await _repository.GetByIdAsync(request.MappingId, request.IntegrationId, cancellationToken);
+        if (mapping is null)
+        {
+            return Result<bool>.Failure(
+                new Error(ErrorType.NotFound, "PendingItemMapping.NotFound", "Bekleyen eşleştirme bulunamadı."));
+        }
+
+        var item = await _itemRepository.GetByIdAsync(request.CargoPilotItemId, companyId, cancellationToken);
+        if (item is null)
+        {
+            return Result<bool>.Failure(
+                new Error(ErrorType.NotFound, "Item.NotFound", "Ürün bulunamadı."));
+        }
+
+        mapping.Approve(request.CargoPilotItemId);
+        _repository.Update(mapping);
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        return Result<bool>.Success(true);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/ApprovePendingItemMappingCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/ApprovePendingItemMappingCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Integrations.PendingItemMappings;
+
+public sealed class ApprovePendingItemMappingCommandValidator : AbstractValidator<ApprovePendingItemMappingCommand>
+{
+    public ApprovePendingItemMappingCommandValidator()
+    {
+        RuleFor(x => x.IntegrationId).NotEmpty();
+        RuleFor(x => x.MappingId).NotEmpty();
+        RuleFor(x => x.CargoPilotItemId).NotEmpty();
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/DeletePendingItemMappingCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/DeletePendingItemMappingCommand.cs
@@ -1,0 +1,8 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.PendingItemMappings;
+
+public sealed record DeletePendingItemMappingCommand(
+    Guid IntegrationId,
+    Guid MappingId) : IRequest<Result<bool>>;

--- a/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/DeletePendingItemMappingCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/DeletePendingItemMappingCommandHandler.cs
@@ -1,0 +1,65 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.PendingItemMappings;
+
+public sealed class DeletePendingItemMappingCommandHandler
+    : IRequestHandler<DeletePendingItemMappingCommand, Result<bool>>
+{
+    private readonly IPendingItemMappingRepository _repository;
+    private readonly IIntegrationRepository _integrationRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IValidator<DeletePendingItemMappingCommand> _validator;
+
+    public DeletePendingItemMappingCommandHandler(
+        IPendingItemMappingRepository repository,
+        IIntegrationRepository integrationRepository,
+        ICurrentUserService currentUserService,
+        IValidator<DeletePendingItemMappingCommand> validator)
+    {
+        _repository = repository;
+        _integrationRepository = integrationRepository;
+        _currentUserService = currentUserService;
+        _validator = validator;
+    }
+
+    public async Task<Result<bool>> Handle(
+        DeletePendingItemMappingCommand request,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<bool>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var companyId = _currentUserService.CompanyId;
+
+        var integration = await _integrationRepository.GetByIdAsync(request.IntegrationId, companyId, cancellationToken);
+        if (integration is null)
+        {
+            return Result<bool>.Failure(
+                new Error(ErrorType.NotFound, "Integration.NotFound", "Entegrasyon bulunamadı."));
+        }
+
+        var mapping = await _repository.GetByIdAsync(request.MappingId, request.IntegrationId, cancellationToken);
+        if (mapping is null)
+        {
+            return Result<bool>.Failure(
+                new Error(ErrorType.NotFound, "PendingItemMapping.NotFound", "Bekleyen eşleştirme bulunamadı."));
+        }
+
+        mapping.Dismiss();
+        _repository.Update(mapping);
+        await _repository.SaveChangesAsync(cancellationToken);
+
+        return Result<bool>.Success(true);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/DeletePendingItemMappingCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/DeletePendingItemMappingCommandValidator.cs
@@ -1,0 +1,12 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Integrations.PendingItemMappings;
+
+public sealed class DeletePendingItemMappingCommandValidator : AbstractValidator<DeletePendingItemMappingCommand>
+{
+    public DeletePendingItemMappingCommandValidator()
+    {
+        RuleFor(x => x.IntegrationId).NotEmpty();
+        RuleFor(x => x.MappingId).NotEmpty();
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/GetPendingItemMappingsQuery.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/GetPendingItemMappingsQuery.cs
@@ -1,0 +1,11 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.PendingItemMappings;
+
+public sealed record GetPendingItemMappingsQuery(
+    Guid IntegrationId,
+    PendingItemMappingStatus? Status,
+    int Page = 1,
+    int PageSize = 20) : IRequest<Result<PagedResult<PendingItemMappingDto>>>;

--- a/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/GetPendingItemMappingsQueryHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/GetPendingItemMappingsQueryHandler.cs
@@ -1,0 +1,65 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.PendingItemMappings;
+
+public sealed class GetPendingItemMappingsQueryHandler
+    : IRequestHandler<GetPendingItemMappingsQuery, Result<PagedResult<PendingItemMappingDto>>>
+{
+    private readonly IPendingItemMappingRepository _repository;
+    private readonly IIntegrationRepository _integrationRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IValidator<GetPendingItemMappingsQuery> _validator;
+
+    public GetPendingItemMappingsQueryHandler(
+        IPendingItemMappingRepository repository,
+        IIntegrationRepository integrationRepository,
+        ICurrentUserService currentUserService,
+        IValidator<GetPendingItemMappingsQuery> validator)
+    {
+        _repository = repository;
+        _integrationRepository = integrationRepository;
+        _currentUserService = currentUserService;
+        _validator = validator;
+    }
+
+    public async Task<Result<PagedResult<PendingItemMappingDto>>> Handle(
+        GetPendingItemMappingsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<PagedResult<PendingItemMappingDto>>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var companyId = _currentUserService.CompanyId;
+
+        var integration = await _integrationRepository.GetByIdAsync(request.IntegrationId, companyId, cancellationToken);
+        if (integration is null)
+        {
+            return Result<PagedResult<PendingItemMappingDto>>.Failure(
+                new Error(ErrorType.NotFound, "Integration.NotFound", "Entegrasyon bulunamadı."));
+        }
+
+        var paged = await _repository.GetPagedAsync(
+            request.IntegrationId, request.Status, request.Page, request.PageSize, cancellationToken);
+
+        var dtos = paged.Items
+            .Select(m => new PendingItemMappingDto(
+                m.Id, m.IntegrationId, m.ErpId, m.ErpSku, m.ErpProductName,
+                m.ErpRawDataJson, m.CargoPilotItemId, m.Status,
+                m.CreatedAtUtc, m.UpdatedAtUtc))
+            .ToList();
+
+        return Result<PagedResult<PendingItemMappingDto>>.Success(
+            new PagedResult<PendingItemMappingDto>(dtos, paged.TotalCount, request.Page, request.PageSize));
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/GetPendingItemMappingsQueryValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/GetPendingItemMappingsQueryValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Integrations.PendingItemMappings;
+
+public sealed class GetPendingItemMappingsQueryValidator : AbstractValidator<GetPendingItemMappingsQuery>
+{
+    public GetPendingItemMappingsQueryValidator()
+    {
+        RuleFor(x => x.IntegrationId).NotEmpty();
+        RuleFor(x => x.Page).GreaterThanOrEqualTo(1);
+        RuleFor(x => x.PageSize).InclusiveBetween(1, 100);
+        RuleFor(x => x.Status).IsInEnum().When(x => x.Status.HasValue);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/PendingItemMappingDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/PendingItemMappings/PendingItemMappingDto.cs
@@ -1,0 +1,15 @@
+using CargoPilot.Domain.Enums;
+
+namespace CargoPilot.Application.Features.Integrations.PendingItemMappings;
+
+public sealed record PendingItemMappingDto(
+    Guid Id,
+    Guid IntegrationId,
+    string ErpId,
+    string ErpSku,
+    string ErpProductName,
+    string ErpRawDataJson,
+    Guid? CargoPilotItemId,
+    PendingItemMappingStatus Status,
+    DateTime CreatedAtUtc,
+    DateTime? UpdatedAtUtc);

--- a/apps/backend/CargoPilot.Application/Features/Integrations/SyncErpItems/SyncErpItemsCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/SyncErpItems/SyncErpItemsCommand.cs
@@ -1,0 +1,9 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.SyncErpItems;
+
+public sealed record SyncErpItemsCommand(
+    Guid IntegrationId,
+    string? CategoryFilter,
+    string? WarehouseFilter) : IRequest<Result<SyncErpItemsResult>>;

--- a/apps/backend/CargoPilot.Application/Features/Integrations/SyncErpItems/SyncErpItemsCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/SyncErpItems/SyncErpItemsCommandHandler.cs
@@ -1,0 +1,200 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Entities;
+using CargoPilot.Domain.Enums;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Integrations.SyncErpItems;
+
+public sealed class SyncErpItemsCommandHandler : IRequestHandler<SyncErpItemsCommand, Result<SyncErpItemsResult>>
+{
+    private readonly IIntegrationRepository _integrationRepository;
+    private readonly IItemRepository _itemRepository;
+    private readonly IPendingItemMappingRepository _pendingMappingRepository;
+    private readonly IErpProductFetcher _erpProductFetcher;
+    private readonly IErpConstraintMappingService _constraintMappingService;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IValidator<SyncErpItemsCommand> _validator;
+
+    public SyncErpItemsCommandHandler(
+        IIntegrationRepository integrationRepository,
+        IItemRepository itemRepository,
+        IPendingItemMappingRepository pendingMappingRepository,
+        IErpProductFetcher erpProductFetcher,
+        IErpConstraintMappingService constraintMappingService,
+        ICurrentUserService currentUserService,
+        IValidator<SyncErpItemsCommand> validator)
+    {
+        _integrationRepository = integrationRepository;
+        _itemRepository = itemRepository;
+        _pendingMappingRepository = pendingMappingRepository;
+        _erpProductFetcher = erpProductFetcher;
+        _constraintMappingService = constraintMappingService;
+        _currentUserService = currentUserService;
+        _validator = validator;
+    }
+
+    public async Task<Result<SyncErpItemsResult>> Handle(
+        SyncErpItemsCommand request,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<SyncErpItemsResult>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var companyId = _currentUserService.CompanyId;
+
+        var integration = await _integrationRepository.GetByIdAsync(request.IntegrationId, companyId, cancellationToken);
+        if (integration is null)
+        {
+            return Result<SyncErpItemsResult>.Failure(
+                new Error(ErrorType.NotFound, "Integration.NotFound", "Entegrasyon bulunamadı."));
+        }
+
+        var syncLog = new SyncLog(Guid.NewGuid(), integration.Id);
+        _integrationRepository.AddSyncLog(syncLog);
+
+        try
+        {
+            var erpProducts = await _erpProductFetcher.FetchAsync(
+                integration.ApiEndpoint,
+                integration.AuthCredentials,
+                request.CategoryFilter,
+                request.WarehouseFilter,
+                cancellationToken);
+
+            var approvedMappings = await _pendingMappingRepository.GetApprovedByIntegrationAsync(integration.Id, cancellationToken);
+            var approvedByErpId = approvedMappings
+                .Where(m => m.CargoPilotItemId.HasValue)
+                .ToDictionary(m => m.ErpId, StringComparer.OrdinalIgnoreCase);
+
+            int added = 0, updated = 0, skipped = 0, pendingMappings = 0, ruleAssigned = 0, ruleNotAssigned = 0;
+
+            foreach (var product in erpProducts)
+            {
+                var resolution = _constraintMappingService.Resolve(integration.MappingTable, product.ErpConstraints);
+
+                if (approvedByErpId.TryGetValue(product.ErpId, out var approvedMapping))
+                {
+                    var linkedItem = await _itemRepository.GetByIdAsync(approvedMapping.CargoPilotItemId!.Value, companyId, cancellationToken);
+                    if (linkedItem is not null)
+                    {
+                        var (rotations, fragility, stackable, maxStack, maxWeight) = ParseRuleFields(resolution.ResolvedValues);
+                        linkedItem.Update(
+                            product.Sku, product.Barcode, product.Name, product.ProductType,
+                            ParseCategory(product.Category), product.Width, product.Height, product.Length,
+                            product.Diameter, product.Weight, fragility, stackable, maxStack, maxWeight,
+                            rotations, linkedItem.ImageUrl, linkedItem.StackGroup, linkedItem.SpecialNotes);
+                        linkedItem.SetErpSource(product.ErpId, integration.Id);
+                        linkedItem.SetRuleAssigned(resolution.IsFullyResolved);
+                        _itemRepository.Update(linkedItem);
+                        updated++;
+                        if (resolution.IsFullyResolved) ruleAssigned++; else ruleNotAssigned++;
+                        continue;
+                    }
+                }
+
+                if (!resolution.IsFullyResolved)
+                {
+                    var existingPending = await _pendingMappingRepository.GetByErpIdAsync(integration.Id, product.ErpId, cancellationToken);
+                    if (existingPending is not null)
+                    {
+                        existingPending.UpdateErpData(product.Sku, product.Name, product.RawDataJson);
+                        _pendingMappingRepository.Update(existingPending);
+                    }
+                    else
+                    {
+                        _pendingMappingRepository.Add(new PendingItemMapping(
+                            Guid.NewGuid(), integration.Id, product.ErpId, product.Sku, product.Name, product.RawDataJson));
+                        pendingMappings++;
+                    }
+                    skipped++;
+                    continue;
+                }
+
+                var (allowedRotations, fragilityType, isStackable, maxStackCount, maxWeightOnTop) = ParseRuleFields(resolution.ResolvedValues);
+                var category = ParseCategory(product.Category);
+
+                var existingItem = await _itemRepository.GetBySkuAsync(product.Sku, companyId, cancellationToken);
+                if (existingItem is not null)
+                {
+                    existingItem.Update(
+                        product.Sku, product.Barcode, product.Name, product.ProductType,
+                        category, product.Width, product.Height, product.Length, product.Diameter,
+                        product.Weight, fragilityType, isStackable, maxStackCount, maxWeightOnTop,
+                        allowedRotations, existingItem.ImageUrl, existingItem.StackGroup, existingItem.SpecialNotes);
+                    existingItem.SetErpSource(product.ErpId, integration.Id);
+                    existingItem.SetRuleAssigned(true);
+                    _itemRepository.Update(existingItem);
+                    updated++;
+                    ruleAssigned++;
+                }
+                else
+                {
+                    var newItem = new Item(
+                        Guid.NewGuid(), product.Sku, product.Name, product.ProductType,
+                        category, product.Width, product.Height, product.Length, product.Weight,
+                        fragilityType, isStackable, maxStackCount, maxWeightOnTop, allowedRotations,
+                        product.Barcode, product.Diameter, companyId: companyId);
+                    newItem.SetErpSource(product.ErpId, integration.Id);
+                    newItem.SetRuleAssigned(true);
+                    _itemRepository.Add(newItem);
+                    added++;
+                    ruleAssigned++;
+                }
+            }
+
+            integration.RecordSync(DateTime.UtcNow);
+            syncLog.Complete(added + updated, ruleAssigned, ruleNotAssigned);
+
+            await _itemRepository.SaveChangesAsync(cancellationToken);
+
+            return Result<SyncErpItemsResult>.Success(
+                new SyncErpItemsResult(syncLog.Id, added, updated, skipped, pendingMappings, ruleAssigned, ruleNotAssigned));
+        }
+        catch (Exception ex)
+        {
+            syncLog.Fail(ex.Message);
+            await _integrationRepository.SaveChangesAsync(cancellationToken);
+            return Result<SyncErpItemsResult>.Failure(
+                new Error(ErrorType.Unexpected, "Sync.Failed", ex.Message));
+        }
+    }
+
+    private static (AllowedRotations, FragilityType, bool, int, decimal) ParseRuleFields(
+        IReadOnlyDictionary<string, string> resolvedValues)
+    {
+        var rotations = resolvedValues.TryGetValue("AllowedRotations", out var r) && Enum.TryParse<AllowedRotations>(r, out var parsedR)
+            ? parsedR : AllowedRotations.All;
+
+        var fragility = resolvedValues.TryGetValue("FragilityType", out var f) && Enum.TryParse<FragilityType>(f, out var parsedF)
+            ? parsedF : FragilityType.NonFragile;
+
+        var stackable = !resolvedValues.TryGetValue("IsStackable", out var s) || !bool.TryParse(s, out var parsedS) || parsedS;
+
+        var maxStack = resolvedValues.TryGetValue("MaxStackCount", out var ms) && int.TryParse(ms, out var parsedMs)
+            ? parsedMs : 1;
+
+        var maxWeight = resolvedValues.TryGetValue("MaxWeightOnTop", out var mw) && decimal.TryParse(mw, out var parsedMw)
+            ? parsedMw : 0m;
+
+        return (rotations, fragility, stackable, maxStack, maxWeight);
+    }
+
+    private static ItemCategory ParseCategory(string? category)
+    {
+        if (string.IsNullOrWhiteSpace(category))
+            return ItemCategory.Package;
+
+        return Enum.TryParse<ItemCategory>(category, ignoreCase: true, out var parsed)
+            ? parsed : ItemCategory.Package;
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/SyncErpItems/SyncErpItemsCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/SyncErpItems/SyncErpItemsCommandValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Integrations.SyncErpItems;
+
+public sealed class SyncErpItemsCommandValidator : AbstractValidator<SyncErpItemsCommand>
+{
+    public SyncErpItemsCommandValidator()
+    {
+        RuleFor(x => x.IntegrationId)
+            .NotEmpty();
+
+        RuleFor(x => x.CategoryFilter)
+            .MaximumLength(200)
+            .When(x => x.CategoryFilter is not null);
+
+        RuleFor(x => x.WarehouseFilter)
+            .MaximumLength(200)
+            .When(x => x.WarehouseFilter is not null);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Integrations/SyncErpItems/SyncErpItemsResult.cs
+++ b/apps/backend/CargoPilot.Application/Features/Integrations/SyncErpItems/SyncErpItemsResult.cs
@@ -1,0 +1,10 @@
+namespace CargoPilot.Application.Features.Integrations.SyncErpItems;
+
+public sealed record SyncErpItemsResult(
+    Guid SyncLogId,
+    int Added,
+    int Updated,
+    int Skipped,
+    int PendingMappings,
+    int RuleAssigned,
+    int RuleNotAssigned);

--- a/apps/backend/CargoPilot.Domain/Entities/PendingItemMapping.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/PendingItemMapping.cs
@@ -1,0 +1,50 @@
+using CargoPilot.Domain.Enums;
+
+namespace CargoPilot.Domain.Entities;
+
+public sealed class PendingItemMapping : BaseEntity {
+    public Guid IntegrationId { get; private set; }
+    public string ErpId { get; private set; } = null!;
+    public string ErpSku { get; private set; } = null!;
+    public string ErpProductName { get; private set; } = null!;
+    public string ErpRawDataJson { get; private set; } = null!;
+    public Guid? CargoPilotItemId { get; private set; }
+    public PendingItemMappingStatus Status { get; private set; }
+
+#pragma warning disable S1144
+    public Integration? Integration { get; private set; }
+    public Item? CargoPilotItem { get; private set; }
+#pragma warning restore S1144
+
+    private PendingItemMapping() { }
+
+    public PendingItemMapping(
+        Guid id,
+        Guid integrationId,
+        string erpId,
+        string erpSku,
+        string erpProductName,
+        string erpRawDataJson) : base(id) {
+        IntegrationId = integrationId;
+        ErpId = erpId;
+        ErpSku = erpSku;
+        ErpProductName = erpProductName;
+        ErpRawDataJson = erpRawDataJson;
+        Status = PendingItemMappingStatus.Pending;
+    }
+
+    public void Approve(Guid cargoPilotItemId) {
+        CargoPilotItemId = cargoPilotItemId;
+        Status = PendingItemMappingStatus.Approved;
+    }
+
+    public void Dismiss() {
+        Status = PendingItemMappingStatus.Dismissed;
+    }
+
+    public void UpdateErpData(string erpSku, string erpProductName, string erpRawDataJson) {
+        ErpSku = erpSku;
+        ErpProductName = erpProductName;
+        ErpRawDataJson = erpRawDataJson;
+    }
+}

--- a/apps/backend/CargoPilot.Domain/Enums/PendingItemMappingStatus.cs
+++ b/apps/backend/CargoPilot.Domain/Enums/PendingItemMappingStatus.cs
@@ -1,0 +1,7 @@
+namespace CargoPilot.Domain.Enums;
+
+public enum PendingItemMappingStatus {
+    Pending = 0,
+    Approved = 1,
+    Dismissed = 2
+}

--- a/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
+++ b/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
@@ -67,6 +67,9 @@ public static class DependencyInjection {
         services.AddScoped<IUserPasswordHistoryRepository, UserPasswordHistoryRepository>();
         services.AddScoped<IErpExportService, ErpExportService>();
         services.AddScoped<INotificationRepository, NotificationRepository>();
+        services.AddScoped<IIntegrationRepository, IntegrationRepository>();
+        services.AddScoped<IPendingItemMappingRepository, PendingItemMappingRepository>();
+        services.AddScoped<IErpProductFetcher, MockErpProductFetcher>();
         services.AddHttpClient<IEmailService, ResendEmailService>(client =>
         {
             // BaseAddress constructor'da options üzerinden set ediliyor.

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContext.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContext.cs
@@ -31,6 +31,7 @@ public class AppDbContext : DbContext {
     public DbSet<SyncLog> SyncLogs => Set<SyncLog>();
     public DbSet<ErpUserMapping> ErpUserMappings => Set<ErpUserMapping>();
     public DbSet<Notification> Notifications => Set<Notification>();
+    public DbSet<PendingItemMapping> PendingItemMappings => Set<PendingItemMapping>();
 
     public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) {
         ApplyAuditFields();
@@ -61,6 +62,7 @@ public class AppDbContext : DbContext {
         modelBuilder.ApplyConfiguration(new SyncLogConfiguration());
         modelBuilder.ApplyConfiguration(new ErpUserMappingConfiguration());
         modelBuilder.ApplyConfiguration(new NotificationConfiguration());
+        modelBuilder.ApplyConfiguration(new PendingItemMappingConfiguration());
     }
 
     private void ApplyAuditFields() {

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/PendingItemMappingConfiguration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/PendingItemMappingConfiguration.cs
@@ -1,0 +1,73 @@
+using CargoPilot.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CargoPilot.Infrastructure.Persistence.Configurations;
+
+internal sealed class PendingItemMappingConfiguration : IEntityTypeConfiguration<PendingItemMapping> {
+    public void Configure(EntityTypeBuilder<PendingItemMapping> builder) {
+        builder.ToTable("PendingItemMappings");
+        builder.HasKey(m => m.Id);
+
+        builder.Property(m => m.CreatedAtUtc)
+            .IsRequired()
+            .HasDefaultValueSql("GETUTCDATE()");
+
+        builder.Property(m => m.CreatedBy);
+        builder.Property(m => m.UpdatedAtUtc);
+        builder.Property(m => m.UpdatedBy);
+
+        builder.Property(m => m.IsDeleted)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(m => m.IsActive)
+            .IsRequired()
+            .HasDefaultValue(true);
+
+        builder.Property(m => m.IntegrationId)
+            .IsRequired();
+
+        builder.Property(m => m.ErpId)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(m => m.ErpSku)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(m => m.ErpProductName)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(m => m.ErpRawDataJson)
+            .IsRequired()
+            .HasColumnType("nvarchar(max)");
+
+        builder.Property(m => m.CargoPilotItemId);
+
+        builder.Property(m => m.Status)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(50);
+
+        builder.HasOne(m => m.Integration)
+            .WithMany()
+            .HasForeignKey(m => m.IntegrationId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(m => m.CargoPilotItem)
+            .WithMany()
+            .HasForeignKey(m => m.CargoPilotItemId)
+            .OnDelete(DeleteBehavior.SetNull)
+            .IsRequired(false);
+
+        builder.HasIndex(m => new { m.IntegrationId, m.ErpId })
+            .HasDatabaseName("IX_PendingItemMappings_IntegrationId_ErpId");
+
+        builder.HasIndex(m => m.IntegrationId)
+            .HasDatabaseName("IX_PendingItemMappings_IntegrationId");
+
+        builder.HasQueryFilter(m => !m.IsDeleted);
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260511172232_AddPendingItemMappingsTable.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260511172232_AddPendingItemMappingsTable.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260511172232_AddPendingItemMappingsTable")]
+    partial class AddPendingItemMappingsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -92,16 +95,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("bit")
                         .HasDefaultValue(false);
-
-                    b.Property<bool>("MustChangePassword")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("bit")
-                        .HasDefaultValue(false);
-
-                    b.Property<string>("PasswordHash")
-                        .HasMaxLength(1000)
-                        .HasColumnType("nvarchar(1000)");
-
 
                     b.Property<DateTime?>("UpdatedAtUtc")
                         .HasColumnType("datetime2");
@@ -314,19 +307,8 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                     b.Property<string>("MappingTable")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<DateTime?>("NextScheduledSyncAt")
-                        .HasColumnType("datetime2");
-
-                    b.Property<int?>("SyncFrequency")
-                        .HasColumnType("int");
-
                     b.Property<int?>("SyncInterval")
                         .HasColumnType("int");
-
-                    b.Property<int>("SyncStatus")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasDefaultValue(0);
 
                     b.Property<string>("SystemName")
                         .IsRequired()
@@ -522,10 +504,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
 
                     b.Property<DateTime?>("DeletedAtUtc")
                         .HasColumnType("datetime2");
-
-                    b.Property<string>("ErpExportStatus")
-                        .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
 
                     b.Property<string>("ErrorCode")
                         .HasMaxLength(64)
@@ -1086,9 +1064,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                         .HasColumnType("bit")
                         .HasDefaultValue(false);
 
-                    b.Property<Guid?>("LoadingPlanId")
-                        .HasColumnType("uniqueidentifier");
-
                     b.Property<int>("RuleAssignedCount")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int")
@@ -1122,9 +1097,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
 
                     b.HasIndex("IntegrationId")
                         .HasDatabaseName("IX_SyncLogs_IntegrationId");
-
-                    b.HasIndex("LoadingPlanId")
-                        .HasDatabaseName("IX_SyncLogs_LoadingPlanId");
 
                     b.ToTable("SyncLogs", (string)null);
                 });
@@ -1653,12 +1625,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                         .HasForeignKey("IntegrationId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
-
-                    b.HasOne("CargoPilot.Domain.Entities.LoadingPlan", null)
-                        .WithMany()
-                        .HasForeignKey("LoadingPlanId")
-                        .OnDelete(DeleteBehavior.SetNull)
-                        .IsRequired(false);
 
                     b.Navigation("Integration");
                 });

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260511172232_AddPendingItemMappingsTable.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260511172232_AddPendingItemMappingsTable.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPendingItemMappingsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PendingItemMappings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    IntegrationId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ErpId = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ErpSku = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    ErpProductName = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    ErpRawDataJson = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CargoPilotItemId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Status = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                    UpdatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    DeletedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false, defaultValue: true),
+                    CreatedBy = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PendingItemMappings", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PendingItemMappings_Integrations_IntegrationId",
+                        column: x => x.IntegrationId,
+                        principalTable: "Integrations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_PendingItemMappings_Items_CargoPilotItemId",
+                        column: x => x.CargoPilotItemId,
+                        principalTable: "Items",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingItemMappings_CargoPilotItemId",
+                table: "PendingItemMappings",
+                column: "CargoPilotItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingItemMappings_IntegrationId",
+                table: "PendingItemMappings",
+                column: "IntegrationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PendingItemMappings_IntegrationId_ErpId",
+                table: "PendingItemMappings",
+                columns: new[] { "IntegrationId", "ErpId" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PendingItemMappings");
+        }
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/IntegrationRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/IntegrationRepository.cs
@@ -14,7 +14,7 @@ internal sealed class IntegrationRepository : IIntegrationRepository
         _dbContext = dbContext;
     }
 
-    public Task<Integration?> GetByIdAsync(Guid id, Guid companyId, CancellationToken cancellationToken = default)
+    public Task<Integration?> GetByIdAsync(Guid id, Guid? companyId, CancellationToken cancellationToken = default)
         => _dbContext.Integrations
             .FirstOrDefaultAsync(i => i.Id == id && i.CompanyId == companyId, cancellationToken);
 
@@ -28,7 +28,7 @@ internal sealed class IntegrationRepository : IIntegrationRepository
             .Where(i => i.CompanyId == companyId)
             .ToListAsync(cancellationToken);
 
-    public void AddSyncLog(SyncLog log) => _dbContext.SyncLogs.Add(log);
+    public void AddSyncLog(SyncLog syncLog) => _dbContext.SyncLogs.Add(syncLog);
 
     public Task SaveChangesAsync(CancellationToken cancellationToken = default)
         => _dbContext.SaveChangesAsync(cancellationToken);

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/ItemRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/ItemRepository.cs
@@ -45,6 +45,12 @@ internal sealed class ItemRepository : IItemRepository
             .ToListAsync(cancellationToken);
     }
 
+    public Task<Item?> GetBySkuAsync(string sku, Guid? companyId, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.Items
+            .FirstOrDefaultAsync(i => i.SKU == sku && i.CompanyId == companyId, cancellationToken);
+    }
+
     public Task<bool> ExistsBySkuAsync(string sku, Guid? companyId, CancellationToken cancellationToken = default)
     {
         return _dbContext.Items

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/PendingItemMappingRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/PendingItemMappingRepository.cs
@@ -1,0 +1,82 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Entities;
+using CargoPilot.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace CargoPilot.Infrastructure.Persistence.Repositories;
+
+internal sealed class PendingItemMappingRepository : IPendingItemMappingRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public PendingItemMappingRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<PendingItemMapping?> GetByIdAsync(Guid id, Guid integrationId, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PendingItemMappings
+            .FirstOrDefaultAsync(m => m.Id == id && m.IntegrationId == integrationId, cancellationToken);
+    }
+
+    public Task<PendingItemMapping?> GetByErpIdAsync(Guid integrationId, string erpId, CancellationToken cancellationToken = default)
+    {
+        return _dbContext.PendingItemMappings
+            .FirstOrDefaultAsync(m => m.IntegrationId == integrationId && m.ErpId == erpId, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<PendingItemMapping>> GetApprovedByIntegrationAsync(Guid integrationId, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.PendingItemMappings
+            .AsNoTracking()
+            .Where(m => m.IntegrationId == integrationId && m.Status == PendingItemMappingStatus.Approved)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<PagedResult<PendingItemMapping>> GetPagedAsync(
+        Guid integrationId,
+        PendingItemMappingStatus? status,
+        int page,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _dbContext.PendingItemMappings
+            .AsNoTracking()
+            .Where(m => m.IntegrationId == integrationId);
+
+        if (status.HasValue)
+            query = query.Where(m => m.Status == status.Value);
+
+        var totalCount = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .OrderByDescending(m => m.CreatedAtUtc)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return new PagedResult<PendingItemMapping>(items, totalCount, page, pageSize);
+    }
+
+    public void Add(PendingItemMapping mapping)
+    {
+        _dbContext.PendingItemMappings.Add(mapping);
+    }
+
+    public void Update(PendingItemMapping mapping)
+    {
+        _dbContext.PendingItemMappings.Update(mapping);
+    }
+
+    public void Remove(PendingItemMapping mapping)
+    {
+        _dbContext.PendingItemMappings.Remove(mapping);
+    }
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        return _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Services/MockErpProductFetcher.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/MockErpProductFetcher.cs
@@ -1,0 +1,58 @@
+using CargoPilot.Application.Common.Erp;
+using CargoPilot.Application.Common.Interfaces;
+using System.Text.Json;
+
+namespace CargoPilot.Infrastructure.Services;
+
+internal sealed class MockErpProductFetcher : IErpProductFetcher
+{
+    public Task<IReadOnlyList<ErpProductDto>> FetchAsync(
+        string apiEndpoint,
+        string? authCredentialsJson,
+        string? categoryFilter,
+        string? warehouseFilter,
+        CancellationToken cancellationToken = default)
+    {
+        var products = new List<ErpProductDto>
+        {
+            new(
+                ErpId: "ERP-001",
+                Sku: "SKU-001",
+                Name: "Test Ürün 1",
+                ProductType: "Standart",
+                Width: 30m,
+                Height: 20m,
+                Length: 40m,
+                Weight: 5m,
+                Category: "Box",
+                Warehouse: "Depo-1",
+                Barcode: "1234567890",
+                Diameter: null,
+                ErpConstraints: new Dictionary<string, string?> { ["DikTasinacak"] = "0" },
+                RawDataJson: JsonSerializer.Serialize(new { ErpId = "ERP-001", Sku = "SKU-001" })),
+
+            new(
+                ErpId: "ERP-002",
+                Sku: "SKU-002",
+                Name: "Test Ürün 2",
+                ProductType: "Kırılgan",
+                Width: 15m,
+                Height: 15m,
+                Length: 15m,
+                Weight: 1m,
+                Category: "Package",
+                Warehouse: "Depo-1",
+                Barcode: null,
+                Diameter: null,
+                ErpConstraints: new Dictionary<string, string?> { ["Kirilgan"] = "Evet" },
+                RawDataJson: JsonSerializer.Serialize(new { ErpId = "ERP-002", Sku = "SKU-002" }))
+        };
+
+        IReadOnlyList<ErpProductDto> filtered = products
+            .Where(p => categoryFilter is null || string.Equals(p.Category, categoryFilter, StringComparison.OrdinalIgnoreCase))
+            .Where(p => warehouseFilter is null || string.Equals(p.Warehouse, warehouseFilter, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        return Task.FromResult(filtered);
+    }
+}

--- a/apps/backend/CargoPilot.WebAPI/Controllers/IntegrationsController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/IntegrationsController.cs
@@ -1,7 +1,10 @@
 using CargoPilot.Application.Features.Integrations.GetSyncSettings;
 using CargoPilot.Application.Features.Integrations.ListIntegrations;
+using CargoPilot.Application.Features.Integrations.PendingItemMappings;
+using CargoPilot.Application.Features.Integrations.SyncErpItems;
 using CargoPilot.Application.Features.Integrations.TriggerSync;
 using CargoPilot.Application.Features.Integrations.UpdateSyncSettings;
+using CargoPilot.Domain.Enums;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -94,6 +97,104 @@ public sealed class IntegrationsController : BaseController
         CancellationToken cancellationToken = default)
     {
         var result = await _mediator.Send(new TriggerSyncCommand(id), cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// ERP'den ürünleri senkronize eder.
+    /// </summary>
+    /// <param name="id">Entegrasyon ID'si.</param>
+    /// <param name="categoryFilter">Kategori filtresi (opsiyonel).</param>
+    /// <param name="warehouseFilter">Depo filtresi (opsiyonel).</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Senkronizasyon tamamlandı, özet döner.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    /// <response code="404">Entegrasyon bulunamadı.</response>
+    [HttpPost("{id:guid}/items/sync")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> SyncItems(
+        Guid id,
+        [FromQuery] string? categoryFilter,
+        [FromQuery] string? warehouseFilter,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new SyncErpItemsCommand(id, categoryFilter, warehouseFilter);
+        var result = await _mediator.Send(command, cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Bekleyen ERP ürün eşleştirmelerini listeler.
+    /// </summary>
+    /// <param name="id">Entegrasyon ID'si.</param>
+    /// <param name="status">Durum filtresi (opsiyonel): Pending=0, Approved=1, Dismissed=2.</param>
+    /// <param name="page">Sayfa numarası (varsayılan: 1).</param>
+    /// <param name="pageSize">Sayfa boyutu, 1-100 arası (varsayılan: 20).</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Bekleyen eşleştirme listesi sayfalı döner.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    /// <response code="404">Entegrasyon bulunamadı.</response>
+    [HttpGet("{id:guid}/pending-item-mappings")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetPendingItemMappings(
+        Guid id,
+        [FromQuery] PendingItemMappingStatus? status,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new GetPendingItemMappingsQuery(id, status, page, pageSize);
+        var result = await _mediator.Send(query, cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Bekleyen bir ERP ürün eşleştirmesini onaylar.
+    /// </summary>
+    /// <param name="id">Entegrasyon ID'si.</param>
+    /// <param name="mappingId">Eşleştirme ID'si.</param>
+    /// <param name="cargoPilotItemId">Bağlanacak Cargo Pilot ürün ID'si.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Eşleştirme onaylandı.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    /// <response code="404">Entegrasyon veya eşleştirme bulunamadı.</response>
+    [HttpPut("{id:guid}/pending-item-mappings/{mappingId:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ApprovePendingItemMapping(
+        Guid id,
+        Guid mappingId,
+        [FromQuery] Guid cargoPilotItemId,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new ApprovePendingItemMappingCommand(id, mappingId, cargoPilotItemId);
+        var result = await _mediator.Send(command, cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Bekleyen bir ERP ürün eşleştirmesini reddeder (Dismissed olarak işaretler).
+    /// </summary>
+    /// <param name="id">Entegrasyon ID'si.</param>
+    /// <param name="mappingId">Eşleştirme ID'si.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Eşleştirme reddedildi.</response>
+    /// <response code="404">Entegrasyon veya eşleştirme bulunamadı.</response>
+    [HttpDelete("{id:guid}/pending-item-mappings/{mappingId:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeletePendingItemMapping(
+        Guid id,
+        Guid mappingId,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new DeletePendingItemMappingCommand(id, mappingId);
+        var result = await _mediator.Send(command, cancellationToken);
         return HandleResult(result);
     }
 }


### PR DESCRIPTION
## Özet

ERP ürün senkronizasyon akışı ve pending mapping yönetimi eklendi. Eklenen endpoint'ler:

- `POST /api/v1/integrations/{id}/items/sync` — ERP'den ürün çekip SKU eşleşmesine göre item ekler/günceller; kısıt eşleştirmesi tamamlanmamış ürünler için `PendingItemMapping` kaydı oluşturur.
- `GET /api/v1/integrations/{id}/pending-item-mappings` — Bekleyen eşleştirmeleri sayfalı listeler, durum filtresi destekler.
- `PUT /api/v1/integrations/{id}/pending-item-mappings/{mappingId}` — Eşleştirmeyi onaylar ve ilgili Cargo Pilot item'ına bağlar.
- `DELETE /api/v1/integrations/{id}/pending-item-mappings/{mappingId}` — Eşleştirmeyi reddeder (Dismissed olarak işaretler).


## İlgili User Story / Issue

US-VY-35

## Değişiklik Tipi

- [x] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x] Manuel test yapıldı

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

- `IErpProductFetcher` şu an `MockErpProductFetcher` ile bağlı; gerçek ERP client sonraki story'de implemente edilecek.
- Migration: `AddPendingItemMappingsTable` — `PendingItemMappings` tablosu oluşturuldu, `Integrations` ve `Items` tablolarına FK'lar eklendi.
- Branch `origin/test` üzerine rebase edildi; `dev` ile conflict var, merge sırasında çözülmesi gerekiyor.
