### PR TITLE
Feature/us xxx container side door position

### DIFF
--- a/apps/frontend/src/features/data-management/components/VehicleDoorDirectionField.tsx
+++ b/apps/frontend/src/features/data-management/components/VehicleDoorDirectionField.tsx
@@ -15,7 +15,7 @@ const DIRECTION_LABELS: Record<string, string> = {
   rear: 'Arka',
   side: 'Yan',
   top: 'Üst',
-  rearAndSide: 'Arka + Yan',
+  all: 'Tümü',
 };
 
 export function VehicleDoorDirectionField({ form }: VehicleDoorDirectionFieldProps) {
@@ -35,7 +35,7 @@ export function VehicleDoorDirectionField({ form }: VehicleDoorDirectionFieldPro
                 if (!val) return;
                 field.onChange(val);
                 form.clearErrors('doorDirection');
-                if (val !== DoorDirection.Side && val !== DoorDirection.RearAndSide) {
+                if (val !== DoorDirection.Side) {
                   form.setValue('doorSide', undefined);
                   form.clearErrors('doorSide');
                 }
@@ -60,7 +60,7 @@ export function VehicleDoorDirectionField({ form }: VehicleDoorDirectionFieldPro
         )}
       />
 
-      {(doorDirection === DoorDirection.Side || doorDirection === DoorDirection.RearAndSide) && (
+      {doorDirection === DoorDirection.Side && (
         <Controller
           control={form.control}
           name="doorSide"

--- a/apps/frontend/src/features/data-management/components/VehicleListRow.tsx
+++ b/apps/frontend/src/features/data-management/components/VehicleListRow.tsx
@@ -19,7 +19,7 @@ const DOOR_LABELS: Record<string, string> = {
   rear: 'Arka',
   side: 'Yan',
   top: 'Üst',
-  rearAndSide: 'Arka+Yan',
+  all: 'Tümü',
 };
 
 const cell = 'py-0 px-3';

--- a/apps/frontend/src/features/data-management/components/VehiclePreview3D.tsx
+++ b/apps/frontend/src/features/data-management/components/VehiclePreview3D.tsx
@@ -341,8 +341,8 @@ function DoorFaceIndicator({
   doorDirection: DoorDirection;
   doorSide?: 'left' | 'right';
 }) {
-  const isRear = doorDirection === 'rear' || doorDirection === 'rearAndSide';
-  const isSide = doorDirection === 'side' || doorDirection === 'rearAndSide';
+  const isRear = doorDirection === 'rear';
+  const isSide = doorDirection === 'side';
   const isTop = doorDirection === 'top';
 
   const sideX = doorSide === 'right' ? width + DOOR_PANEL_T / 2 : -DOOR_PANEL_T / 2;

--- a/apps/frontend/src/features/data-management/components/VehiclePreviewCanvas.tsx
+++ b/apps/frontend/src/features/data-management/components/VehiclePreviewCanvas.tsx
@@ -62,10 +62,10 @@ export const VehiclePreviewCanvas = memo(function VehiclePreviewCanvas({
           rx={isContainer ? 2 : 6}
         />
 
-        {(doorDirection === 'rear' || doorDirection === 'rearAndSide') && (
+        {doorDirection === 'rear' && (
           <rect x={bx + bw - 5} y={by} width={5} height={bh} fill="var(--primary)" opacity={0.6} />
         )}
-        {(doorDirection === 'side' || doorDirection === 'rearAndSide') && (
+        {doorDirection === 'side' && (
           <rect x={bx} y={by + bh - 5} width={bw} height={5} fill="var(--primary)" opacity={0.6} />
         )}
         {doorDirection === 'top' && (

--- a/apps/frontend/src/features/data-management/components/VehiclePreviewPanel.tsx
+++ b/apps/frontend/src/features/data-management/components/VehiclePreviewPanel.tsx
@@ -10,7 +10,7 @@ const DOOR_LABELS: Record<string, string> = {
   rear: 'Arka',
   side: 'Yan',
   top: 'Üst',
-  rearAndSide: 'Arka + Yan',
+  all: 'Tümü',
 };
 
 const TYPE_LABELS: Record<string, string> = {

--- a/apps/frontend/src/features/data-management/components/VehicleTable.tsx
+++ b/apps/frontend/src/features/data-management/components/VehicleTable.tsx
@@ -166,7 +166,7 @@ const DOOR_CONFIG: Record<string, { label: string }> = {
   rear: { label: 'Arka' },
   side: { label: 'Yan' },
   top: { label: 'Üst' },
-  rearAndSide: { label: 'Arka + Yan' },
+  all: { label: 'Tümü' },
 };
 
 // ─── Category tabs ────────────────────────────────────────────────────────────
@@ -183,13 +183,13 @@ const CATEGORY_TABS: { value: CategoryFilter; label: string }[] = [
 
 // ─── Door direction filter ────────────────────────────────────────────────────
 
-type DoorFilter = 'rear' | 'side' | 'top' | 'rearAndSide';
+type DoorFilter = 'rear' | 'side' | 'top' | 'all';
 
 const DOOR_FILTER_OPTIONS: { value: DoorFilter; label: string }[] = [
   { value: 'rear', label: 'Arka Kapı' },
   { value: 'side', label: 'Yan Kapı' },
   { value: 'top', label: 'Üst Kapı' },
-  { value: 'rearAndSide', label: 'Arka + Yan' },
+  { value: 'all', label: 'Tümü' },
 ];
 
 // ─── Skeleton ─────────────────────────────────────────────────────────────────
@@ -504,7 +504,7 @@ export function VehicleTable({ onCreateClick }: VehicleTableProps) {
                       />
                       <span
                         className={cn('inline-block h-2 w-2 rounded-full', {
-                          'bg-zinc-400': value === 'rear' || value === 'rearAndSide',
+                          'bg-zinc-400': value === 'rear' || value === 'all',
                           'bg-teal-500': value === 'side',
                           'bg-violet-500': value === 'top',
                         })}

--- a/apps/frontend/src/features/data-management/schemas/vehicleSchema.ts
+++ b/apps/frontend/src/features/data-management/schemas/vehicleSchema.ts
@@ -63,7 +63,7 @@ export const vehicleFormSchema = z
       .optional(),
 
     // VY-07: Kapı yönü
-    doorDirection: z.enum(['rear', 'side', 'top', 'rearAndSide'] as const, {
+    doorDirection: z.enum(['rear', 'side', 'top', 'all'] as const, {
       message: 'Lütfen kapı yönünü seçiniz',
     }),
     doorSide: z.enum(['right', 'left'] as const).optional(),
@@ -120,7 +120,7 @@ export const vehicleFormSchema = z
     }
 
     // VY-07: Yan kapı seçilince taraf zorunlu
-    if ((data.doorDirection === 'side' || data.doorDirection === 'rearAndSide') && !data.doorSide) {
+    if (data.doorDirection === 'side' && !data.doorSide) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Kapı tarafı seçiniz (Sağ veya Sol)',

--- a/apps/frontend/src/features/planning/components/AddVehicleModal.tsx
+++ b/apps/frontend/src/features/planning/components/AddVehicleModal.tsx
@@ -23,7 +23,7 @@ const vehicleModalSchema = z.object({
   width: z.number({ error: 'Sayı giriniz' }).positive('Pozitif olmalı'),
   height: z.number({ error: 'Sayı giriniz' }).positive('Pozitif olmalı'),
   layerCount: z.number({ error: 'Sayı giriniz' }).int().min(1, 'En az 1'),
-  loadingArea: z.enum(['arka', 'yan', 'ust', 'arka-yan']),
+  loadingArea: z.enum(['arka', 'yan', 'ust', 'tumu']),
 });
 
 type VehicleModalValues = z.infer<typeof vehicleModalSchema>;
@@ -56,13 +56,13 @@ const VEHICLE_TYPES: Array<{
 // ─── Loading area config ──────────────────────────────────────────────────────
 
 const LOADING_AREAS: Array<{
-  value: 'arka' | 'yan' | 'ust' | 'arka-yan';
+  value: 'arka' | 'yan' | 'ust' | 'tumu';
   label: string;
 }> = [
-  { value: 'arka', label: 'Yalnızca Arka' },
-  { value: 'yan', label: 'Yan Kapı' },
-  { value: 'ust', label: 'Üst Kapak' },
-  { value: 'arka-yan', label: 'Arka + Yan' },
+  { value: 'arka', label: 'Arka' },
+  { value: 'yan', label: 'Yan' },
+  { value: 'ust', label: 'Üst' },
+  { value: 'tumu', label: 'Tümü' },
 ];
 
 // ─── AddVehicleModal ──────────────────────────────────────────────────────────
@@ -84,7 +84,7 @@ const LOADING_AREA_INT: Record<string, number> = {
   arka: 0,
   yan: 1,
   ust: 2,
-  'arka-yan': 3,
+  tumu: 3,
 };
 
 export function AddVehicleModal({ open, onOpenChange, onCreated }: AddVehicleModalProps) {

--- a/apps/frontend/src/features/planning/components/PlanLeftPanel.tsx
+++ b/apps/frontend/src/features/planning/components/PlanLeftPanel.tsx
@@ -29,7 +29,7 @@ import { usePlanStore, type UnplacedEntry } from '@/lib/store/usePlanStore';
 import { useSceneStore } from '@/lib/store/useSceneStore';
 import { SCENE } from '@/lib/config/scene-config';
 import { useItems } from '@/lib/api/useItems';
-import { AddItemModal } from './AddItemModal';
+
 import type { Item } from '@/lib/types/item';
 
 // Minimum item count to switch from DnD to virtual list rendering
@@ -303,7 +303,7 @@ export function PlanLeftPanel() {
     Array<{ id: string; ad: string; acik: boolean; itemIdler: string[] }>
   >([]);
   const [ungroupedIds, setUngroupedIds] = useState<string[]>([]);
-  const [showItemModal, setShowItemModal] = useState(false);
+
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [activeConstraints] = useState<Set<string>>(new Set());
@@ -483,7 +483,7 @@ export function PlanLeftPanel() {
             size="icon"
             title="Ürün Ekle"
             className="h-7 w-7 bg-zinc-900 text-white hover:bg-zinc-700"
-            onClick={() => setShowItemModal(true)}
+            onClick={() => navigate('/products')}
           >
             <Plus className="w-3.5 h-3.5" />
           </Button>
@@ -754,8 +754,6 @@ export function PlanLeftPanel() {
           )}
         </div>
       )}
-
-      <AddItemModal open={showItemModal} onOpenChange={setShowItemModal} />
     </div>
   );
 }

--- a/apps/frontend/src/features/planning/components/scene/ContainerBody.tsx
+++ b/apps/frontend/src/features/planning/components/scene/ContainerBody.tsx
@@ -17,7 +17,7 @@ interface ContainerBodyProps {
   width: number;
   height: number;
   length: number;
-  doorDirection?: 'rear' | 'side' | 'top';
+  doorDirection?: 'rear' | 'side' | 'top' | 'all';
   doorSide?: 'left' | 'right';
 }
 

--- a/apps/frontend/src/features/planning/components/scene/ContainerBody.tsx
+++ b/apps/frontend/src/features/planning/components/scene/ContainerBody.tsx
@@ -9,24 +9,25 @@ import roughnessUrl from '@/assets/textures/container-steel/roughness.jpg';
 import metalnessUrl from '@/assets/textures/container-steel/metalness.jpg';
 import aoUrl from '@/assets/textures/container-steel/ao.jpg';
 
-const WALL_GAP_CM = 0.5;
-
-// 1m = 100cm. UV_SCALE ile konteyner boyutuna göre texture tekrar sayısı hesaplanır.
+// z-fighting'i önlemek için duvar yüzeylerini hafif içeriye çek
+const OFFSET = 0.1;
 const UV_SCALE = 0.008;
 
 interface ContainerBodyProps {
   width: number;
   height: number;
   length: number;
+  doorDirection?: 'rear' | 'side' | 'top';
+  doorSide?: 'left' | 'right';
 }
 
-// BackSide render'da texture çalışır — normal vektörler ters gelir ama map görünür.
-// ContainerBody iç duvarları texture'lı metal olarak render eder.
-export function ContainerBody({ width, height, length }: ContainerBodyProps) {
-  const innerW = width - 2 * WALL_GAP_CM;
-  const innerH = height - 2 * WALL_GAP_CM;
-  const innerL = length - 2 * WALL_GAP_CM;
-
+export function ContainerBody({
+  width,
+  height,
+  length,
+  doorDirection = 'rear',
+  doorSide,
+}: ContainerBodyProps) {
   const [normalMap, roughnessMap, metalnessMap, aoMap] = useTexture([
     normalUrl,
     roughnessUrl,
@@ -44,18 +45,92 @@ export function ContainerBody({ width, height, length }: ContainerBodyProps) {
     }
   }, [width, height, length, normalMap, roughnessMap, metalnessMap, aoMap]);
 
+  // Kapı tarafındaki duvarı atla
+  // side+left → kapı X=width duvarında → 'right' atlanır
+  // side+right → kapı X=0 duvarında → 'left' atlanır
+  const skipWall =
+    doorDirection === 'top'
+      ? 'ceiling'
+      : doorDirection === 'rear'
+        ? 'rear'
+        : doorSide === 'left'
+          ? 'right'
+          : 'left';
+
+  const matProps = {
+    normalMap,
+    roughnessMap,
+    metalnessMap,
+    aoMap,
+    metalness: 0.45,
+    roughness: 0.7,
+  };
+
   return (
-    <mesh position={[width / 2, height / 2, length / 2]} receiveShadow>
-      <boxGeometry args={[innerW, innerH, innerL]} />
-      <meshStandardMaterial
-        normalMap={normalMap}
-        roughnessMap={roughnessMap}
-        metalnessMap={metalnessMap}
-        aoMap={aoMap}
-        side={THREE.BackSide}
-        metalness={0.45}
-        roughness={0.7}
-      />
-    </mesh>
+    <group>
+      {/* Zemin — Y=0, normal +Y */}
+      <mesh
+        position={[width / 2, OFFSET, length / 2]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        receiveShadow
+      >
+        <planeGeometry args={[width, length]} />
+        <meshStandardMaterial {...matProps} />
+      </mesh>
+
+      {/* Tavan — Y=height, normal -Y */}
+      {skipWall !== 'ceiling' && (
+        <mesh
+          position={[width / 2, height - OFFSET, length / 2]}
+          rotation={[Math.PI / 2, 0, 0]}
+          receiveShadow
+        >
+          <planeGeometry args={[width, length]} />
+          <meshStandardMaterial {...matProps} />
+        </mesh>
+      )}
+
+      {/* Arka duvar — Z=0, normal +Z */}
+      {skipWall !== 'rear' && (
+        <mesh position={[width / 2, height / 2, OFFSET]} receiveShadow>
+          <planeGeometry args={[width, height]} />
+          <meshStandardMaterial {...matProps} />
+        </mesh>
+      )}
+
+      {/* Ön duvar — Z=length, normal -Z */}
+      <mesh
+        position={[width / 2, height / 2, length - OFFSET]}
+        rotation={[0, Math.PI, 0]}
+        receiveShadow
+      >
+        <planeGeometry args={[width, height]} />
+        <meshStandardMaterial {...matProps} />
+      </mesh>
+
+      {/* Sol duvar — X=0, normal +X */}
+      {skipWall !== 'left' && (
+        <mesh
+          position={[OFFSET, height / 2, length / 2]}
+          rotation={[0, Math.PI / 2, 0]}
+          receiveShadow
+        >
+          <planeGeometry args={[length, height]} />
+          <meshStandardMaterial {...matProps} />
+        </mesh>
+      )}
+
+      {/* Sağ duvar — X=width, normal -X */}
+      {skipWall !== 'right' && (
+        <mesh
+          position={[width - OFFSET, height / 2, length / 2]}
+          rotation={[0, -Math.PI / 2, 0]}
+          receiveShadow
+        >
+          <planeGeometry args={[length, height]} />
+          <meshStandardMaterial {...matProps} />
+        </mesh>
+      )}
+    </group>
   );
 }

--- a/apps/frontend/src/features/planning/components/scene/ContainerMesh.tsx
+++ b/apps/frontend/src/features/planning/components/scene/ContainerMesh.tsx
@@ -424,7 +424,7 @@ function TopCoverHalf({
   return (
     <group>
       {/* Panel: XZ düzleminde, rotate ile yatay yap */}
-      <group rotation={[-Math.PI / 2, 0, 0]} scale={[1, sign, 1]}>
+      <group rotation={[Math.PI / 2, 0, 0]} scale={[1, sign, 1]}>
         <DoorPanel width={width} height={panelLength} />
       </group>
       <TopCoverGrid width={width} panelLength={panelLength} sign={sign} />
@@ -473,20 +473,26 @@ export function ContainerMesh() {
 
   return (
     <group>
-      <ContainerBody width={width} height={height} length={length} />
+      <ContainerBody
+        width={width}
+        height={height}
+        length={length}
+        doorDirection={doorDirection}
+        doorSide={doorSide}
+      />
       <ContainerEdges width={width} height={height} length={length} />
 
-      {(doorDirection === 'rear' || doorDirection === 'rearAndSide') && (
+      {doorDirection === 'rear' && (
         <group key={`rear-${vehicle.id}`} position={[0, 0, 0]}>
           <RearDoors width={width} height={height} />
         </group>
       )}
 
-      {(doorDirection === 'side' || doorDirection === 'rearAndSide') && (
+      {doorDirection === 'side' && (
         <group
           key={`side-${vehicle.id}`}
-          position={[doorSide === 'left' ? 0 : width, 0, 0]}
-          scale={[doorSide === 'left' ? 1 : -1, 1, 1]}
+          position={[doorSide === 'left' ? width : 0, 0, 0]}
+          scale={[doorSide === 'left' ? -1 : 1, 1, 1]}
         >
           <SideDoors width={width} height={height} length={length} />
         </group>

--- a/apps/frontend/src/lib/api/vehicleMappers.ts
+++ b/apps/frontend/src/lib/api/vehicleMappers.ts
@@ -26,7 +26,7 @@ export const LOADING_TYPE_FROM_INT: Record<
   0: { direction: DoorDirection.Rear },
   1: { direction: DoorDirection.Side, doorSide: 'right' },
   2: { direction: DoorDirection.Side, doorSide: 'left' },
-  3: { direction: DoorDirection.RearAndSide },
+  3: { direction: DoorDirection.All },
   4: { direction: DoorDirection.Top },
 };
 
@@ -215,7 +215,7 @@ export function buildCreateVehiclePayload(values: VehicleFormValues): CreateVehi
       if (values.doorDirection === 'side') {
         return values.doorSide === 'left' ? 2 : 1; // SideLeft=2, SideRight=1
       }
-      const map: Record<string, number> = { rear: 0, rearAndSide: 3, top: 4 };
+      const map: Record<string, number> = { rear: 0, all: 3, top: 4 };
       return map[values.doorDirection] ?? 0;
     })(),
     isActive: values.isActive ?? true,

--- a/apps/frontend/src/lib/types/loadingPlan.ts
+++ b/apps/frontend/src/lib/types/loadingPlan.ts
@@ -79,7 +79,7 @@ export const loadingPlanListItemSchema = z.object({
   interiorHeightM: z.number().positive(),
   interiorDepthM: z.number().positive(),
   vehicleType: z.enum(['Tir', 'Kamyon', 'Kamposet', 'Konteyner']).optional(),
-  doorDirection: z.enum(['rear', 'side', 'top', 'rearAndSide']).optional(),
+  doorDirection: z.enum(['rear', 'side', 'top', 'all']).optional(),
   doorSide: z.enum(['right', 'left']).optional(),
 });
 

--- a/apps/frontend/src/lib/types/vehicle.ts
+++ b/apps/frontend/src/lib/types/vehicle.ts
@@ -12,7 +12,7 @@ export const DoorDirection = {
   Rear: 'rear',
   Side: 'side',
   Top: 'top',
-  RearAndSide: 'rearAndSide',
+  All: 'all',
 } as const;
 export type DoorDirection = (typeof DoorDirection)[keyof typeof DoorDirection];
 


### PR DESCRIPTION
● Özet

  3D sahnede yan kapılı konteynerlarda kapı paneli ve animasyon, aracın karşı duvarına (X ekseni
  zıttı) taşındı. Aynı zamanda kapı tarafındaki duvar ContainerBody'den kaldırıldı — kutu içeriden ve
   dışarıdan bakıldığında kapı bölgesinde duvar görünmez.

  İlgili User Story / Issue

  US-XXX

  Değişiklik Tipi

  - 🚀 Yeni özellik (feature)

  Test Edildi mi?

  - Manuel test yapıldı
    - Yan kapılı konteyner (left/right) her iki doorSide değeri için test edildi
    - Kapı animasyonu karşı duvarda doğru açılıyor
    - Kapı tarafındaki duvar iç ve dış açıdan görünmüyor
    - Arka kapı ve üst kapı davranışları etkilenmedi
    - doorDirection: 'all' değeri için derleme hatası giderildi

  Kontrol Listesi

  - Kod standartlarına uygun
  - Commit mesajları commit kurallarına (docs/conventions/COMMITS.md) uygun
  - Linter hataları yok
  - Self-review yapıldı
  - Dokümantasyon güncellendi (gerekiyorsa)

  Ek Notlar

  Etkilenen dosyalar:
  - ContainerMesh.tsx — doorSide === 'left' için konum X=width'e, doorSide === 'right' için X=0'a
  taşındı
  - ContainerBody.tsx — Tek BoxGeometry + BackSide yerine 6 ayrı planeGeometry düzlemi; doorDirection
   ve doorSide'a göre kapı tarafındaki duvar render edilmiyor. 'all' değeri tip tanımına eklendi.
