### PR TITLE
Feature/us sub 01 subscription plans

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Settings/SubscriptionPlanSettings.cs
+++ b/apps/backend/CargoPilot.Application/Common/Settings/SubscriptionPlanSettings.cs
@@ -1,0 +1,18 @@
+namespace CargoPilot.Application.Common.Settings;
+
+public sealed class SubscriptionPlanSettings
+{
+    public PlanPricing Baslangic { get; set; } = new();
+    public PlanPricing Buyume { get; set; } = new();
+}
+
+public sealed class PlanPricing
+{
+    public decimal MonthlyPrice { get; set; }
+    public decimal YearlyMonthlyPrice { get; set; }
+
+    public int YearlyDiscountPercent =>
+        MonthlyPrice > 0
+            ? (int)Math.Round((1 - YearlyMonthlyPrice / MonthlyPrice) * 100)
+            : 0;
+}

--- a/apps/backend/CargoPilot.Application/Features/Subscriptions/GetCurrentSubscription/CurrentSubscriptionDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Subscriptions/GetCurrentSubscription/CurrentSubscriptionDto.cs
@@ -1,0 +1,6 @@
+namespace CargoPilot.Application.Features.Subscriptions.GetCurrentSubscription;
+
+public sealed record CurrentSubscriptionDto(
+    string PlanType,
+    string DisplayName
+);

--- a/apps/backend/CargoPilot.Application/Features/Subscriptions/GetCurrentSubscription/GetCurrentSubscriptionQuery.cs
+++ b/apps/backend/CargoPilot.Application/Features/Subscriptions/GetCurrentSubscription/GetCurrentSubscriptionQuery.cs
@@ -1,0 +1,6 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Subscriptions.GetCurrentSubscription;
+
+public sealed record GetCurrentSubscriptionQuery : IRequest<Result<CurrentSubscriptionDto>>;

