### PR TITLE
fix(landing): header scroll davranışı tersine çevrildi, onboarding ta…

### DIFF
--- a/apps/frontend/src/features/platform/components/OnboardingDialog.tsx
+++ b/apps/frontend/src/features/platform/components/OnboardingDialog.tsx
@@ -84,7 +84,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="sm:max-w-md p-0 overflow-hidden gap-0"
+        className="sm:max-w-md p-0 overflow-hidden gap-0 data-[state=open]:[--tw-enter-translate-x:0px] data-[state=open]:[--tw-enter-translate-y:0px] data-[state=closed]:[--tw-exit-translate-x:0px] data-[state=closed]:[--tw-exit-translate-y:0px]"
         onPointerDownOutside={(e) => e.preventDefault()}
       >
         {/* Progress bar */}

--- a/apps/frontend/src/pages/LandingPage.tsx
+++ b/apps/frontend/src/pages/LandingPage.tsx
@@ -71,16 +71,16 @@ function Navbar() {
   const [menuOpen, setMenuOpen] = useState(false);
   const navRef = useRef<HTMLElement>(null);
   const mouseX = useMotionValue(Infinity);
-  const navLinksX = useMotionValue(-65);
+  const navLinksX = useMotionValue(0);
 
   useEffect(() => {
     const onScroll = () => {
       const progress = Math.min(window.scrollY / 280, 1);
       if (navRef.current) {
-        navRef.current.style.maxWidth = `${896 + progress * (1280 - 896)}px`;
+        navRef.current.style.maxWidth = `${1280 - progress * (1280 - 896)}px`;
       }
-      // same progress drives x: -40 → 0
-      navLinksX.set(-65 * (1 - progress));
+      // same progress drives x: 0 → -65
+      navLinksX.set(-65 * progress);
     };
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
@@ -93,7 +93,7 @@ function Navbar() {
         <nav
           ref={navRef}
           className="w-full bg-background/90 backdrop-blur-md border border-border rounded-2xl shadow-lg shadow-black/5"
-          style={{ maxWidth: 896 }}
+          style={{ maxWidth: 1280 }}
         >
           <div className="h-14 px-4 sm:px-5 grid grid-cols-[1fr_auto_1fr] items-center">
             <Link


### PR DESCRIPTION
…m ortada açılıyor

- Landing header başlangıçta wide (1280px), scroll ile küçülüyor (896px)
- Onboarding dialog slide-in animasyonu kaldırıldı, tam viewport merkezinde açılıyor

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
