### PR TITLE
ci(test-deploy): VITE_OAUTH_GOOGLE_URL build-args fix

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -197,6 +197,12 @@ jobs:
           tags: |
             ghcr.io/divizyon/cargo-pilot-frontend:test
             ghcr.io/divizyon/cargo-pilot-frontend:${{ steps.sha.outputs.tag }}
+          build-args: |
+            VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}
+            VITE_OAUTH_GOOGLE_URL=${{ secrets.VITE_OAUTH_GOOGLE_URL }}
+            VITE_OAUTH_MICROSOFT_URL=${{ secrets.VITE_OAUTH_MICROSOFT_URL }}
+            VITE_APP_ENV=test
+            VITE_APP_VERSION=${{ github.sha }}
           cache-from: type=gha,scope=frontend-test
           cache-to: type=gha,mode=max,scope=frontend-test
 
@@ -281,6 +287,12 @@ jobs:
           push: false
           load: true
           tags: ghcr.io/divizyon/cargo-pilot-frontend:test
+          build-args: |
+            VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}
+            VITE_OAUTH_GOOGLE_URL=${{ secrets.VITE_OAUTH_GOOGLE_URL }}
+            VITE_OAUTH_MICROSOFT_URL=${{ secrets.VITE_OAUTH_MICROSOFT_URL }}
+            VITE_APP_ENV=test
+            VITE_APP_VERSION=${{ github.sha }}
           cache-from: type=gha,scope=frontend-test
           cache-to: type=gha,mode=max,scope=frontend-test
 


### PR DESCRIPTION
## Sorun

`VITE_OAUTH_GOOGLE_URL` gibi `VITE_*` değişkenleri Vite'ın **build zamanında** bundle'a gömülür. Sunucudaki `.env.test` veya Docker Compose `environment:` bloğu image zaten derlendiği için etkisizdir.

`test-deploy.yml`'deki her iki frontend build adımında `build-args` bloğu hiç yoktu → `VITE_OAUTH_GOOGLE_URL` her zaman `undefined` → Google butonu görünür ama tıklanınca `handleOAuth(undefined)` → `if (!url) return` → sessizce hiçbir şey olmaz.

## Değişiklik

Sadece `.github/workflows/test-deploy.yml` — 12 satır eklendi:

- **build job** `Frontend image build ve GHCR push` adımına `build-args` eklendi
- **deploy job** `Frontend image build (deploy için)` adımına `build-args` eklendi

```yaml
build-args: |
  VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}
  VITE_OAUTH_GOOGLE_URL=${{ secrets.VITE_OAUTH_GOOGLE_URL }}
  VITE_OAUTH_MICROSOFT_URL=${{ secrets.VITE_OAUTH_MICROSOFT_URL }}
  VITE_APP_ENV=test
  VITE_APP_VERSION=${{ github.sha }}
```

## Ön Koşul

GitHub Secrets altında tanımlı olmalı:
- `VITE_API_BASE_URL` ✅ (zaten var)
- `VITE_OAUTH_GOOGLE_URL` ✅ (zaten var)
- `VITE_OAUTH_MICROSOFT_URL` — opsiyonel, boş bırakılabilir

🤖 Generated with [Claude Code](https://claude.com/claude-code)