### PR TITLE
feat(BE-3D-03-3): optimizasyon entegrasyonu - grup filtresi ve grup-a…

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanItemGroupRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/ILoadingPlanItemGroupRepository.cs
@@ -6,6 +6,7 @@ public interface ILoadingPlanItemGroupRepository
 {
     Task<LoadingPlanItemGroup?> GetByIdAsync(Guid id, Guid planId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<LoadingPlanItemGroup>> GetByPlanIdAsync(Guid planId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<LoadingPlanItemGroup>> GetByIdsAsync(IReadOnlyList<Guid> ids, Guid? companyId, CancellationToken cancellationToken = default);
     void Add(LoadingPlanItemGroup group);
     Task NullifyGroupOnItemsAsync(Guid groupId, CancellationToken cancellationToken = default);
     Task DeleteItemsByGroupAsync(Guid groupId, CancellationToken cancellationToken = default);

--- a/apps/backend/CargoPilot.Application/Common/Models/OptimizationInput.cs
+++ b/apps/backend/CargoPilot.Application/Common/Models/OptimizationInput.cs
@@ -21,4 +21,6 @@ public sealed record OptimizationItemInput(
     decimal Weight,
     bool IsStackable,
     AllowedRotations AllowedRotations,
-    int Quantity);
+    int Quantity,
+    Guid? GroupId = null,
+    int? UnloadingOrder = null);

--- a/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandHandler.cs
@@ -14,6 +14,7 @@ public sealed class CreatePlanCommandHandler : IRequestHandler<CreatePlanCommand
     private readonly ILoadingPlanRepository _planRepository;
     private readonly IVehicleRepository _vehicleRepository;
     private readonly IItemRepository _itemRepository;
+    private readonly ILoadingPlanItemGroupRepository _groupRepository;
     private readonly IOptimizationEngine _optimizationEngine;
     private readonly ICurrentUserService _currentUserService;
     private readonly IValidator<CreatePlanCommand> _validator;
@@ -22,6 +23,7 @@ public sealed class CreatePlanCommandHandler : IRequestHandler<CreatePlanCommand
         ILoadingPlanRepository planRepository,
         IVehicleRepository vehicleRepository,
         IItemRepository itemRepository,
+        ILoadingPlanItemGroupRepository groupRepository,
         IOptimizationEngine optimizationEngine,
         ICurrentUserService currentUserService,
         IValidator<CreatePlanCommand> validator)
@@ -29,6 +31,7 @@ public sealed class CreatePlanCommandHandler : IRequestHandler<CreatePlanCommand
         _planRepository = planRepository;
         _vehicleRepository = vehicleRepository;
         _itemRepository = itemRepository;
+        _groupRepository = groupRepository;
         _optimizationEngine = optimizationEngine;
         _currentUserService = currentUserService;
         _validator = validator;
@@ -77,15 +80,55 @@ public sealed class CreatePlanCommandHandler : IRequestHandler<CreatePlanCommand
         }
 
         var itemMap = items.ToDictionary(i => i.Id);
-        var inputTotalQuantity = request.Items.Sum(i => i.Quantity);
 
