### PR TITLE
ci: e-posta değiştirme özelliği için EmailChange env var'larını ekle

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -245,6 +245,7 @@ jobs:
       RESEND_FROM_EMAIL: ${{ secrets.RESEND_FROM_EMAIL || 'ci@example.com' }}
       RESEND_FROM_NAME: ${{ secrets.RESEND_FROM_NAME || 'Cargo Pilot CI' }}
       PASSWORD_RESET_FRONTEND_URL: ${{ secrets.PASSWORD_RESET_FRONTEND_URL || 'http://localhost:3001/auth/reset-password' }}
+      EMAIL_CHANGE_FRONTEND_CONFIRM_URL: ${{ secrets.EMAIL_CHANGE_FRONTEND_CONFIRM_URL || 'http://localhost:3001/confirm-email-change' }}
 
     steps:
       - name: Kodu al

--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -32,6 +32,8 @@ services:
       Resend__FromEmail: ${RESEND_FROM_EMAIL:-}
       Resend__FromName: ${RESEND_FROM_NAME:-}
       PasswordReset__FrontendResetUrl: ${PASSWORD_RESET_FRONTEND_URL:-}
+      EmailChange__FrontendConfirmUrl: ${EMAIL_CHANGE_FRONTEND_CONFIRM_URL:-}
+      EmailChange__TokenExpiryMinutes: ${EMAIL_CHANGE_TOKEN_EXPIRY_MINUTES:-60}
     ports:
       - "${BACKEND_PORT}:8080"
     depends_on:


### PR DESCRIPTION
Dev'e merge edildi (#557). Test'e taşınıyor.

Backend e-posta değiştirme özelliğinin ihtiyaç duyduğu `EmailChange__FrontendConfirmUrl` ve `EmailChange__TokenExpiryMinutes` env var'ları `docker-compose.test.yml` ve `test-deploy.yml`'ye eklendi.

Sunucudaki `.env.test` dosyası da güncellendi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)