### PR TITLE
Feature/be 3 d 03 2 group management endpoints

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanItemGroupRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanItemGroupRepository.cs
@@ -1,0 +1,13 @@
+using CargoPilot.Domain.Entities;
+
+namespace CargoPilot.Application.Common.Interfaces;
+
+public interface ILoadingPlanItemGroupRepository
+{
+    Task<LoadingPlanItemGroup?> GetByIdAsync(Guid id, Guid planId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<LoadingPlanItemGroup>> GetByPlanIdAsync(Guid planId, CancellationToken cancellationToken = default);
+    void Add(LoadingPlanItemGroup group);
+    Task NullifyGroupOnItemsAsync(Guid groupId, CancellationToken cancellationToken = default);
+    Task DeleteItemsByGroupAsync(Guid groupId, CancellationToken cancellationToken = default);
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanRepository.cs
@@ -40,6 +40,8 @@ public interface ILoadingPlanRepository
     Task<int> CountByUserAsync(Guid userId, CancellationToken cancellationToken = default);
     Task<int> CountByCompanyAsync(Guid companyId, CancellationToken cancellationToken = default);
 
+    Task<LoadingPlanInputItem?> GetInputItemByIdAsync(Guid inputItemId, Guid planId, CancellationToken cancellationToken = default);
+
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
 
     Task SaveWithResultAsync(

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/AssignItemToGroup/AssignItemToGroupCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/AssignItemToGroup/AssignItemToGroupCommand.cs
@@ -1,0 +1,9 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.Groups.AssignItemToGroup;
+
+public sealed record AssignItemToGroupCommand(
+    Guid PlanId,
+    Guid InputItemId,
+    Guid? GroupId) : IRequest<Result<Guid>>;

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/AssignItemToGroup/AssignItemToGroupCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/AssignItemToGroup/AssignItemToGroupCommandHandler.cs
@@ -1,0 +1,68 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.Groups.AssignItemToGroup;
+
+internal sealed class AssignItemToGroupCommandHandler : IRequestHandler<AssignItemToGroupCommand, Result<Guid>>
+{
+    private readonly ILoadingPlanRepository _planRepository;
+    private readonly ILoadingPlanItemGroupRepository _groupRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IValidator<AssignItemToGroupCommand> _validator;
+
+    public AssignItemToGroupCommandHandler(
+        ILoadingPlanRepository planRepository,
+        ILoadingPlanItemGroupRepository groupRepository,
+        ICurrentUserService currentUserService,
+        IValidator<AssignItemToGroupCommand> validator)
+    {
+        _planRepository = planRepository;
+        _groupRepository = groupRepository;
+        _currentUserService = currentUserService;
+        _validator = validator;
+    }
+
+    public async Task<Result<Guid>> Handle(AssignItemToGroupCommand request, CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var companyId = _currentUserService.CompanyId;
+        if (companyId is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Unauthorized, "Auth.NoCompany", "Şirket bağlamı bulunamadı."));
+
+        var plan = await _planRepository.GetByIdAsync(request.PlanId, companyId, cancellationToken);
+        if (plan is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "Plan.NotFound", "Yükleme planı bulunamadı."));
+
+        var inputItem = await _planRepository.GetInputItemByIdAsync(request.InputItemId, plan.Id, cancellationToken);
+        if (inputItem is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "InputItem.NotFound", "Ürün bulunamadı."));
+
+        if (request.GroupId.HasValue)
+        {
+            var group = await _groupRepository.GetByIdAsync(request.GroupId.Value, plan.Id, cancellationToken);
+            if (group is null)
+                return Result<Guid>.Failure(
+                    new Error(ErrorType.NotFound, "Group.NotFound", "Grup bulunamadı."));
+        }
+
+        inputItem.AssignGroup(request.GroupId);
+        await _planRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<Guid>.Success(inputItem.Id);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/AssignItemToGroup/AssignItemToGroupCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/AssignItemToGroup/AssignItemToGroupCommandValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Plans.Groups.AssignItemToGroup;
+
+public sealed class AssignItemToGroupCommandValidator : AbstractValidator<AssignItemToGroupCommand>
+{
+    public AssignItemToGroupCommandValidator()
+    {
+        RuleFor(x => x.PlanId)
+            .NotEmpty().WithMessage("Plan ID boş olamaz.");
+
+        RuleFor(x => x.InputItemId)
+            .NotEmpty().WithMessage("InputItem ID boş olamaz.");
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/CreateGroup/CreateGroupCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/CreateGroup/CreateGroupCommand.cs
@@ -1,0 +1,10 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.Groups.CreateGroup;
+
+public sealed record CreateGroupCommand(
+    Guid PlanId,
+    string Name,
+    string Color,
+    int UnloadingOrder) : IRequest<Result<Guid>>;

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/CreateGroup/CreateGroupCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/CreateGroup/CreateGroupCommandHandler.cs
@@ -1,0 +1,57 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Entities;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.Groups.CreateGroup;
+
+internal sealed class CreateGroupCommandHandler : IRequestHandler<CreateGroupCommand, Result<Guid>>
+{
+    private readonly ILoadingPlanRepository _planRepository;
+    private readonly ILoadingPlanItemGroupRepository _groupRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IValidator<CreateGroupCommand> _validator;
+
+    public CreateGroupCommandHandler(
+        ILoadingPlanRepository planRepository,
+        ILoadingPlanItemGroupRepository groupRepository,
+        ICurrentUserService currentUserService,
+        IValidator<CreateGroupCommand> validator)
+    {
+        _planRepository = planRepository;
+        _groupRepository = groupRepository;
+        _currentUserService = currentUserService;
+        _validator = validator;
+    }
+
+    public async Task<Result<Guid>> Handle(CreateGroupCommand request, CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var companyId = _currentUserService.CompanyId;
+        if (companyId is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Unauthorized, "Auth.NoCompany", "Şirket bağlamı bulunamadı."));
+
+        var plan = await _planRepository.GetByIdAsync(request.PlanId, companyId, cancellationToken);
+        if (plan is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "Plan.NotFound", "Yükleme planı bulunamadı."));
+
+        var group = new LoadingPlanItemGroup(Guid.NewGuid(), plan.Id, request.Name, request.Color, request.UnloadingOrder);
+        _groupRepository.Add(group);
+        await _groupRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<Guid>.Success(group.Id);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/CreateGroup/CreateGroupCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/CreateGroup/CreateGroupCommandValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Plans.Groups.CreateGroup;
+
+public sealed class CreateGroupCommandValidator : AbstractValidator<CreateGroupCommand>
+{
+    public CreateGroupCommandValidator()
+    {
+        RuleFor(x => x.PlanId)
+            .NotEmpty().WithMessage("Plan ID boş olamaz.");
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Grup adı boş olamaz.")
+            .MaximumLength(100).WithMessage("Grup adı en fazla 100 karakter olabilir.");
+
+        RuleFor(x => x.Color)
+            .NotEmpty().WithMessage("Renk boş olamaz.")
+            .MaximumLength(50).WithMessage("Renk en fazla 50 karakter olabilir.");
+
+        RuleFor(x => x.UnloadingOrder)
+            .GreaterThanOrEqualTo(0).WithMessage("Boşaltma sırası 0 veya daha büyük olmalıdır.");
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/DeleteGroup/DeleteGroupCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/DeleteGroup/DeleteGroupCommand.cs
@@ -1,0 +1,9 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.Groups.DeleteGroup;
+
+public sealed record DeleteGroupCommand(
+    Guid PlanId,
+    Guid GroupId,
+    bool MoveItemsToNull) : IRequest<Result<Guid>>;

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/DeleteGroup/DeleteGroupCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/DeleteGroup/DeleteGroupCommandHandler.cs
@@ -1,0 +1,65 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.Groups.DeleteGroup;
+
+internal sealed class DeleteGroupCommandHandler : IRequestHandler<DeleteGroupCommand, Result<Guid>>
+{
+    private readonly ILoadingPlanRepository _planRepository;
+    private readonly ILoadingPlanItemGroupRepository _groupRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IValidator<DeleteGroupCommand> _validator;
+
+    public DeleteGroupCommandHandler(
+        ILoadingPlanRepository planRepository,
+        ILoadingPlanItemGroupRepository groupRepository,
+        ICurrentUserService currentUserService,
+        IValidator<DeleteGroupCommand> validator)
+    {
+        _planRepository = planRepository;
+        _groupRepository = groupRepository;
+        _currentUserService = currentUserService;
+        _validator = validator;
+    }
+
+    public async Task<Result<Guid>> Handle(DeleteGroupCommand request, CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var companyId = _currentUserService.CompanyId;
+        if (companyId is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Unauthorized, "Auth.NoCompany", "Şirket bağlamı bulunamadı."));
+
+        var plan = await _planRepository.GetByIdAsync(request.PlanId, companyId, cancellationToken);
+        if (plan is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "Plan.NotFound", "Yükleme planı bulunamadı."));
+
+        var group = await _groupRepository.GetByIdAsync(request.GroupId, plan.Id, cancellationToken);
+        if (group is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "Group.NotFound", "Grup bulunamadı."));
+
+        if (request.MoveItemsToNull)
+            await _groupRepository.NullifyGroupOnItemsAsync(group.Id, cancellationToken);
+        else
+            await _groupRepository.DeleteItemsByGroupAsync(group.Id, cancellationToken);
+
+        group.MarkAsDeleted();
+        await _groupRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<Guid>.Success(group.Id);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/DeleteGroup/DeleteGroupCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/DeleteGroup/DeleteGroupCommandValidator.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Plans.Groups.DeleteGroup;
+
+public sealed class DeleteGroupCommandValidator : AbstractValidator<DeleteGroupCommand>
+{
+    public DeleteGroupCommandValidator()
+    {
+        RuleFor(x => x.PlanId)
+            .NotEmpty().WithMessage("Plan ID boş olamaz.");
+
+        RuleFor(x => x.GroupId)
+            .NotEmpty().WithMessage("Grup ID boş olamaz.");
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/UpdateGroup/UpdateGroupCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/UpdateGroup/UpdateGroupCommand.cs
@@ -1,0 +1,11 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.Groups.UpdateGroup;
+
+public sealed record UpdateGroupCommand(
+    Guid PlanId,
+    Guid GroupId,
+    string Name,
+    string Color,
+    int UnloadingOrder) : IRequest<Result<Guid>>;

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/UpdateGroup/UpdateGroupCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/UpdateGroup/UpdateGroupCommandHandler.cs
@@ -1,0 +1,60 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.Groups.UpdateGroup;
+
+internal sealed class UpdateGroupCommandHandler : IRequestHandler<UpdateGroupCommand, Result<Guid>>
+{
+    private readonly ILoadingPlanRepository _planRepository;
+    private readonly ILoadingPlanItemGroupRepository _groupRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IValidator<UpdateGroupCommand> _validator;
+
+    public UpdateGroupCommandHandler(
+        ILoadingPlanRepository planRepository,
+        ILoadingPlanItemGroupRepository groupRepository,
+        ICurrentUserService currentUserService,
+        IValidator<UpdateGroupCommand> validator)
+    {
+        _planRepository = planRepository;
+        _groupRepository = groupRepository;
+        _currentUserService = currentUserService;
+        _validator = validator;
+    }
+
+    public async Task<Result<Guid>> Handle(UpdateGroupCommand request, CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var companyId = _currentUserService.CompanyId;
+        if (companyId is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.Unauthorized, "Auth.NoCompany", "Şirket bağlamı bulunamadı."));
+
+        var plan = await _planRepository.GetByIdAsync(request.PlanId, companyId, cancellationToken);
+        if (plan is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "Plan.NotFound", "Yükleme planı bulunamadı."));
+
+        var group = await _groupRepository.GetByIdAsync(request.GroupId, plan.Id, cancellationToken);
+        if (group is null)
+            return Result<Guid>.Failure(
+                new Error(ErrorType.NotFound, "Group.NotFound", "Grup bulunamadı."));
+
+        group.Update(request.Name, request.Color, request.UnloadingOrder);
+        await _groupRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<Guid>.Success(group.Id);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/Groups/UpdateGroup/UpdateGroupCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/Groups/UpdateGroup/UpdateGroupCommandValidator.cs
@@ -1,0 +1,26 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Plans.Groups.UpdateGroup;
+
+public sealed class UpdateGroupCommandValidator : AbstractValidator<UpdateGroupCommand>
+{
+    public UpdateGroupCommandValidator()
+    {
+        RuleFor(x => x.PlanId)
+            .NotEmpty().WithMessage("Plan ID boş olamaz.");
+
+        RuleFor(x => x.GroupId)
+            .NotEmpty().WithMessage("Grup ID boş olamaz.");
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Grup adı boş olamaz.")
+            .MaximumLength(100).WithMessage("Grup adı en fazla 100 karakter olabilir.");
+
+        RuleFor(x => x.Color)
+            .NotEmpty().WithMessage("Renk boş olamaz.")
+            .MaximumLength(50).WithMessage("Renk en fazla 50 karakter olabilir.");
+
+        RuleFor(x => x.UnloadingOrder)
+            .GreaterThanOrEqualTo(0).WithMessage("Boşaltma sırası 0 veya daha büyük olmalıdır.");
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
+++ b/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
@@ -69,6 +69,7 @@ public static class DependencyInjection {
         services.AddScoped<IVehicleRepository, VehicleRepository>();
         services.AddScoped<IUserVehicleFavoriteRepository, UserVehicleFavoriteRepository>();
         services.AddScoped<ILoadingPlanRepository, LoadingPlanRepository>();
+        services.AddScoped<ILoadingPlanItemGroupRepository, LoadingPlanItemGroupRepository>();
         services.AddScoped<IOptimizationEngine, OptimizationEngine>();
         services.AddScoped<IErpConstraintMappingService, ErpConstraintMappingService>();
         services.AddScoped<IIntegrationRepository, IntegrationRepository>();

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanItemGroupRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanItemGroupRepository.cs
@@ -1,0 +1,47 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace CargoPilot.Infrastructure.Persistence.Repositories;
+
+internal sealed class LoadingPlanItemGroupRepository : ILoadingPlanItemGroupRepository
+{
+    private readonly AppDbContext _context;
+
+    public LoadingPlanItemGroupRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<LoadingPlanItemGroup?> GetByIdAsync(Guid id, Guid planId, CancellationToken cancellationToken = default)
+        => await _context.LoadingPlanItemGroups
+            .FirstOrDefaultAsync(g => g.Id == id && g.LoadingPlanId == planId, cancellationToken);
+
+    public async Task<IReadOnlyList<LoadingPlanItemGroup>> GetByPlanIdAsync(Guid planId, CancellationToken cancellationToken = default)
+        => await _context.LoadingPlanItemGroups
+            .AsNoTracking()
+            .Where(g => g.LoadingPlanId == planId)
+            .ToListAsync(cancellationToken);
+
+    public void Add(LoadingPlanItemGroup group)
+        => _context.LoadingPlanItemGroups.Add(group);
+
+    public async Task NullifyGroupOnItemsAsync(Guid groupId, CancellationToken cancellationToken = default)
+        => await _context.LoadingPlanInputItems
+            .Where(i => i.GroupId == groupId)
+            .ExecuteUpdateAsync(s => s.SetProperty(i => i.GroupId, (Guid?)null), cancellationToken);
+
+    public async Task DeleteItemsByGroupAsync(Guid groupId, CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        await _context.LoadingPlanInputItems
+            .Where(i => i.GroupId == groupId)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(i => i.IsDeleted, true)
+                .SetProperty(i => i.DeletedAtUtc, now)
+                .SetProperty(i => i.IsActive, false), cancellationToken);
+    }
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken = default)
+        => _context.SaveChangesAsync(cancellationToken);
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
@@ -267,6 +267,10 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
     public Task<int> CountByCompanyAsync(Guid companyId, CancellationToken cancellationToken = default)
         => _context.LoadingPlans.CountAsync(p => p.CompanyId == companyId, cancellationToken);
 
+    public async Task<LoadingPlanInputItem?> GetInputItemByIdAsync(Guid inputItemId, Guid planId, CancellationToken cancellationToken = default)
+        => await _context.LoadingPlanInputItems
+            .FirstOrDefaultAsync(i => i.Id == inputItemId && i.LoadingPlanId == planId, cancellationToken);
+
     public Task SaveChangesAsync(CancellationToken cancellationToken = default)
         => _context.SaveChangesAsync(cancellationToken);
 

--- a/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
@@ -4,6 +4,10 @@ using CargoPilot.Application.Features.Plans.DeletePlan;
 using CargoPilot.Application.Features.Plans.GetLoadingPlanReports;
 using CargoPilot.Application.Features.Plans.GetPlanById;
 using CargoPilot.Application.Features.Plans.GetPlans;
+using CargoPilot.Application.Features.Plans.Groups.AssignItemToGroup;
+using CargoPilot.Application.Features.Plans.Groups.CreateGroup;
+using CargoPilot.Application.Features.Plans.Groups.DeleteGroup;
+using CargoPilot.Application.Features.Plans.Groups.UpdateGroup;
 using CargoPilot.Application.Features.Plans.ReOptimizePlan;
 using CargoPilot.Application.Features.Plans.UpdatePlanName;
 using MediatR;
@@ -201,6 +205,105 @@ public sealed class PlansController : BaseController
     }
 
     /// <summary>
+    /// Belirtilen yükleme planı altında yeni bir grup oluşturur.
+    /// </summary>
+    /// <param name="planId">Planın ID'si.</param>
+    /// <param name="request">Grup adı, rengi ve boşaltma sırası.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="201">Grup oluşturuldu; yeni grubun ID'si döner.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    /// <response code="404">Plan bulunamadı.</response>
+    [HttpPost("{planId:guid}/groups")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CreateGroup(
+        [FromRoute] Guid planId,
+        [FromBody] CreateGroupRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new CreateGroupCommand(planId, request.Name, request.Color, request.UnloadingOrder);
+        var result = await _mediator.Send(command, cancellationToken);
+        if (!result.IsSuccess) return HandleResult(result);
+        return CreatedAtAction(nameof(GetById), new { id = planId }, result);
+    }
+
+    /// <summary>
+    /// Belirtilen grubu günceller.
+    /// </summary>
+    /// <param name="planId">Planın ID'si.</param>
+    /// <param name="groupId">Güncellenecek grubun ID'si.</param>
+    /// <param name="request">Yeni grup adı, rengi ve boşaltma sırası.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Grup güncellendi.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    /// <response code="404">Plan veya grup bulunamadı.</response>
+    [HttpPut("{planId:guid}/groups/{groupId:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateGroup(
+        [FromRoute] Guid planId,
+        [FromRoute] Guid groupId,
+        [FromBody] UpdateGroupRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new UpdateGroupCommand(planId, groupId, request.Name, request.Color, request.UnloadingOrder);
+        var result = await _mediator.Send(command, cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Belirtilen grubu siler. moveItemsToNull true ise gruptaki ürünlerin grubu kaldırılır, false ise ürünler de silinir.
+    /// </summary>
+    /// <param name="planId">Planın ID'si.</param>
+    /// <param name="groupId">Silinecek grubun ID'si.</param>
+    /// <param name="request">moveItemsToNull parametresi.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Grup silindi.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    /// <response code="404">Plan veya grup bulunamadı.</response>
+    [HttpDelete("{planId:guid}/groups/{groupId:guid}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteGroup(
+        [FromRoute] Guid planId,
+        [FromRoute] Guid groupId,
+        [FromBody] DeleteGroupRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new DeleteGroupCommand(planId, groupId, request.MoveItemsToNull);
+        var result = await _mediator.Send(command, cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Bir ürünü gruba atar veya gruptan çıkarır. groupId null gönderilirse ürün gruptan çıkarılır.
+    /// </summary>
+    /// <param name="planId">Planın ID'si.</param>
+    /// <param name="inputItemId">Güncellenecek InputItem'ın ID'si.</param>
+    /// <param name="request">Atanacak grubun ID'si (null ise gruptan çıkarır).</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Ürün gruba atandı veya gruptan çıkarıldı.</response>
+    /// <response code="400">Doğrulama hatası.</response>
+    /// <response code="404">Plan, ürün veya grup bulunamadı.</response>
+    [HttpPut("{planId:guid}/items/{inputItemId:guid}/group")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> AssignItemToGroup(
+        [FromRoute] Guid planId,
+        [FromRoute] Guid inputItemId,
+        [FromBody] AssignItemToGroupRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new AssignItemToGroupCommand(planId, inputItemId, request.GroupId);
+        var result = await _mediator.Send(command, cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
     /// Yükleme planını soft-delete ile siler.
     /// </summary>
     /// <param name="id">Silinecek planın ID'si.</param>
@@ -223,4 +326,23 @@ public sealed class PlansController : BaseController
 /// PATCH /api/v1/loading-plans/{id} için request body.
 /// </summary>
 public sealed record UpdatePlanNameRequest(string PlanName);
+
+/// <summary>POST /groups request body.</summary>
+public sealed record CreateGroupRequest(
+    string Name,
+    string Color,
+    [property: System.Text.Json.Serialization.JsonRequired] int UnloadingOrder);
+
+/// <summary>PUT /groups/{groupId} request body.</summary>
+public sealed record UpdateGroupRequest(
+    string Name,
+    string Color,
+    [property: System.Text.Json.Serialization.JsonRequired] int UnloadingOrder);
+
+/// <summary>DELETE /groups/{groupId} request body.</summary>
+public sealed record DeleteGroupRequest(
+    [property: System.Text.Json.Serialization.JsonRequired] bool MoveItemsToNull);
+
+/// <summary>PUT /items/{inputItemId}/group request body.</summary>
+public sealed record AssignItemToGroupRequest(Guid? GroupId);
 


### PR DESCRIPTION
## Özet

LoadingPlanItemGroup entity'si üzerine grup yönetim endpoint'leri eklendi. Bir yükleme planı altında grup oluşturma, güncelleme, silme ve input item'ları
gruba atama işlemleri yapılabiliyor.

## İlgili User Story / Issue

  BE-3D-03-2

## Değişiklik Tipi

- [ x] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x ] Manuel test yapıldı

## Kontrol Listesi

- [ x] Kod standartlarına uygun
- [ x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [x ] Linter hataları yok
- [x ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

  Yeni endpoint'ler:
  - POST /api/v1/loading-plans/{planId}/groups — grup oluştur
  - PUT /api/v1/loading-plans/{planId}/groups/{groupId} — grup güncelle
  - DELETE /api/v1/loading-plans/{planId}/groups/{groupId} — grup sil (moveItemsToNull: true → item'ların GroupId'si null yapılır, false → item'lar soft
  delete edilir)
  - PUT /api/v1/loading-plans/{planId}/items/{inputItemId}/group — item'ı gruba ata veya gruptan çıkar (groupId: null gönderilirse gruptan çıkar)

  Bağımlılık: BE-3D-03-1 (LoadingPlanItemGroup entity ve migration) bu branch'in tabanında yer alıyor. Dev'e PR açılmadan önce BE-3D-03-1'in merge edilmesi
   gerekiyor.

  Swagger Test Adımları:

  1. POST /api/v1/auth/login ile giriş yap → accessToken al
  2. Swagger'da "Authorize" butonuna tıkla → Bearer <token> gir
  3. POST /api/v1/loading-plans ile yeni plan oluştur (demo araç ve item ID'leri kullanılabilir) → data alanından planId al
  4. GET /api/v1/loading-plans/{planId} ile planı getir → inputItems[].id değerlerini not al (inputItemId olarak kullanılacak)
  5. POST /api/v1/loading-plans/{planId}/groups ile grup oluştur → data alanından groupId al
  { "name": "Grup A", "color": "#FF5733", "unloadingOrder": 1 }
  6. PUT /api/v1/loading-plans/{planId}/items/{inputItemId}/group ile item'ı gruba ata
  { "groupId": "<groupId>" }
  7. PUT /api/v1/loading-plans/{planId}/groups/{groupId} ile grubu güncelle
  8. DELETE /api/v1/loading-plans/{planId}/groups/{groupId} ile grubu sil
  { "moveItemsToNull": true }

  ▎ Not: Mevcut demo planların inputItems dizisi boştur (seed data). Test için mutlaka API üzerinden yeni plan oluşturulmalıdır.
