### PR TITLE
ci: e-posta değiştirme özelliği için EmailChange env var'larını ekle

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -245,6 +245,7 @@ jobs:
       RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL || 'ci@example.com' }}
       RESEND_FROM_NAME: ${{ secrets.RESEND_FROM_NAME || 'Cargo Pilot CI' }}
       PASSWORD_RESET_FRONTEND_URL: ${{ secrets.PASSWORD_RESET_FRONTEND_URL || 'http://localhost:3001/auth/reset-password' }}
+      EMAIL_CHANGE_FRONTEND_CONFIRM_URL: ${{ secrets.EMAIL_CHANGE_FRONTEND_CONFIRM_URL || 'http://localhost:3001/confirm-email-change' }}
 
     steps:
       - name: Kodu al

--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -32,6 +32,8 @@ services:
       Resend__FromEmail: ${RESEND_FROM_EMAIL:-}
       Resend__FromName: ${RESEND_FROM_NAME:-}
       PasswordReset__FrontendResetUrl: ${PASSWORD_RESET_FRONTEND_URL:-}
+      EmailChange__FrontendConfirmUrl: ${EMAIL_CHANGE_FRONTEND_CONFIRM_URL:-}
+      EmailChange__TokenExpiryMinutes: ${EMAIL_CHANGE_TOKEN_EXPIRY_MINUTES:-60}
     ports:
       - "${BACKEND_PORT}:8080"
     depends_on:


### PR DESCRIPTION
Backend e-posta değiştirme PR'ı için gerekli altyapı değişiklikleri.

## Değişiklikler

**`infra/compose/docker-compose.test.yml`**
```yaml
EmailChange__FrontendConfirmUrl: ${EMAIL_CHANGE_FRONTEND_CONFIRM_URL:-}
EmailChange__TokenExpiryMinutes: ${EMAIL_CHANGE_TOKEN_EXPIRY_MINUTES:-60}
```
Backend container bu env var'ları okuyamazsa uygulama başlamaz. `PasswordReset__FrontendResetUrl` ile birebir aynı pattern.

**`.github/workflows/test-deploy.yml`**
```yaml
EMAIL_CHANGE_FRONTEND_CONFIRM_URL: ${{ secrets.EMAIL_CHANGE_FRONTEND_CONFIRM_URL || 'http://localhost:3001/confirm-email-change' }}
```
CI ortamında `.env.test` olmadığı için workflow'dan verilmesi gerekiyor. `PASSWORD_RESET_FRONTEND_URL` ile birebir aynı yaklaşım.

## Gerekli Manuel Adım

Sunucudaki `.env.test` dosyasına eklenmeli:
```
EMAIL_CHANGE_FRONTEND_CONFIRM_URL=https://cargopilot.divizyon.org/confirm-email-change
```
`EMAIL_CHANGE_TOKEN_EXPIRY_MINUTES` opsiyonel — varsayılan 60 dakika.

🤖 Generated with [Claude Code](https://claude.com/claude-code)