### PR TITLE
US-3D-31: plan paylaşım backend implementasyonu eklendi

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Interfaces/IShareLinkRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/IShareLinkRepository.cs
@@ -1,0 +1,14 @@
+using CargoPilot.Application.Features.Shares.CreateShareLink;
+using CargoPilot.Application.Features.Shares.GetSharePlanByToken;
+using CargoPilot.Domain.Entities;
+
+namespace CargoPilot.Application.Common.Interfaces;
+
+public interface IShareLinkRepository
+{
+    Task<ShareLink?> GetByTokenAsync(string token, CancellationToken cancellationToken = default);
+    Task<SharePlanDto?> GetSharePlanByTokenAsync(string token, CancellationToken cancellationToken = default);
+    Task<ShareLinkDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    void Add(ShareLink shareLink);
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/apps/backend/CargoPilot.Application/Features/Shares/CreateShareLink/CreateShareLinkCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Shares/CreateShareLink/CreateShareLinkCommand.cs
@@ -1,0 +1,6 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Shares.CreateShareLink;
+
+public sealed record CreateShareLinkCommand(Guid PlanId, string Validity) : IRequest<Result<ShareLinkDto>>;

--- a/apps/backend/CargoPilot.Application/Features/Shares/CreateShareLink/CreateShareLinkCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Shares/CreateShareLink/CreateShareLinkCommandHandler.cs
@@ -1,0 +1,71 @@
+using System.Security.Cryptography;
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Entities;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Shares.CreateShareLink;
+
+internal sealed class CreateShareLinkCommandHandler : IRequestHandler<CreateShareLinkCommand, Result<ShareLinkDto>>
+{
+    private static readonly string[] ValidValidities = ["24h", "7d", "unlimited"];
+
+    private readonly IShareLinkRepository _shareRepository;
+    private readonly ILoadingPlanRepository _planRepository;
+    private readonly ICurrentUserService _currentUserService;
+
+    public CreateShareLinkCommandHandler(
+        IShareLinkRepository shareRepository,
+        ILoadingPlanRepository planRepository,
+        ICurrentUserService currentUserService)
+    {
+        _shareRepository = shareRepository;
+        _planRepository = planRepository;
+        _currentUserService = currentUserService;
+    }
+
+    public async Task<Result<ShareLinkDto>> Handle(CreateShareLinkCommand request, CancellationToken cancellationToken)
+    {
+        if (_currentUserService.UserId is not { } userId)
+            return Result<ShareLinkDto>.Failure(
+                new Error(ErrorType.Unauthorized, "AUTH_UNAUTHORIZED", "Kimlik doğrulaması gereklidir."));
+
+        if (!ValidValidities.Contains(request.Validity))
+            return Result<ShareLinkDto>.Failure(
+                new Error(ErrorType.Validation, "SHARE_INVALID_VALIDITY", "Geçerlilik süresi '24h', '7d' veya 'unlimited' olmalıdır."));
+
+        var plan = await _planRepository.GetByIdAsync(request.PlanId, _currentUserService.CompanyId, cancellationToken);
+        if (plan is null)
+            return Result<ShareLinkDto>.Failure(
+                new Error(ErrorType.NotFound, "Plan.NotFound", "Yükleme planı bulunamadı."));
+
+        var rawBytes = RandomNumberGenerator.GetBytes(32);
+        var token = Convert.ToBase64String(rawBytes)
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+
+        DateTime? expiresAt = request.Validity switch
+        {
+            "24h" => DateTime.UtcNow.AddHours(24),
+            "7d"  => DateTime.UtcNow.AddDays(7),
+            _     => null
+        };
+
+        var shareLink = new ShareLink(Guid.NewGuid(), request.PlanId, userId, token, request.Validity, expiresAt);
+        _shareRepository.Add(shareLink);
+        await _shareRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<ShareLinkDto>.Success(new ShareLinkDto(
+            shareLink.Id,
+            shareLink.PlanId,
+            plan.PlanName,
+            shareLink.Token,
+            shareLink.Validity,
+            shareLink.ExpiresAt,
+            shareLink.CreatedAtUtc,
+            shareLink.IsExpired,
+            shareLink.ViewCount));
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Shares/CreateShareLink/ShareLinkDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Shares/CreateShareLink/ShareLinkDto.cs
@@ -1,0 +1,12 @@
+namespace CargoPilot.Application.Features.Shares.CreateShareLink;
+
+public sealed record ShareLinkDto(
+    Guid Id,
+    Guid PlanId,
+    string PlanName,
+    string Token,
+    string Validity,
+    DateTime? ExpiresAt,
+    DateTime CreatedAt,
+    bool IsExpired,
+    int ViewCount);

--- a/apps/backend/CargoPilot.Application/Features/Shares/GetSharePlanByToken/GetSharePlanByTokenQuery.cs
+++ b/apps/backend/CargoPilot.Application/Features/Shares/GetSharePlanByToken/GetSharePlanByTokenQuery.cs
@@ -1,0 +1,6 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Shares.GetSharePlanByToken;
+
+public sealed record GetSharePlanByTokenQuery(string Token) : IRequest<Result<SharePlanDto>>;

--- a/apps/backend/CargoPilot.Application/Features/Shares/GetSharePlanByToken/GetSharePlanByTokenQueryHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Shares/GetSharePlanByToken/GetSharePlanByTokenQueryHandler.cs
@@ -1,0 +1,26 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Shares.GetSharePlanByToken;
+
+internal sealed class GetSharePlanByTokenQueryHandler : IRequestHandler<GetSharePlanByTokenQuery, Result<SharePlanDto>>
+{
+    private readonly IShareLinkRepository _repository;
+
+    public GetSharePlanByTokenQueryHandler(IShareLinkRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Result<SharePlanDto>> Handle(GetSharePlanByTokenQuery request, CancellationToken cancellationToken)
+    {
+        var dto = await _repository.GetSharePlanByTokenAsync(request.Token, cancellationToken);
+
+        if (dto is null)
+            return Result<SharePlanDto>.Failure(
+                new Error(ErrorType.NotFound, "Share.NotFound", "Paylaşım bağlantısı bulunamadı."));
+
+        return Result<SharePlanDto>.Success(dto);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Shares/GetSharePlanByToken/SharePlanDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Shares/GetSharePlanByToken/SharePlanDto.cs
@@ -1,0 +1,38 @@
+namespace CargoPilot.Application.Features.Shares.GetSharePlanByToken;
+
+public sealed record ShareVehicleDataDto(
+    decimal Width,
+    decimal Height,
+    decimal Length,
+    string DoorDirection,
+    string? VehicleType);
+
+public sealed record SharePlacementDetailDto(
+    Guid ItemId,
+    decimal PositionX,
+    decimal PositionY,
+    decimal PositionZ,
+    decimal Width,
+    decimal Height,
+    decimal Depth,
+    int OrientationIndex,
+    int Layer,
+    bool IsViolation,
+    string? Color,
+    decimal Weight);
+
+public sealed record SharePlanDto(
+    string PlanName,
+    string PlanCode,
+    string VehicleName,
+    string? VehiclePlate,
+    DateTime CreatedAt,
+    DateTime? PlannedAt,
+    string Status,
+    int ProductCount,
+    decimal TotalWeightKg,
+    decimal VehicleCapacityKg,
+    decimal FillPercentage,
+    bool IsExpired,
+    ShareVehicleDataDto? VehicleData,
+    IReadOnlyList<SharePlacementDetailDto>? Placements);

--- a/apps/backend/CargoPilot.Application/Features/Shares/RecordShareView/RecordShareViewCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Shares/RecordShareView/RecordShareViewCommand.cs
@@ -1,0 +1,6 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Shares.RecordShareView;
+
+public sealed record RecordShareViewCommand(string Token) : IRequest<Result<bool>>;

--- a/apps/backend/CargoPilot.Application/Features/Shares/RecordShareView/RecordShareViewCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Shares/RecordShareView/RecordShareViewCommandHandler.cs
@@ -1,0 +1,28 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Shares.RecordShareView;
+
+internal sealed class RecordShareViewCommandHandler : IRequestHandler<RecordShareViewCommand, Result<bool>>
+{
+    private readonly IShareLinkRepository _repository;
+
+    public RecordShareViewCommandHandler(IShareLinkRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Result<bool>> Handle(RecordShareViewCommand request, CancellationToken cancellationToken)
+    {
+        var shareLink = await _repository.GetByTokenAsync(request.Token, cancellationToken);
+
+        if (shareLink is not null && !shareLink.IsExpired)
+        {
+            shareLink.IncrementViewCount();
+            await _repository.SaveChangesAsync(cancellationToken);
+        }
+
+        return Result<bool>.Success(true);
+    }
+}

--- a/apps/backend/CargoPilot.Domain/Entities/ShareLink.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/ShareLink.cs
@@ -1,0 +1,35 @@
+namespace CargoPilot.Domain.Entities;
+
+public sealed class ShareLink
+{
+    public Guid Id { get; private set; }
+    public Guid PlanId { get; private set; }
+    public Guid CreatedByUserId { get; private set; }
+    public string Token { get; private set; } = null!;
+    public string Validity { get; private set; } = null!;
+    public DateTime? ExpiresAt { get; private set; }
+    public DateTime CreatedAtUtc { get; private set; }
+    public int ViewCount { get; private set; }
+
+#pragma warning disable S1144
+    public LoadingPlan Plan { get; private set; } = null!;
+#pragma warning restore S1144
+
+    public bool IsExpired => ExpiresAt.HasValue && DateTime.UtcNow > ExpiresAt.Value;
+
+    private ShareLink() { }
+
+    public ShareLink(Guid id, Guid planId, Guid createdByUserId, string token, string validity, DateTime? expiresAt)
+    {
+        Id = id;
+        PlanId = planId;
+        CreatedByUserId = createdByUserId;
+        Token = token;
+        Validity = validity;
+        ExpiresAt = expiresAt;
+        CreatedAtUtc = DateTime.UtcNow;
+        ViewCount = 0;
+    }
+
+    public void IncrementViewCount() => ViewCount++;
+}

--- a/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
+++ b/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
@@ -89,6 +89,7 @@ public static class DependencyInjection {
         services.AddDataProtection();
         services.AddScoped<IErpPasswordProtector, DataProtectionErpPasswordProtector>();
         services.AddScoped<IErpSettingsRepository, ErpSettingsRepository>();
+        services.AddScoped<IShareLinkRepository, ShareLinkRepository>();
         services.AddTransient<IErpConnector, LogoErpConnector>();
         services.AddTransient<IErpConnector, NetsisErpConnector>();
         services.AddHttpClient<IEmailService, ResendEmailService>(client =>

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContext.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/AppDbContext.cs
@@ -35,6 +35,7 @@ public class AppDbContext : DbContext {
     public DbSet<Notification> Notifications => Set<Notification>();
     public DbSet<PendingItemMapping> PendingItemMappings => Set<PendingItemMapping>();
     public DbSet<ErpSettings> ErpSettings => Set<ErpSettings>();
+    public DbSet<ShareLink> ShareLinks => Set<ShareLink>();
 
     public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) {
         ApplyAuditFields();
@@ -69,6 +70,7 @@ public class AppDbContext : DbContext {
         modelBuilder.ApplyConfiguration(new NotificationConfiguration());
         modelBuilder.ApplyConfiguration(new PendingItemMappingConfiguration());
         modelBuilder.ApplyConfiguration(new ErpSettingsConfiguration());
+        modelBuilder.ApplyConfiguration(new ShareLinkConfiguration());
     }
 
     private void ApplyAuditFields() {

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/ShareLinkConfiguration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/ShareLinkConfiguration.cs
@@ -1,0 +1,47 @@
+using CargoPilot.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace CargoPilot.Infrastructure.Persistence.Configurations;
+
+internal sealed class ShareLinkConfiguration : IEntityTypeConfiguration<ShareLink>
+{
+    public void Configure(EntityTypeBuilder<ShareLink> builder)
+    {
+        builder.ToTable("ShareLinks");
+        builder.HasKey(sl => sl.Id);
+
+        builder.Property(sl => sl.PlanId).IsRequired();
+        builder.Property(sl => sl.CreatedByUserId).IsRequired();
+
+        builder.Property(sl => sl.Token)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(sl => sl.Validity)
+            .IsRequired()
+            .HasMaxLength(20);
+
+        builder.Property(sl => sl.ExpiresAt);
+
+        builder.Property(sl => sl.CreatedAtUtc)
+            .IsRequired()
+            .HasDefaultValueSql("GETUTCDATE()");
+
+        builder.Property(sl => sl.ViewCount)
+            .IsRequired()
+            .HasDefaultValue(0);
+
+        builder.HasIndex(sl => sl.Token)
+            .IsUnique()
+            .HasDatabaseName("UX_ShareLinks_Token");
+
+        builder.HasIndex(sl => sl.PlanId)
+            .HasDatabaseName("IX_ShareLinks_PlanId");
+
+        builder.HasOne(sl => sl.Plan)
+            .WithMany()
+            .HasForeignKey(sl => sl.PlanId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260516095452_AddShareLinks.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260516095452_AddShareLinks.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516095452_AddShareLinks")]
+    partial class AddShareLinks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260516095452_AddShareLinks.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260516095452_AddShareLinks.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShareLinks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ShareLinks",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    PlanId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    CreatedByUserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Token = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Validity = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    CreatedAtUtc = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETUTCDATE()"),
+                    ViewCount = table.Column<int>(type: "int", nullable: false, defaultValue: 0)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ShareLinks", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ShareLinks_LoadingPlans_PlanId",
+                        column: x => x.PlanId,
+                        principalTable: "LoadingPlans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ShareLinks_PlanId",
+                table: "ShareLinks",
+                column: "PlanId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_ShareLinks_Token",
+                table: "ShareLinks",
+                column: "Token",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ShareLinks");
+        }
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/ShareLinkRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/ShareLinkRepository.cs
@@ -1,0 +1,162 @@
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Features.Shares.CreateShareLink;
+using CargoPilot.Application.Features.Shares.GetSharePlanByToken;
+using CargoPilot.Domain.Entities;
+using CargoPilot.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace CargoPilot.Infrastructure.Persistence.Repositories;
+
+internal sealed class ShareLinkRepository : IShareLinkRepository
+{
+    private readonly AppDbContext _context;
+
+    public ShareLinkRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<ShareLink?> GetByTokenAsync(string token, CancellationToken cancellationToken = default)
+        => await _context.ShareLinks
+            .FirstOrDefaultAsync(sl => sl.Token == token, cancellationToken);
+
+    public async Task<SharePlanDto?> GetSharePlanByTokenAsync(string token, CancellationToken cancellationToken = default)
+    {
+        var shareLink = await _context.ShareLinks
+            .AsNoTracking()
+            .Include(sl => sl.Plan)
+                .ThenInclude(p => p.Vehicle)
+            .FirstOrDefaultAsync(sl => sl.Token == token, cancellationToken);
+
+        if (shareLink is null) return null;
+
+        var plan = shareLink.Plan;
+        var vehicle = plan.Vehicle;
+
+        var placements = await _context.LoadingPlanPlacements
+            .AsNoTracking()
+            .Include(p => p.Item)
+            .Where(p => p.LoadingPlanId == plan.Id)
+            .ToListAsync(cancellationToken);
+
+        var inputItems = await _context.LoadingPlanInputItems
+            .AsNoTracking()
+            .Include(i => i.Group)
+            .Where(i => i.LoadingPlanId == plan.Id)
+            .ToListAsync(cancellationToken);
+
+        var colorByItemId = inputItems
+            .Where(i => i.GroupId.HasValue && i.Group is not null)
+            .GroupBy(i => i.ItemId)
+            .ToDictionary(g => g.Key, g => g.First().Group!.Color);
+
+        var placementDtos = placements
+            .Select(p =>
+            {
+                var (w, h, d) = ApplyRotation(p.Item.Width, p.Item.Height, p.Item.Length, p.Rotation);
+                colorByItemId.TryGetValue(p.ItemId, out var color);
+                return new SharePlacementDetailDto(
+                    p.ItemId,
+                    p.PositionX,
+                    p.PositionY,
+                    p.PositionZ,
+                    w,
+                    h,
+                    d,
+                    (int)p.Rotation,
+                    1,
+                    false,
+                    color,
+                    p.Item.Weight);
+            })
+            .ToList();
+
+        var vehicleData = new ShareVehicleDataDto(
+            vehicle.InternalWidth,
+            vehicle.InternalHeight,
+            vehicle.InternalLength,
+            MapDoorDirection(vehicle.LoadingType),
+            MapVehicleType(vehicle.VehicleType));
+
+        return new SharePlanDto(
+            plan.PlanName,
+            $"#{plan.Id.ToString("N")[..8].ToUpperInvariant()}",
+            vehicle.VehicleName,
+            vehicle.PlateNumber,
+            plan.CreatedAtUtc,
+            null,
+            MapStatus(plan.OptimizationStatus),
+            plan.PlacedQuantity,
+            plan.TotalWeight,
+            vehicle.MaxWeightCapacity,
+            plan.FillRate,
+            shareLink.IsExpired,
+            placementDtos.Count > 0 ? vehicleData : null,
+            placementDtos.Count > 0 ? placementDtos : null);
+    }
+
+    public async Task<ShareLinkDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var sl = await _context.ShareLinks
+            .AsNoTracking()
+            .Include(s => s.Plan)
+            .FirstOrDefaultAsync(s => s.Id == id, cancellationToken);
+
+        if (sl is null) return null;
+
+        return new ShareLinkDto(
+            sl.Id,
+            sl.PlanId,
+            sl.Plan.PlanName,
+            sl.Token,
+            sl.Validity,
+            sl.ExpiresAt,
+            sl.CreatedAtUtc,
+            sl.IsExpired,
+            sl.ViewCount);
+    }
+
+    public void Add(ShareLink shareLink) => _context.ShareLinks.Add(shareLink);
+
+    public async Task SaveChangesAsync(CancellationToken cancellationToken = default)
+        => await _context.SaveChangesAsync(cancellationToken);
+
+    private static (decimal w, decimal h, decimal d) ApplyRotation(
+        decimal width, decimal height, decimal length, LoadingPlanPlacementRotation rotation)
+        => rotation switch
+        {
+            LoadingPlanPlacementRotation.NoRotation => (width,  height,  length),
+            LoadingPlanPlacementRotation.Yaw        => (length, height,  width),
+            LoadingPlanPlacementRotation.Pitch      => (width,  length,  height),
+            LoadingPlanPlacementRotation.Roll       => (height, width,   length),
+            LoadingPlanPlacementRotation.YawPitch   => (height, length,  width),
+            LoadingPlanPlacementRotation.RollYaw    => (length, width,   height),
+            _                                       => (width,  height,  length),
+        };
+
+    private static string MapDoorDirection(LoadingType loadingType)
+        => loadingType switch
+        {
+            LoadingType.Rear     => "rear",
+            LoadingType.SideRight or LoadingType.SideLeft => "side",
+            LoadingType.SideBoth => "rearAndSide",
+            LoadingType.Top      => "top",
+            _                    => "rear",
+        };
+
+    private static string? MapVehicleType(VehicleType vehicleType)
+        => vehicleType switch
+        {
+            VehicleType.Truck     => "Kamyon",
+            VehicleType.Container => "Konteyner",
+            _                     => "Tir",
+        };
+
+    private static string MapStatus(LoadingPlanOptimizationStatus status)
+        => status switch
+        {
+            LoadingPlanOptimizationStatus.Calculated => "tamamlandi",
+            LoadingPlanOptimizationStatus.Failed     => "iptal",
+            _                                        => "taslak",
+        };
+}

--- a/apps/backend/CargoPilot.WebAPI/Controllers/SharesController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/SharesController.cs
@@ -1,0 +1,90 @@
+using CargoPilot.Application.Features.Shares.CreateShareLink;
+using CargoPilot.Application.Features.Shares.GetSharePlanByToken;
+using CargoPilot.Application.Features.Shares.RecordShareView;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CargoPilot.WebAPI.Controllers;
+
+/// <summary>
+/// Yükleme planı paylaşım bağlantısı endpoint'leri.
+/// </summary>
+[Route("api/v1/shares")]
+[Tags("Shares")]
+public sealed class SharesController : BaseController
+{
+    private readonly IMediator _mediator;
+
+    public SharesController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Belirtilen plan için zaman sınırlı bir paylaşım bağlantısı oluşturur.
+    /// </summary>
+    /// <param name="request">PlanId ve geçerlilik süresi ('24h', '7d', 'unlimited').</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Paylaşım bağlantısı oluşturuldu.</response>
+    /// <response code="400">Geçersiz istek.</response>
+    /// <response code="401">Kimlik doğrulaması gereklidir.</response>
+    /// <response code="404">Plan bulunamadı.</response>
+    [HttpPost]
+    [Authorize(Policy = "CompanyMember")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CreateShareLink(
+        [FromBody] CreateShareLinkRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new CreateShareLinkCommand(request.PlanId, request.Validity);
+        var result = await _mediator.Send(command, cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Token ile paylaşılan planın read-only görünüm verilerini döndürür.
+    /// </summary>
+    /// <param name="token">Paylaşım token'ı.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Plan verisi döner.</response>
+    /// <response code="404">Bağlantı bulunamadı.</response>
+    [HttpGet("{token}/plan")]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetSharePlan(
+        [FromRoute] string token,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new GetSharePlanByTokenQuery(token);
+        var result = await _mediator.Send(query, cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
+    /// Paylaşım bağlantısı için görüntülenme sayısını artırır.
+    /// </summary>
+    /// <param name="token">Paylaşım token'ı.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="204">Görüntülenme kaydedildi.</response>
+    [HttpPost("{token}/view")]
+    [AllowAnonymous]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> RecordView(
+        [FromRoute] string token,
+        CancellationToken cancellationToken = default)
+    {
+        await _mediator.Send(new RecordShareViewCommand(token), cancellationToken);
+        return NoContent();
+    }
+}
+
+public sealed record CreateShareLinkRequest
+{
+    public required Guid PlanId { get; init; }
+    public required string Validity { get; init; }
+}


### PR DESCRIPTION
- ShareLink entity, token üretimi (32-byte URL-safe base64) ve ExpiresAt desteği
- CreateShareLink komutu: plan sahipliği kontrolü, 24h/7d/unlimited geçerlilik
- GetSharePlanByToken sorgusu: araç boyutları, rotation-aware placement boyutları, grup rengi
- RecordShareView komutu: görüntülenme sayacı
- POST /api/v1/shares (authenticated), GET /api/v1/shares/{token}/plan ve POST /{token}/view (public)
- EF Core migrasyonu: ShareLinks tablosu, UX_ShareLinks_Token unique index

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
