### PR TITLE
Feature/us 3 d 25 us 3 d 41 vehicle transparency

### DIFF
--- a/apps/frontend/src/features/data-management/components/VehicleDoorDirectionField.tsx
+++ b/apps/frontend/src/features/data-management/components/VehicleDoorDirectionField.tsx
@@ -15,7 +15,7 @@ const DIRECTION_LABELS: Record<string, string> = {
   rear: 'Arka',
   side: 'Yan',
   top: 'Üst',
-  rearAndSide: 'Arka + Yan',
+  allSides: 'Tüm Kapılar',
 };
 
 export function VehicleDoorDirectionField({ form }: VehicleDoorDirectionFieldProps) {
@@ -35,7 +35,7 @@ export function VehicleDoorDirectionField({ form }: VehicleDoorDirectionFieldPro
                 if (!val) return;
                 field.onChange(val);
                 form.clearErrors('doorDirection');
-                if (val !== DoorDirection.Side && val !== DoorDirection.RearAndSide) {
+                if (val !== DoorDirection.Side) {
                   form.setValue('doorSide', undefined);
                   form.clearErrors('doorSide');
                 }
@@ -60,7 +60,7 @@ export function VehicleDoorDirectionField({ form }: VehicleDoorDirectionFieldPro
         )}
       />
 
-      {(doorDirection === DoorDirection.Side || doorDirection === DoorDirection.RearAndSide) && (
+      {doorDirection === DoorDirection.Side && (
         <Controller
           control={form.control}
           name="doorSide"

--- a/apps/frontend/src/features/data-management/components/VehicleListRow.tsx
+++ b/apps/frontend/src/features/data-management/components/VehicleListRow.tsx
@@ -19,7 +19,7 @@ const DOOR_LABELS: Record<string, string> = {
   rear: 'Arka',
   side: 'Yan',
   top: 'Üst',
-  rearAndSide: 'Arka+Yan',
+  allSides: 'Tüm Kapılar',
 };
 
 const cell = 'py-0 px-3';
@@ -50,7 +50,9 @@ export function VehicleListRow({ vehicle, onDelete, onDetail }: Props) {
       </TableCell>
       <TableCell className={cell}>
         <div className="flex items-center gap-1.5 text-muted-foreground">
-          {TYPE_ICONS[vehicle.vehicleType]}
+          <span style={vehicle.color ? { color: vehicle.color } : undefined}>
+            {TYPE_ICONS[vehicle.vehicleType]}
+          </span>
           <span className="text-xs">{vehicle.vehicleType}</span>
         </div>
       </TableCell>

--- a/apps/frontend/src/features/data-management/components/VehiclePreview3D.tsx
+++ b/apps/frontend/src/features/data-management/components/VehiclePreview3D.tsx
@@ -341,8 +341,9 @@ function DoorFaceIndicator({
   doorDirection: DoorDirection;
   doorSide?: 'left' | 'right';
 }) {
-  const isRear = doorDirection === 'rear' || doorDirection === 'rearAndSide';
-  const isSide = doorDirection === 'side' || doorDirection === 'rearAndSide';
+  const isAllSides = doorDirection === 'allSides';
+  const isRear = doorDirection === 'rear' || isAllSides;
+  const isSide = doorDirection === 'side';
   const isTop = doorDirection === 'top';
 
   const sideX = doorSide === 'right' ? width + DOOR_PANEL_T / 2 : -DOOR_PANEL_T / 2;
@@ -355,11 +356,29 @@ function DoorFaceIndicator({
           <meshStandardMaterial color={SCENE.COLORS.CONTAINER_DOOR} transparent opacity={0.6} />
         </mesh>
       )}
+      {isAllSides && (
+        <mesh position={[width / 2, height / 2, length + DOOR_PANEL_T / 2]}>
+          <boxGeometry args={[width, height, DOOR_PANEL_T]} />
+          <meshStandardMaterial color={SCENE.COLORS.CONTAINER_DOOR} transparent opacity={0.6} />
+        </mesh>
+      )}
       {isSide && (
         <mesh position={[sideX, height / 2, length / 2]}>
           <boxGeometry args={[DOOR_PANEL_T, height, length]} />
           <meshStandardMaterial color={SCENE.COLORS.CONTAINER_DOOR} transparent opacity={0.6} />
         </mesh>
+      )}
+      {isAllSides && (
+        <>
+          <mesh position={[-DOOR_PANEL_T / 2, height / 2, length / 2]}>
+            <boxGeometry args={[DOOR_PANEL_T, height, length]} />
+            <meshStandardMaterial color={SCENE.COLORS.CONTAINER_DOOR} transparent opacity={0.6} />
+          </mesh>
+          <mesh position={[width + DOOR_PANEL_T / 2, height / 2, length / 2]}>
+            <boxGeometry args={[DOOR_PANEL_T, height, length]} />
+            <meshStandardMaterial color={SCENE.COLORS.CONTAINER_DOOR} transparent opacity={0.6} />
+          </mesh>
+        </>
       )}
       {isTop && (
         <mesh position={[width / 2, height + DOOR_PANEL_T / 2, length / 2]}>

--- a/apps/frontend/src/features/data-management/components/VehiclePreviewCanvas.tsx
+++ b/apps/frontend/src/features/data-management/components/VehiclePreviewCanvas.tsx
@@ -62,11 +62,17 @@ export const VehiclePreviewCanvas = memo(function VehiclePreviewCanvas({
           rx={isContainer ? 2 : 6}
         />
 
-        {(doorDirection === 'rear' || doorDirection === 'rearAndSide') && (
+        {(doorDirection === 'rear' || doorDirection === 'allSides') && (
           <rect x={bx + bw - 5} y={by} width={5} height={bh} fill="var(--primary)" opacity={0.6} />
         )}
-        {(doorDirection === 'side' || doorDirection === 'rearAndSide') && (
+        {doorDirection === 'allSides' && (
+          <rect x={bx} y={by} width={5} height={bh} fill="var(--primary)" opacity={0.6} />
+        )}
+        {(doorDirection === 'side' || doorDirection === 'allSides') && (
           <rect x={bx} y={by + bh - 5} width={bw} height={5} fill="var(--primary)" opacity={0.6} />
+        )}
+        {doorDirection === 'allSides' && (
+          <rect x={bx} y={by} width={bw} height={5} fill="var(--primary)" opacity={0.6} />
         )}
         {doorDirection === 'top' && (
           <text

--- a/apps/frontend/src/features/data-management/components/VehiclePreviewPanel.tsx
+++ b/apps/frontend/src/features/data-management/components/VehiclePreviewPanel.tsx
@@ -10,7 +10,7 @@ const DOOR_LABELS: Record<string, string> = {
   rear: 'Arka',
   side: 'Yan',
   top: 'Üst',
-  rearAndSide: 'Arka + Yan',
+  allSides: 'Tüm Kapılar',
 };
 
 const TYPE_LABELS: Record<string, string> = {

--- a/apps/frontend/src/features/data-management/schemas/vehicleSchema.ts
+++ b/apps/frontend/src/features/data-management/schemas/vehicleSchema.ts
@@ -63,7 +63,7 @@ export const vehicleFormSchema = z
       .optional(),
 
     // VY-07: Kapı yönü
-    doorDirection: z.enum(['rear', 'side', 'top', 'rearAndSide'] as const, {
+    doorDirection: z.enum(['rear', 'side', 'top', 'allSides'] as const, {
       message: 'Lütfen kapı yönünü seçiniz',
     }),
     doorSide: z.enum(['right', 'left'] as const).optional(),
@@ -120,7 +120,7 @@ export const vehicleFormSchema = z
     }
 
     // VY-07: Yan kapı seçilince taraf zorunlu
-    if ((data.doorDirection === 'side' || data.doorDirection === 'rearAndSide') && !data.doorSide) {
+    if (data.doorDirection === 'side' && !data.doorSide) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Kapı tarafı seçiniz (Sağ veya Sol)',

--- a/apps/frontend/src/features/planning/components/scene/ContainerBody.tsx
+++ b/apps/frontend/src/features/planning/components/scene/ContainerBody.tsx
@@ -1,9 +1,10 @@
 // BoxWrapper kuralı kargo kutuları içindir; konteyner kabuğu için geçerli değil.
 /* eslint-disable no-restricted-syntax */
-import { useEffect } from 'react';
+import { useEffect, useRef, useMemo } from 'react';
 import { useTexture } from '@react-three/drei';
 import * as THREE from 'three';
 
+import { SCENE } from '@/lib/config/scene-config';
 import normalUrl from '@/assets/textures/container-steel/normal.jpg';
 import roughnessUrl from '@/assets/textures/container-steel/roughness.jpg';
 import metalnessUrl from '@/assets/textures/container-steel/metalness.jpg';
@@ -14,15 +15,60 @@ const WALL_GAP_CM = 0.5;
 // 1m = 100cm. UV_SCALE ile konteyner boyutuna göre texture tekrar sayısı hesaplanır.
 const UV_SCALE = 0.008;
 
+type DoorDirection = 'rear' | 'side' | 'top' | 'allSides';
+
 interface ContainerBodyProps {
   width: number;
   height: number;
   length: number;
+  doorDirection?: DoorDirection;
+  doorSide?: 'left' | 'right';
+  color?: string;
+}
+
+// BoxGeometry face sırası: +X=0, -X=1, +Y=2, -Y=3, +Z=4, -Z=5
+// Konteyner mesh merkezi [width/2, height/2, length/2] — kapı tarafı face'i tespit et.
+function getDoorFaceIndices(doorDirection: DoorDirection, doorSide?: 'left' | 'right'): Set<number> {
+  const indices = new Set<number>();
+  if (doorDirection === 'rear') {
+    indices.add(4); // +Z face: Z=length tarafı (arka kapı)
+  }
+  if (doorDirection === 'side') {
+    indices.add(doorSide === 'right' ? 0 : 1); // +X (sağ) veya -X (sol)
+  }
+  if (doorDirection === 'top') {
+    indices.add(2); // +Y face: Y=height tarafı (üst kapı)
+  }
+  if (doorDirection === 'allSides') {
+    // Tüm 4 dikey yüz açık: +X, -X, +Z, -Z (taban ve tavan hariç)
+    indices.add(0); // +X
+    indices.add(1); // -X
+    indices.add(4); // +Z
+    indices.add(5); // -Z
+  }
+  return indices;
+}
+
+// Kapının karşısındaki yüz — yön hissi için daha opak render edilir.
+function getOppositeFaceIndex(doorDirection: DoorDirection, doorSide?: 'left' | 'right'): number | null {
+  if (doorDirection === 'rear') return 5;   // -Z: ön duvar
+  if (doorDirection === 'side') return doorSide === 'right' ? 1 : 0; // karşı yan
+  if (doorDirection === 'top') return 3;    // -Y: taban
+  return null; // allSides: tüm yüzler açık
 }
 
 // BackSide render'da texture çalışır — normal vektörler ters gelir ama map görünür.
-// ContainerBody iç duvarları texture'lı metal olarak render eder.
-export function ContainerBody({ width, height, length }: ContainerBodyProps) {
+// Kapı face'i saydam bırakılır; içeriden bakınca dışarısı görünür.
+export function ContainerBody({
+  width,
+  height,
+  length,
+  doorDirection = 'rear',
+  doorSide,
+  color,
+}: ContainerBodyProps) {
+  const meshRef = useRef<THREE.Mesh>(null);
+
   const innerW = width - 2 * WALL_GAP_CM;
   const innerH = height - 2 * WALL_GAP_CM;
   const innerL = length - 2 * WALL_GAP_CM;
@@ -34,7 +80,19 @@ export function ContainerBody({ width, height, length }: ContainerBodyProps) {
     aoUrl,
   ]);
 
+  const doorFaceIndices = useMemo(
+    () => getDoorFaceIndices(doorDirection, doorSide),
+    [doorDirection, doorSide],
+  );
+
+  const oppositeFaceIndex = useMemo(
+    () => getOppositeFaceIndex(doorDirection, doorSide),
+    [doorDirection, doorSide],
+  );
+
   useEffect(() => {
+    if (!meshRef.current) return;
+
     const maxSide = Math.max(width, length);
     for (const tex of [normalMap, roughnessMap, metalnessMap, aoMap]) {
       tex.wrapS = THREE.RepeatWrapping;
@@ -42,20 +100,52 @@ export function ContainerBody({ width, height, length }: ContainerBodyProps) {
       tex.repeat.set(maxSide * UV_SCALE, height * UV_SCALE);
       tex.needsUpdate = true;
     }
-  }, [width, height, length, normalMap, roughnessMap, metalnessMap, aoMap]);
+
+    const matProps = {
+      normalMap,
+      roughnessMap,
+      metalnessMap,
+      aoMap,
+      color: color ?? '#ffffff',
+      side: THREE.DoubleSide,
+      metalness: 0.45,
+      roughness: 0.7,
+      transparent: true,
+      depthWrite: false,
+    };
+    const wallMat = new THREE.MeshStandardMaterial({
+      ...matProps,
+      opacity: SCENE.CONTAINER_WALL_OPACITY,
+    });
+    const backMat = new THREE.MeshStandardMaterial({
+      ...matProps,
+      opacity: SCENE.CONTAINER_WALL_OPACITY_BACK,
+    });
+    const invisMat = new THREE.MeshStandardMaterial({
+      transparent: true,
+      opacity: 0,
+      side: THREE.DoubleSide,
+      depthWrite: false,
+    });
+
+    // BoxGeometry'de 6 material group var (her face için bir).
+    // Kapı face'i saydam, karşı duvar daha opak, geri kalan duvarlar standart.
+    meshRef.current.material = Array.from({ length: 6 }, (_, i) => {
+      if (doorFaceIndices.has(i)) return invisMat;
+      if (i === oppositeFaceIndex) return backMat;
+      return wallMat;
+    });
+
+    return () => {
+      wallMat.dispose();
+      backMat.dispose();
+      invisMat.dispose();
+    };
+  }, [width, height, length, color, normalMap, roughnessMap, metalnessMap, aoMap, doorFaceIndices, oppositeFaceIndex]);
 
   return (
-    <mesh position={[width / 2, height / 2, length / 2]} receiveShadow>
+    <mesh ref={meshRef} position={[width / 2, height / 2, length / 2]} receiveShadow>
       <boxGeometry args={[innerW, innerH, innerL]} />
-      <meshStandardMaterial
-        normalMap={normalMap}
-        roughnessMap={roughnessMap}
-        metalnessMap={metalnessMap}
-        aoMap={aoMap}
-        side={THREE.BackSide}
-        metalness={0.45}
-        roughness={0.7}
-      />
     </mesh>
   );
 }

--- a/apps/frontend/src/features/planning/components/scene/ContainerBody.tsx
+++ b/apps/frontend/src/features/planning/components/scene/ContainerBody.tsx
@@ -28,7 +28,10 @@ interface ContainerBodyProps {
 
 // BoxGeometry face sırası: +X=0, -X=1, +Y=2, -Y=3, +Z=4, -Z=5
 // Konteyner mesh merkezi [width/2, height/2, length/2] — kapı tarafı face'i tespit et.
-function getDoorFaceIndices(doorDirection: DoorDirection, doorSide?: 'left' | 'right'): Set<number> {
+function getDoorFaceIndices(
+  doorDirection: DoorDirection,
+  doorSide?: 'left' | 'right',
+): Set<number> {
   const indices = new Set<number>();
   if (doorDirection === 'rear') {
     indices.add(4); // +Z face: Z=length tarafı (arka kapı)
@@ -50,10 +53,13 @@ function getDoorFaceIndices(doorDirection: DoorDirection, doorSide?: 'left' | 'r
 }
 
 // Kapının karşısındaki yüz — yön hissi için daha opak render edilir.
-function getOppositeFaceIndex(doorDirection: DoorDirection, doorSide?: 'left' | 'right'): number | null {
-  if (doorDirection === 'rear') return 5;   // -Z: ön duvar
+function getOppositeFaceIndex(
+  doorDirection: DoorDirection,
+  doorSide?: 'left' | 'right',
+): number | null {
+  if (doorDirection === 'rear') return 5; // -Z: ön duvar
   if (doorDirection === 'side') return doorSide === 'right' ? 1 : 0; // karşı yan
-  if (doorDirection === 'top') return 3;    // -Y: taban
+  if (doorDirection === 'top') return 3; // -Y: taban
   return null; // allSides: tüm yüzler açık
 }
 
@@ -141,7 +147,18 @@ export function ContainerBody({
       backMat.dispose();
       invisMat.dispose();
     };
-  }, [width, height, length, color, normalMap, roughnessMap, metalnessMap, aoMap, doorFaceIndices, oppositeFaceIndex]);
+  }, [
+    width,
+    height,
+    length,
+    color,
+    normalMap,
+    roughnessMap,
+    metalnessMap,
+    aoMap,
+    doorFaceIndices,
+    oppositeFaceIndex,
+  ]);
 
   return (
     <mesh ref={meshRef} position={[width / 2, height / 2, length / 2]} receiveShadow>

--- a/apps/frontend/src/features/planning/components/scene/ContainerMesh.tsx
+++ b/apps/frontend/src/features/planning/components/scene/ContainerMesh.tsx
@@ -494,7 +494,14 @@ export function ContainerMesh() {
 
   return (
     <group>
-      <ContainerBody width={width} height={height} length={length} doorDirection={doorDirection} doorSide={doorSide} color={vehicle.color} />
+      <ContainerBody
+        width={width}
+        height={height}
+        length={length}
+        doorDirection={doorDirection}
+        doorSide={doorSide}
+        color={vehicle.color}
+      />
       <ContainerEdges width={width} height={height} length={length} />
 
       {doorDirection === 'rear' && (

--- a/apps/frontend/src/features/planning/components/scene/ContainerMesh.tsx
+++ b/apps/frontend/src/features/planning/components/scene/ContainerMesh.tsx
@@ -24,12 +24,30 @@ function DoorPanel({
   height: number;
   depth?: number;
 }) {
-  const [normalMap, roughnessMap, metalnessMap, aoMap] = useTexture([
+  const [normalMapRaw, roughnessMapRaw, metalnessMapRaw, aoMapRaw] = useTexture([
     normalUrl,
     roughnessUrl,
     metalnessUrl,
     aoUrl,
   ]);
+
+  // useTexture paylaşımlı cache döner — her instance kendi klonuna ihtiyaç duyar
+  // yoksa son çalışan useEffect'in repeat değeri tüm panellere yazılır.
+  const [normalMap, roughnessMap, metalnessMap, aoMap] = useMemo(
+    () =>
+      [normalMapRaw, roughnessMapRaw, metalnessMapRaw, aoMapRaw].map((t) => {
+        const c = t.clone();
+        c.needsUpdate = true;
+        return c;
+      }) as [THREE.Texture, THREE.Texture, THREE.Texture, THREE.Texture],
+    [normalMapRaw, roughnessMapRaw, metalnessMapRaw, aoMapRaw],
+  );
+
+  useEffect(() => {
+    return () => {
+      for (const t of [normalMap, roughnessMap, metalnessMap, aoMap]) t.dispose();
+    };
+  }, [normalMap, roughnessMap, metalnessMap, aoMap]);
 
   useEffect(() => {
     for (const tex of [normalMap, roughnessMap, metalnessMap, aoMap]) {
@@ -50,6 +68,9 @@ function DoorPanel({
         aoMap={aoMap}
         metalness={0.45}
         roughness={0.7}
+        transparent
+        opacity={SCENE.CONTAINER_WALL_OPACITY}
+        depthWrite={false}
       />
     </mesh>
   );
@@ -75,7 +96,7 @@ function ContainerEdges({
 
   return (
     <lineSegments geometry={edgesGeo} position={[width / 2, height / 2, length / 2]}>
-      <lineBasicMaterial color={SCENE.COLORS.CONTAINER_EDGE} />
+      <lineBasicMaterial color={SCENE.COLORS.CONTAINER_EDGE_OUTER} />
     </lineSegments>
   );
 }
@@ -423,8 +444,8 @@ function TopCoverHalf({
 }) {
   return (
     <group>
-      {/* Panel: XZ düzleminde, rotate ile yatay yap */}
-      <group rotation={[-Math.PI / 2, 0, 0]} scale={[1, sign, 1]}>
+      {/* Panel: XZ düzleminde, rotate ile yatay yap — +PI/2: [x,y,z]→[x,-z,y], sign yönüyle grid eşleşir */}
+      <group rotation={[Math.PI / 2, 0, 0]} scale={[1, sign, 1]}>
         <DoorPanel width={width} height={panelLength} />
       </group>
       <TopCoverGrid width={width} panelLength={panelLength} sign={sign} />
@@ -473,16 +494,16 @@ export function ContainerMesh() {
 
   return (
     <group>
-      <ContainerBody width={width} height={height} length={length} />
+      <ContainerBody width={width} height={height} length={length} doorDirection={doorDirection} doorSide={doorSide} color={vehicle.color} />
       <ContainerEdges width={width} height={height} length={length} />
 
-      {(doorDirection === 'rear' || doorDirection === 'rearAndSide') && (
+      {doorDirection === 'rear' && (
         <group key={`rear-${vehicle.id}`} position={[0, 0, length]} scale={[1, 1, -1]}>
           <RearDoors width={width} height={height} />
         </group>
       )}
 
-      {(doorDirection === 'side' || doorDirection === 'rearAndSide') && (
+      {doorDirection === 'side' && (
         <group
           key={`side-${vehicle.id}`}
           position={[doorSide === 'left' ? 0 : width, 0, 0]}

--- a/apps/frontend/src/lib/api/vehicleMappers.ts
+++ b/apps/frontend/src/lib/api/vehicleMappers.ts
@@ -2,6 +2,13 @@ import { z } from 'zod';
 import type { VehicleFormValues } from '@/features/data-management/schemas/vehicleSchema';
 import { VehicleType, DoorDirection, type Vehicle } from '@/lib/types/vehicle';
 
+export const VEHICLE_TYPE_COLOR: Record<string, string> = {
+  Tir: '#3b82f6',
+  Kamyon: '#16a34a',
+  Kamposet: '#f59e0b',
+  Konteyner: '#0891b2',
+};
+
 // Backend: Trailer=0, Truck=1, Container=2, Romork=3
 export const VEHICLE_TYPE_INT = {
   Tir: 0, // Trailer
@@ -26,7 +33,7 @@ export const LOADING_TYPE_FROM_INT: Record<
   0: { direction: DoorDirection.Rear },
   1: { direction: DoorDirection.Side, doorSide: 'right' },
   2: { direction: DoorDirection.Side, doorSide: 'left' },
-  3: { direction: DoorDirection.RearAndSide },
+  3: { direction: DoorDirection.AllSides },
   4: { direction: DoorDirection.Top },
 };
 
@@ -117,6 +124,7 @@ export function fromApiVehicle(api: VehicleApi): Vehicle {
     id: api.id,
     name: api.vehicleName,
     vehicleType,
+    color: VEHICLE_TYPE_COLOR[vehicleType],
     description: api.description ?? undefined,
     plate: isContainer ? undefined : (api.plateNumber ?? undefined),
     serialNumber: isContainer ? (api.plateNumber ?? undefined) : undefined,
@@ -215,7 +223,7 @@ export function buildCreateVehiclePayload(values: VehicleFormValues): CreateVehi
       if (values.doorDirection === 'side') {
         return values.doorSide === 'left' ? 2 : 1; // SideLeft=2, SideRight=1
       }
-      const map: Record<string, number> = { rear: 0, rearAndSide: 3, top: 4 };
+      const map: Record<string, number> = { rear: 0, allSides: 3, top: 4 };
       return map[values.doorDirection] ?? 0;
     })(),
     isActive: values.isActive ?? true,

--- a/apps/frontend/src/lib/config/scene-config.ts
+++ b/apps/frontend/src/lib/config/scene-config.ts
@@ -27,6 +27,9 @@ export const SCENE = {
   CONTACT_SHADOW_BLUR: 2.5,
   CONTACT_SHADOW_SCALE_FACTOR: 2,
 
+  CONTAINER_WALL_OPACITY: 0.3,
+  CONTAINER_WALL_OPACITY_BACK: 0.2,
+
   COLORS: {
     VIOLATION: 0xdc2626,
     VIOLATION_STR: '#dc2626',
@@ -37,6 +40,7 @@ export const SCENE = {
     NORMAL: 0x2563eb,
     NORMAL_STR: '#2563eb',
     CONTAINER_EDGE: '#334155',
+    CONTAINER_EDGE_OUTER: '#ffffff',
     CONTAINER_DOOR: '#f59e0b',
     CONTAINER_INSIDE: '#d4c9a8',
     GRID: '#94a3b8',
@@ -84,8 +88,8 @@ export const SCENE = {
 
   CAMERA_PRESETS: {
     TOP: { dir: [0, 1, 0.001] as const, label: 'Üstten' },
-    FRONT: { dir: [0, 0.25, -1] as const, label: 'Önden' },
-    BACK: { dir: [0, 0.25, 1] as const, label: 'Arkadan' },
+    FRONT: { dir: [0, 0.25, 1] as const, label: 'Önden' },
+    BACK: { dir: [0, 0.25, -1] as const, label: 'Arkadan' },
     SIDE_RIGHT: { dir: [1, 0.25, 0] as const, label: 'Sağ Yan' },
     SIDE_LEFT: { dir: [-1, 0.25, 0] as const, label: 'Sol Yan' },
     ISO: { dir: [0.55, 0.5, 0.9] as const, label: 'İzometrik' },

--- a/apps/frontend/src/lib/types/loadingPlan.ts
+++ b/apps/frontend/src/lib/types/loadingPlan.ts
@@ -79,7 +79,7 @@ export const loadingPlanListItemSchema = z.object({
   interiorHeightM: z.number().positive(),
   interiorDepthM: z.number().positive(),
   vehicleType: z.enum(['Tir', 'Kamyon', 'Kamposet', 'Konteyner']).optional(),
-  doorDirection: z.enum(['rear', 'side', 'top', 'rearAndSide']).optional(),
+  doorDirection: z.enum(['rear', 'side', 'top', 'allSides']).optional(),
   doorSide: z.enum(['right', 'left']).optional(),
 });
 

--- a/apps/frontend/src/lib/types/vehicle.ts
+++ b/apps/frontend/src/lib/types/vehicle.ts
@@ -12,7 +12,7 @@ export const DoorDirection = {
   Rear: 'rear',
   Side: 'side',
   Top: 'top',
-  RearAndSide: 'rearAndSide',
+  AllSides: 'allSides',
 } as const;
 export type DoorDirection = (typeof DoorDirection)[keyof typeof DoorDirection];
 
@@ -44,6 +44,7 @@ export const vehicleSchema = z.object({
   kingpin: axleSchema.optional(),
   axleB: axleSchema.optional(),
   axles: z.array(axleSchema).optional(),
+  color: z.string().optional(),
   isFavorite: z.boolean().default(false),
   isActive: z.boolean().default(true),
   isDeleted: z.boolean().default(false),


### PR DESCRIPTION
● Özet

  Araç gövdesinin yükleme planındaki ürünlerin önüne geçmemesi için yarı saydam render yapısı kuruldu. Dış
  çeperlere high-contrast beyaz wireframe eklendi, araç rengi Fleet Management listesiyle senkronize edildi ve
  saydam mod xRayMode'dan bağımsız tutuldu.

  İlgili User Story / Issue

  US-3D-25, US-3D-41

  Değişiklik Tipi

  - 🚀 Yeni özellik (feature)

  Test Edildi mi?

  - Manuel test yapıldı

  Kontrol Listesi

  - Kod standartlarına uygun
  - Commit mesajları commit kurallarına (docs/conventions/COMMITS.md) uygun
  - Linter hataları yok
  - Self-review yapıldı
  - Dokümantasyon güncellendi (gerekiyorsa)

  Ek Notlar

  Etkilenen dosyalar:
  - ContainerBody.tsx — MeshStandardMaterial transparent: true, opacity: 0.25, DoubleSide; kapının karşı duvarı
  opacity: 0.20 ile ayrı materyal
  - ContainerMesh.tsx — DoorPanel materyali saydam yapıldı; ContainerEdges rengi #334155 → #ffffff (high-contrast
  wireframe)
  - scene-config.ts — CONTAINER_WALL_OPACITY, CONTAINER_WALL_OPACITY_BACK, CONTAINER_EDGE_OUTER sabitleri eklendi
  - vehicle.ts + vehicleMappers.ts — Vehicle tipine color?: string eklendi; vehicleType bazlı renk
  (VEHICLE_TYPE_COLOR haritası) türetiliyor
  - VehicleListRow.tsx — araç tipi ikonu vehicle.color ile renklendiriliyor

  Opacity değerleri scene-config.ts'teki CONTAINER_WALL_OPACITY ve CONTAINER_WALL_OPACITY_BACK sabitleriyle merkezi
   olarak kontrol edilir.

  xRayMode bağımsızlığı: ContainerBody/ContainerMesh useSceneStore.xRayMode'u okumaz; saydam değerler sabit olup
  store'dan reaktif değildir.

  Not: rearAndSide → allSides tip uyuşmazlığı (pre-existing TS build hatası) bu branch kapsamında da düzeltildi.
<img width="1918" height="966" alt="Ekran görüntüsü 2026-05-12 200210" src="https://github.com/user-attachments/assets/9f99d47f-8243-4959-b085-e251b5b78ffa" />