--- a/apps/backend/CargoPilot.Application/Features/Subscriptions/GetCurrentSubscription/GetCurrentSubscriptionQueryHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Subscriptions/GetCurrentSubscription/GetCurrentSubscriptionQueryHandler.cs
@@ -1,0 +1,47 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Subscriptions.GetCurrentSubscription;
+
+internal sealed class GetCurrentSubscriptionQueryHandler
+    : IRequestHandler<GetCurrentSubscriptionQuery, Result<CurrentSubscriptionDto>>
+{
+    private readonly ICompanyRepository _companyRepository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public GetCurrentSubscriptionQueryHandler(
+        ICompanyRepository companyRepository,
+        ICurrentUserService currentUserService)
+    {
+        _companyRepository = companyRepository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<Result<CurrentSubscriptionDto>> Handle(
+        GetCurrentSubscriptionQuery request,
+        CancellationToken cancellationToken)
+    {
+        if (_currentUserService.CompanyId is not { } companyId)
+            return Result<CurrentSubscriptionDto>.Failure(
+                new Error(ErrorType.Unauthorized, "AUTH_UNAUTHORIZED", "Kimlik doğrulaması gereklidir."));
+
+        var company = await _companyRepository.GetByIdAsync(companyId, cancellationToken);
+        if (company is null)
+            return Result<CurrentSubscriptionDto>.Failure(
+                new Error(ErrorType.NotFound, "Company.NotFound", "Firma bulunamadı."));
+
+        var displayName = company.SubscriptionType switch
+        {
+            SubscriptionType.Free       => "Başlangıç",
+            SubscriptionType.Pro        => "Büyüme",
+            SubscriptionType.Enterprise => "Kurumsal",
+            _                           => company.SubscriptionType.ToString()
+        };
+
+        return Result<CurrentSubscriptionDto>.Success(
+            new CurrentSubscriptionDto(company.SubscriptionType.ToString(), displayName));
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Subscriptions/GetPlans/GetSubscriptionPlansQuery.cs
+++ b/apps/backend/CargoPilot.Application/Features/Subscriptions/GetPlans/GetSubscriptionPlansQuery.cs
@@ -1,0 +1,6 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Subscriptions.GetPlans;
+
+public sealed record GetSubscriptionPlansQuery : IRequest<Result<IReadOnlyList<SubscriptionPlanDto>>>;

--- a/apps/backend/CargoPilot.Application/Features/Subscriptions/GetPlans/GetSubscriptionPlansQueryHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Subscriptions/GetPlans/GetSubscriptionPlansQueryHandler.cs
@@ -1,6 +1,7 @@
 using CargoPilot.Application.Common.Models;
 using CargoPilot.Application.Common.Settings;
 using CargoPilot.Domain.Enums;
+using CargoPilot.Domain.Subscriptions;
 using MediatR;
 using Microsoft.Extensions.Options;
 
@@ -11,22 +12,17 @@ internal sealed class GetSubscriptionPlansQueryHandler
 {
     private readonly SubscriptionPlanSettings _settings;
 
-    // Plan başına sabit limitler ve özellikler
     private static readonly IReadOnlyList<(
         SubscriptionType Type,
         string DisplayName,
-        int? MaxUsers,
-        int? MaxLoadingPlans,
-        int? MaxVehicles,
-        int? MaxProducts,
         bool ErpAccess,
         bool ReportSharing,
         bool IsRecommended,
         bool IsEnterprise)> PlanFeatures =
     [
-        (SubscriptionType.Free,       "Başlangıç", 3,    10,   5,    100,  false, false, false, false),
-        (SubscriptionType.Pro,        "Büyüme",    10,   50,   20,   500,  true,  true,  true,  false),
-        (SubscriptionType.Enterprise, "Kurumsal",  null, null, null, null, true,  true,  false, true),
+        (SubscriptionType.Free,       "Başlangıç", false, false, false, false),
+        (SubscriptionType.Pro,        "Büyüme",    true,  true,  true,  false),
+        (SubscriptionType.Enterprise, "Kurumsal",  true,  true,  false, true),
     ];
 
     public GetSubscriptionPlansQueryHandler(IOptions<SubscriptionPlanSettings> settings)
@@ -63,10 +59,10 @@ internal sealed class GetSubscriptionPlansQueryHandler
                 p.IsEnterprise ? null : monthly,
                 p.IsEnterprise ? null : yearlyMonthly,
                 p.IsEnterprise ? null : discountPercent,
-                p.MaxUsers,
-                p.MaxLoadingPlans,
-                p.MaxVehicles,
-                p.MaxProducts,
+                SubscriptionLimits.GetMaxUserCount(p.Type),
+                SubscriptionLimits.GetMaxLoadingPlanCount(p.Type),
+                SubscriptionLimits.GetMaxVehicleCount(p.Type),
+                SubscriptionLimits.GetMaxItemCount(p.Type),
                 p.ErpAccess,
                 p.ReportSharing,
                 p.IsRecommended,

--- a/apps/backend/CargoPilot.Application/Features/Subscriptions/GetPlans/GetSubscriptionPlansQueryHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Subscriptions/GetPlans/GetSubscriptionPlansQueryHandler.cs
@@ -1,0 +1,78 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Application.Common.Settings;
+using CargoPilot.Domain.Enums;
+using MediatR;
+using Microsoft.Extensions.Options;
+
+namespace CargoPilot.Application.Features.Subscriptions.GetPlans;
+
+internal sealed class GetSubscriptionPlansQueryHandler
+    : IRequestHandler<GetSubscriptionPlansQuery, Result<IReadOnlyList<SubscriptionPlanDto>>>
+{
+    private readonly SubscriptionPlanSettings _settings;
+
+    // Plan başına sabit limitler ve özellikler
+    private static readonly IReadOnlyList<(
+        SubscriptionType Type,
+        string DisplayName,
+        int? MaxUsers,
+        int? MaxLoadingPlans,
+        int? MaxVehicles,
+        int? MaxProducts,
+        bool ErpAccess,
+        bool ReportSharing,
+        bool IsRecommended,
+        bool IsEnterprise)> PlanFeatures =
+    [
+        (SubscriptionType.Free,       "Başlangıç", 3,    10,   5,    100,  false, false, false, false),
+        (SubscriptionType.Pro,        "Büyüme",    10,   50,   20,   500,  true,  true,  true,  false),
+        (SubscriptionType.Enterprise, "Kurumsal",  null, null, null, null, true,  true,  false, true),
+    ];
+
+    public GetSubscriptionPlansQueryHandler(IOptions<SubscriptionPlanSettings> settings)
+    {
+        _settings = settings.Value;
+    }
+
+    public Task<Result<IReadOnlyList<SubscriptionPlanDto>>> Handle(
+        GetSubscriptionPlansQuery request,
+        CancellationToken cancellationToken)
+    {
+        var plans = PlanFeatures.Select(p =>
+        {
+            decimal? monthly = null;
+            decimal? yearlyMonthly = null;
+            int? discountPercent = null;
+
+            if (p.Type == SubscriptionType.Free)
+            {
+                monthly = _settings.Baslangic.MonthlyPrice;
+                yearlyMonthly = _settings.Baslangic.YearlyMonthlyPrice;
+                discountPercent = _settings.Baslangic.YearlyDiscountPercent;
+            }
+            else if (p.Type == SubscriptionType.Pro)
+            {
+                monthly = _settings.Buyume.MonthlyPrice;
+                yearlyMonthly = _settings.Buyume.YearlyMonthlyPrice;
+                discountPercent = _settings.Buyume.YearlyDiscountPercent;
+            }
+
+            return new SubscriptionPlanDto(
+                p.Type.ToString(),
+                p.DisplayName,
+                p.IsEnterprise ? null : monthly,
+                p.IsEnterprise ? null : yearlyMonthly,
+                p.IsEnterprise ? null : discountPercent,
+                p.MaxUsers,
+                p.MaxLoadingPlans,
+                p.MaxVehicles,
+                p.MaxProducts,
+                p.ErpAccess,
+                p.ReportSharing,
+                p.IsRecommended,
+                p.IsEnterprise);
+        }).ToList();
+
+        return Task.FromResult(Result<IReadOnlyList<SubscriptionPlanDto>>.Success(plans));
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Subscriptions/GetPlans/SubscriptionPlanDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Subscriptions/GetPlans/SubscriptionPlanDto.cs
@@ -1,0 +1,17 @@
+namespace CargoPilot.Application.Features.Subscriptions.GetPlans;
+
+public sealed record SubscriptionPlanDto(
+    string PlanType,
+    string DisplayName,
+    decimal? MonthlyPrice,
+    decimal? YearlyMonthlyPrice,
+    int? YearlyDiscountPercent,
+    int? MaxUsers,
+    int? MaxLoadingPlans,
+    int? MaxVehicles,
+    int? MaxProducts,
+    bool ErpAccess,
+    bool ReportSharing,
+    bool IsRecommended,
+    bool IsEnterprise
+);

--- a/apps/backend/CargoPilot.Domain/Subscriptions/SubscriptionLimits.cs
+++ b/apps/backend/CargoPilot.Domain/Subscriptions/SubscriptionLimits.cs
@@ -1,0 +1,38 @@
+using CargoPilot.Domain.Enums;
+
+namespace CargoPilot.Domain.Subscriptions;
+
+public static class SubscriptionLimits
+{
+    public static int? GetMaxUserCount(SubscriptionType type) => type switch
+    {
+        SubscriptionType.Free       => 1,
+        SubscriptionType.Pro        => 10,
+        SubscriptionType.Enterprise => null,
+        _                           => null
+    };
+
+    public static int? GetMaxLoadingPlanCount(SubscriptionType type) => type switch
+    {
+        SubscriptionType.Free       => 10,
+        SubscriptionType.Pro        => 50,
+        SubscriptionType.Enterprise => null,
+        _                           => null
+    };
+
+    public static int? GetMaxVehicleCount(SubscriptionType type) => type switch
+    {
+        SubscriptionType.Free       => 5,
+        SubscriptionType.Pro        => 20,
+        SubscriptionType.Enterprise => null,
+        _                           => null
+    };
+
+    public static int? GetMaxItemCount(SubscriptionType type) => type switch
+    {
+        SubscriptionType.Free       => 100,
+        SubscriptionType.Pro        => 500,
+        SubscriptionType.Enterprise => null,
+        _                           => null
+    };
+}

--- a/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
+++ b/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
@@ -61,6 +61,10 @@ public static class DependencyInjection {
             .Validate(s => s.TokenExpiryMinutes > 0, "PasswordReset:TokenExpiryMinutes must be greater than 0.")
             .ValidateOnStart();
 
+        services.AddOptions<SubscriptionPlanSettings>()
+            .Bind(configuration.GetSection("SubscriptionPlans"))
+            .ValidateOnStart();
+
         services.AddScoped<ICurrentUserService, AnonymousCurrentUserService>();
         services.AddScoped<IPasswordHasher, BCryptPasswordHasher>();
         services.AddScoped<IJwtTokenService, JwtTokenService>();

--- a/apps/backend/CargoPilot.WebAPI/Controllers/SubscriptionsController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/SubscriptionsController.cs
@@ -1,0 +1,48 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Application.Features.Subscriptions.GetCurrentSubscription;
+using CargoPilot.Application.Features.Subscriptions.GetPlans;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CargoPilot.WebAPI.Controllers;
+
+/// <summary>
+/// Abonelik planları endpoint'leri.
+/// </summary>
+[Route("api/v1/subscriptions")]
+[Tags("Subscriptions")]
+public sealed class SubscriptionsController : BaseController
+{
+    private readonly IMediator _mediator;
+
+    public SubscriptionsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Mevcut tüm abonelik planlarını fiyat ve limit bilgileriyle döndürür.
+    /// </summary>
+    [HttpGet("plans")]
+    [AllowAnonymous]
+    [ProducesResponseType(typeof(Result<IReadOnlyList<SubscriptionPlanDto>>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetPlans(CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(new GetSubscriptionPlansQuery(), cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Oturum açmış kullanıcının firmasının aktif abonelik planını döndürür.
+    /// </summary>
+    [HttpGet("current")]
+    [Authorize(Policy = "CompanyMember")]
+    [ProducesResponseType(typeof(Result<CurrentSubscriptionDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetCurrent(CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(new GetCurrentSubscriptionQuery(), cancellationToken);
+        return HandleResult(result);
+    }
+}

--- a/apps/backend/CargoPilot.WebAPI/appsettings.json
+++ b/apps/backend/CargoPilot.WebAPI/appsettings.json
@@ -41,5 +41,15 @@
     "Google": {
       "ClientId": ""
     }
+  },
+  "SubscriptionPlans": {
+    "Baslangic": {
+      "MonthlyPrice": 299.00,
+      "YearlyMonthlyPrice": 249.00
+    },
+    "Buyume": {
+      "MonthlyPrice": 699.00,
+      "YearlyMonthlyPrice": 583.00
+    }
   }
 }


### PR DESCRIPTION
## Özet

PR #565 revizyonu kapsamında abonelik limitleri merkezi bir yapıya taşındı. `SubscriptionLimits.cs` oluşturularak tüm plan limitleri tek bir yerden yönetilir hale getirildi. `GetSubscriptionPlansQueryHandler` artık hardcoded değerler yerine bu sınıfı kullanıyor. Ayrıca Free planın maksimum kullanıcı sayısı 1 olarak güncellendi.

## İlgili User Story / Issue

US-SUB-01, PR #565

## Değişiklik Tipi

- [x] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x] Manuel test yapıldı

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

- `CargoPilot.Domain/Subscriptions/SubscriptionLimits.cs` oluşturuldu — `GetMaxUserCount`, `GetMaxLoadingPlanCount`, `GetMaxVehicleCount`, `GetMaxItemCount` metotlarıyla tüm planlar için limit değerleri tek kaynaktan sunuluyor.
- `GetSubscriptionPlansQueryHandler`'daki `PlanFeatures` tuple'ından limit alanları çıkarıldı; artık `SubscriptionLimits` statik metotları çağrılıyor.
- Free plan `MaxUsers`: 3 → 1 olarak değiştirildi.
- Enterprise plan limitleri `null` döndürüyor (sınırsız).