-        var optimizationInput = BuildInput(vehicle, request.Items, itemMap, request.OptimizationCriteria);
+        // Load groups for any GroupId present in the request; filter out inactive ones
+        var requestedGroupIds = request.Items
+            .Where(i => i.GroupId.HasValue)
+            .Select(i => i.GroupId!.Value)
+            .Distinct()
+            .ToList();
+
+        Dictionary<Guid, LoadingPlanItemGroup> groupMap = [];
+        if (requestedGroupIds.Count > 0)
+        {
+            var groups = await _groupRepository.GetByIdsAsync(requestedGroupIds, companyId, cancellationToken);
+            groupMap = groups.ToDictionary(g => g.Id);
+
+            var missingGroupIds = requestedGroupIds.Except(groupMap.Keys).ToList();
+            if (missingGroupIds.Count > 0)
+            {
+                var failures = missingGroupIds
+                    .Select(id => new ValidationFailure("Items", $"Grup bulunamadı: {id}"))
+                    .ToList();
+                return Result<Guid>.Failure(
+                    new Error(ErrorType.NotFound, "Groups.NotFound", "Bir veya daha fazla grup bulunamadı.", failures));
+            }
+        }
+
+        var inactiveGroupIds = groupMap.Values
+            .Where(g => !g.IsActive)
+            .Select(g => g.Id)
+            .ToHashSet();
+
+        var activeItems = request.Items
+            .Where(i => !i.GroupId.HasValue || !inactiveGroupIds.Contains(i.GroupId.Value))
+            .ToList();
+
+        var inputTotalQuantity = activeItems.Sum(i => i.Quantity);
+
+        var optimizationInput = BuildInput(vehicle, activeItems, itemMap, groupMap, request.OptimizationCriteria);
         var result = _optimizationEngine.Run(optimizationInput);
 
         var planId = Guid.NewGuid();
         var plan = new LoadingPlan(planId, request.PlanName, vehicle.Id, request.OptimizationCriteria, inputTotalQuantity, companyId);
-        var inputItems = request.Items
-            .Select(i => new LoadingPlanInputItem(Guid.NewGuid(), planId, i.ItemId, i.Quantity))
+        var inputItems = activeItems
+            .Select(i =>
+            {
+                var inputItem = new LoadingPlanInputItem(Guid.NewGuid(), planId, i.ItemId, i.Quantity);
+                if (i.GroupId.HasValue && groupMap.ContainsKey(i.GroupId.Value))
+                    inputItem.AssignGroup(i.GroupId);
+                return inputItem;
+            })
             .ToList();
 
         await _planRepository.SaveWithResultAsync(plan, inputItems, result, cancellationToken);
@@ -97,16 +140,19 @@ public sealed class CreatePlanCommandHandler : IRequestHandler<CreatePlanCommand
         Vehicle vehicle,
         IReadOnlyList<CreatePlanItemRequest> requestItems,
         Dictionary<Guid, Item> itemMap,
+        Dictionary<Guid, LoadingPlanItemGroup> groupMap,
         LoadingPlanOptimizationCriteria criteria)
     {
         var inputs = requestItems
             .Select(r =>
             {
                 var item = itemMap[r.ItemId];
+                var group = r.GroupId.HasValue && groupMap.TryGetValue(r.GroupId.Value, out var g) ? g : null;
                 return new OptimizationItemInput(
                     item.Id, item.SKU, item.Name, item.ImageUrl,
                     item.Width, item.Height, item.Length, item.Weight,
-                    item.IsStackable, item.AllowedRotations, r.Quantity);
+                    item.IsStackable, item.AllowedRotations, r.Quantity,
+                    group?.Id, group?.UnloadingOrder);
             })
             .ToList();
 

--- a/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanItemRequest.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanItemRequest.cs
@@ -1,3 +1,3 @@
 namespace CargoPilot.Application.Features.Plans.CreatePlan;
 
-public sealed record CreatePlanItemRequest(Guid ItemId, int Quantity);
+public sealed record CreatePlanItemRequest(Guid ItemId, int Quantity, Guid? GroupId = null);

--- a/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/InputItemDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/InputItemDto.cs
@@ -1,3 +1,3 @@
 namespace CargoPilot.Application.Features.Plans.GetPlanById;
 
-public sealed record InputItemDto(Guid Id, Guid ItemId, int Quantity, ItemInPlanDto Item);
+public sealed record InputItemDto(Guid Id, Guid ItemId, int Quantity, ItemInPlanDto Item, Guid? GroupId = null);

--- a/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/PlanDetailDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/PlanDetailDto.cs
@@ -25,4 +25,5 @@ public sealed record PlanDetailDto(
     IReadOnlyList<PlacementDto> Placements,
     IReadOnlyList<UnplacedItemDto> UnplacedItems,
     IReadOnlyList<WarningDto> Warnings,
-    IReadOnlyList<InputItemDto> InputItems);
+    IReadOnlyList<InputItemDto> InputItems,
+    IReadOnlyList<PlanGroupDto> Groups);

--- a/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/PlanGroupDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/PlanGroupDto.cs
@@ -1,0 +1,9 @@
+namespace CargoPilot.Application.Features.Plans.GetPlanById;
+
+public sealed record PlanGroupDto(
+    Guid Id,
+    string Name,
+    string Color,
+    int UnloadingOrder,
+    bool IsActive,
+    IReadOnlyList<InputItemDto> Items);

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanItemGroupRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanItemGroupRepository.cs
@@ -23,6 +23,12 @@ internal sealed class LoadingPlanItemGroupRepository : ILoadingPlanItemGroupRepo
             .Where(g => g.LoadingPlanId == planId)
             .ToListAsync(cancellationToken);
 
+    public async Task<IReadOnlyList<LoadingPlanItemGroup>> GetByIdsAsync(IReadOnlyList<Guid> ids, Guid? companyId, CancellationToken cancellationToken = default)
+        => await _context.LoadingPlanItemGroups
+            .AsNoTracking()
+            .Where(g => ids.Contains(g.Id) && g.LoadingPlan.CompanyId == companyId)
+            .ToListAsync(cancellationToken);
+
     public void Add(LoadingPlanItemGroup group)
         => _context.LoadingPlanItemGroups.Add(group);
 

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
@@ -174,7 +174,12 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
             .Where(i => i.LoadingPlanId == id)
             .ToListAsync(cancellationToken);
 
-        return MapToDetailDto(plan, placements, unplacedItems, warnings, inputItems);
+        var groups = await _context.LoadingPlanItemGroups
+            .AsNoTracking()
+            .Where(g => g.LoadingPlanId == id)
+            .ToListAsync(cancellationToken);
+
+        return MapToDetailDto(plan, placements, unplacedItems, warnings, inputItems, groups);
     }
 
     private static PlanDetailDto MapToDetailDto(
@@ -182,7 +187,8 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
         List<LoadingPlanPlacement> placements,
         List<LoadingPlanUnplacedItem> unplacedItems,
         List<LoadingPlanWarning> warnings,
-        List<LoadingPlanInputItem> inputItems)
+        List<LoadingPlanInputItem> inputItems,
+        List<LoadingPlanItemGroup> groups)
     {
         var vehicleDto = new VehicleInPlanDto(
             plan.Vehicle.Id,
@@ -228,7 +234,23 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
                 i.Id,
                 i.ItemId,
                 i.Quantity,
-                ToItemInPlanDto(i.Item)))
+                ToItemInPlanDto(i.Item),
+                i.GroupId))
+            .ToList();
+
+        var inputItemsByGroup = inputItemDtos
+            .Where(i => i.GroupId.HasValue)
+            .GroupBy(i => i.GroupId!.Value)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<InputItemDto>)g.ToList());
+
+        var groupDtos = groups
+            .Select(g => new PlanGroupDto(
+                g.Id,
+                g.Name,
+                g.Color,
+                g.UnloadingOrder,
+                g.IsActive,
+                inputItemsByGroup.TryGetValue(g.Id, out var gItems) ? gItems : []))
             .ToList();
 
         return new PlanDetailDto(
@@ -254,7 +276,8 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
             placementDtos,
             unplacedItemDtos,
             warningDtos,
-            inputItemDtos);
+            inputItemDtos,
+            groupDtos);
     }
 
     public async Task<LoadingPlan?> GetByIdAsync(Guid id, Guid? companyId, CancellationToken cancellationToken = default)

--- a/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
@@ -18,15 +18,7 @@ internal sealed class OptimizationEngine : IOptimizationEngine
         var expanded = input.Items
             .SelectMany(i => Enumerable.Range(0, i.Quantity).Select(_ => i));
 
-        var instances = input.Criteria switch
-        {
-            LoadingPlanOptimizationCriteria.WeightBalance =>
-                expanded.OrderByDescending(i => i.Weight).ToList(),
-            LoadingPlanOptimizationCriteria.Lifo =>
-                expanded.ToList(),
-            _ =>
-                expanded.OrderByDescending(i => i.Width * i.Height * i.Length).ToList(),
-        };
+        var instances = SortForGroupPlacement(expanded, input.Criteria);
 
         var halfW = input.VehicleWidth  / 2m;
         var halfL = input.VehicleLength / 2m;
@@ -140,6 +132,55 @@ internal sealed class OptimizationEngine : IOptimizationEngine
 
         return new OptimizationResult(placedResults, unplacedResults, totalWeight, fillRate, cogX, cogY, cogZ, balanceOffsetX, balanceOffsetZ);
     }
+
+    // ── Grup-bilinçli sıralama ────────────────────────────────────────────────
+    // GroupId'si olan items yükleme sırasına göre sıralanır:
+    // yüksek UnloadingOrder = araç arkası = önce yüklenir (DESC sıra).
+    // GroupId'si olmayan items en sona eklenir.
+    // Grup yoksa mevcut criteria-based sıralama uygulanır.
+    private static List<OptimizationItemInput> SortForGroupPlacement(
+        IEnumerable<OptimizationItemInput> expanded,
+        LoadingPlanOptimizationCriteria criteria)
+    {
+        var list = expanded.ToList();
+
+        var hasGroups = list.Any(i => i.GroupId.HasValue);
+        if (!hasGroups)
+        {
+            return criteria switch
+            {
+                LoadingPlanOptimizationCriteria.WeightBalance =>
+                    list.OrderByDescending(i => i.Weight).ToList(),
+                LoadingPlanOptimizationCriteria.Lifo =>
+                    list,
+                _ =>
+                    list.OrderByDescending(i => i.Width * i.Height * i.Length).ToList(),
+            };
+        }
+
+        var grouped = list
+            .Where(i => i.GroupId.HasValue)
+            .GroupBy(i => (i.GroupId!.Value, i.UnloadingOrder ?? 0))
+            .OrderByDescending(g => g.Key.Item2);
+
+        var sortedGrouped = grouped.SelectMany(g => ApplyCriteriaSort(g, criteria));
+        var ungrouped = ApplyCriteriaSort(list.Where(i => !i.GroupId.HasValue), criteria);
+
+        return sortedGrouped.Concat(ungrouped).ToList();
+    }
+
+    private static IEnumerable<OptimizationItemInput> ApplyCriteriaSort(
+        IEnumerable<OptimizationItemInput> items,
+        LoadingPlanOptimizationCriteria criteria)
+        => criteria switch
+        {
+            LoadingPlanOptimizationCriteria.WeightBalance =>
+                items.OrderByDescending(i => i.Weight),
+            LoadingPlanOptimizationCriteria.Lifo =>
+                items,
+            _ =>
+                items.OrderByDescending(i => i.Width * i.Height * i.Length),
+        };
 
     // ── İkinci geçiş: greedy swap balance iyileştirici ───────────────────────
     //


### PR DESCRIPTION
## Özet

gruplama sisteminin optimizasyon motoruna entegrasyonu yapıldı

## İlgili User Story / Issue
BE-3D-03-3

## Değişiklik Tipi

- [x ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [x ] Manuel test yapıldı

## Kontrol Listesi

- [x ] Kod standartlarına uygun
- [ x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ x] Linter hataları yok
- [x ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

- CreatePlanItemRequest'e GroupId (Guid?) eklendi
- OptimizationItemInput'a GroupId ve UnloadingOrder eklendi
- Handler'da IsActive=false gruplara ait items OptimizationInput'dan hariç tutuldu
- Eksik/yabancı GroupId için Groups.NotFound hatası dönülüyor (tenant scope dahil)
- GetByIdsAsync companyId ile scoped sorgu yapıyor (cross-tenant erişim engellendi)
- OptimizationEngine'e SortForGroupPlacement eklendi: yüksek UnloadingOrder = araç arkası
- GET /api/v1/loading-plans/{id} response'una Groups ve her grubun InputItem listesi eklendi
