### PR TITLE
feat(colors): update Genel group colors for koli and varil

### DIFF
--- a/apps/frontend/src/features/data-management/components/ProductForm.tsx
+++ b/apps/frontend/src/features/data-management/components/ProductForm.tsx
@@ -51,6 +51,7 @@ import { formatVolumeDisplay } from '@/lib/utils/unitConversion';
 import { cn } from '@/lib/utils';
 import { ProductPreview3D } from '@/features/data-management/components/ProductPreview3D';
 import { FormWithPreviewLayout } from '@/components/shared/FormWithPreviewLayout';
+import { resolveProductColor } from '@/lib/config/productColors';
 
 interface ProductFormProps {
   defaultValues?: Partial<ProductFormValues>;
@@ -521,6 +522,7 @@ export function ProductForm({
     allowRotateZ,
     notes,
     incompatibleGroups,
+    stackGroup,
   ] = useWatch({
     control: form.control,
     name: [
@@ -537,6 +539,7 @@ export function ProductForm({
       'allowRotateZ',
       'notes',
       'incompatibleGroups',
+      'stackGroup',
     ],
   });
 
@@ -1142,6 +1145,7 @@ export function ProductForm({
               <PreviewPanel
                 name={name}
                 productType={productType ?? 'koli'}
+                stackGroup={stackGroup}
                 length={length}
                 width={width}
                 height={height}
@@ -1167,6 +1171,7 @@ export function ProductForm({
 interface PreviewPanelProps {
   name?: string;
   productType: 'koli' | 'varil' | 'palet';
+  stackGroup?: string;
   length?: number;
   width?: number;
   height?: number;
@@ -1185,6 +1190,7 @@ function PreviewPanel(props: PreviewPanelProps) {
   const {
     name,
     productType,
+    stackGroup,
     length,
     width,
     height,
@@ -1261,6 +1267,7 @@ function PreviewPanel(props: PreviewPanelProps) {
             heightCm={heightCm}
             depthCm={depthCm}
             productType={productType}
+            color={resolveProductColor(productType, stackGroup)}
           />
         ) : (
           <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 text-muted-foreground">

--- a/apps/frontend/src/lib/api/loadingPlanMappers.ts
+++ b/apps/frontend/src/lib/api/loadingPlanMappers.ts
@@ -239,7 +239,6 @@ function mapStatus(
 
 // ─── Mapper: placements → PlanProductGroup[] ─────────────────────────────────
 
-
 export function fromApiDetailPlacements(rawPlacements: PlacementItemApi[]): PlanProductGroup[] {
   // itemId → { item, count }
   const itemMap = new Map<string, { p: PlacementItemApi; count: number }>();
@@ -316,7 +315,6 @@ export function fromApiDetailPlacements(rawPlacements: PlacementItemApi[]): Plan
 //   3=Roll(H,W,L)        4=YawPitch(H,L,W)  5=RollYaw(L,W,H)
 // We store placed dims directly and orientationIndex=0 so rendering needs no further rotation.
 
-
 function placedDimensions(
   w: number,
   h: number,
@@ -367,9 +365,7 @@ export function fromApiPlacementsToScene(
     const rawType = (item.productType as string | undefined)?.toLowerCase();
     const productType = rawType === 'varil' ? 'varil' : rawType === 'palet' ? 'palet' : 'koli';
 
-    const groupName = (item.groupName ?? item.categoryName ?? item.category) as
-      | string
-      | undefined;
+    const groupName = (item.groupName ?? item.categoryName ?? item.category) as string | undefined;
     const color = colorMap?.[sku] ?? resolveProductColor(productType, groupName);
 
     return [

--- a/apps/frontend/src/lib/api/loadingPlanMappers.ts
+++ b/apps/frontend/src/lib/api/loadingPlanMappers.ts
@@ -10,7 +10,7 @@ import type { Vehicle } from '@/lib/types/vehicle';
 import { VehicleType, DoorDirection } from '@/lib/types/vehicle';
 import { VEHICLE_TYPE_FROM_INT, LOADING_TYPE_FROM_INT } from './vehicleMappers';
 import { type OrientationIndex } from '@/lib/utils/boxOrientations';
-import { SCENE } from '@/lib/config/scene-config';
+import { resolveProductColor } from '@/lib/config/productColors';
 
 // ─── Vehicle sub-object ───────────────────────────────────────────────────────
 
@@ -239,16 +239,6 @@ function mapStatus(
 
 // ─── Mapper: placements → PlanProductGroup[] ─────────────────────────────────
 
-const GROUP_COLORS = [
-  '#3b82f6',
-  '#10b981',
-  '#f59e0b',
-  '#8b5cf6',
-  '#ec4899',
-  '#06b6d4',
-  '#84cc16',
-  '#f97316',
-];
 
 export function fromApiDetailPlacements(rawPlacements: PlacementItemApi[]): PlanProductGroup[] {
   // itemId → { item, count }
@@ -270,17 +260,16 @@ export function fromApiDetailPlacements(rawPlacements: PlacementItemApi[]): Plan
     string,
     { color: string; entries: Array<{ id: string; p: PlacementItemApi; count: number }> }
   >();
-  let colorIdx = 0;
-
   for (const [itemId, { p, count }] of itemMap) {
     const item = p.item;
     const groupName = item?.groupName ?? item?.categoryName ?? item?.category ?? 'Yük Grubu';
-    const groupColor =
-      item?.groupColor ?? item?.categoryColor ?? GROUP_COLORS[colorIdx % GROUP_COLORS.length];
+    const rawType = (item as Record<string, unknown> | undefined)?.['productType'] as
+      | string
+      | undefined;
+    const groupColor = resolveProductColor(rawType, groupName);
 
     if (!groupMap.has(groupName)) {
       groupMap.set(groupName, { color: groupColor, entries: [] });
-      colorIdx++;
     }
     groupMap.get(groupName)!.entries.push({ id: itemId, p, count });
   }
@@ -327,18 +316,6 @@ export function fromApiDetailPlacements(rawPlacements: PlacementItemApi[]): Plan
 //   3=Roll(H,W,L)        4=YawPitch(H,L,W)  5=RollYaw(L,W,H)
 // We store placed dims directly and orientationIndex=0 so rendering needs no further rotation.
 
-const SKU_PALETTE = [
-  '#3b82f6',
-  '#f59e0b',
-  '#10b981',
-  '#ef4444',
-  '#8b5cf6',
-  '#06b6d4',
-  '#f97316',
-  '#84cc16',
-  '#ec4899',
-  '#6366f1',
-];
 
 function placedDimensions(
   w: number,
@@ -366,9 +343,6 @@ export function fromApiPlacementsToScene(
   rawPlacements: PlacementItemApi[],
   colorMap?: Record<string, string>,
 ): PlacementWithDimensions[] {
-  const skuColorIndex: Record<string, number> = {};
-  let colorIdx = 0;
-
   return rawPlacements.flatMap((p) => {
     const raw = p as Record<string, unknown>;
     const itemId = (raw.itemId as string | undefined) ?? (raw.id as string | undefined) ?? '';
@@ -390,16 +364,13 @@ export function fromApiPlacementsToScene(
 
     const { pw, ph, pd } = placedDimensions(origW, origH, origL, rotation);
 
-    let color = colorMap?.[sku];
-    if (!color) {
-      if (skuColorIndex[sku] === undefined) {
-        skuColorIndex[sku] = colorIdx++ % SKU_PALETTE.length;
-      }
-      color = SKU_PALETTE[skuColorIndex[sku]];
-    }
-
     const rawType = (item.productType as string | undefined)?.toLowerCase();
     const productType = rawType === 'varil' ? 'varil' : rawType === 'palet' ? 'palet' : 'koli';
+
+    const groupName = (item.groupName ?? item.categoryName ?? item.category) as
+      | string
+      | undefined;
+    const color = colorMap?.[sku] ?? resolveProductColor(productType, groupName);
 
     return [
       {
@@ -596,15 +567,17 @@ export function fromApiFullDetail(
   type InputItemFull = z.infer<typeof inputItemFullSchema>;
   type PlacementFull = z.infer<typeof placementFullSchema>;
 
-  // Build color map from inputItems order
+  // Build color map from inputItems — renk (productType × yük grubu) kombinasyonuna göre belirlenir
   const skuColorMap: Record<string, string> = {};
-  const palette = SCENE.COLORS.SKU_PALETTE;
-  let colorIdx = 0;
   const inputItems = (data.inputItems ?? []).map((ii: InputItemFull) => {
     const item = apiItemToItem(ii.item);
     if (!skuColorMap[item.sku]) {
-      skuColorMap[item.sku] = palette[colorIdx % palette.length];
-      colorIdx++;
+      const rawItem = ii.item as Record<string, unknown>;
+      const groupName = (rawItem.groupName ?? rawItem.categoryName ?? rawItem.category) as
+        | string
+        | undefined;
+      const productType = (rawItem.productType as string | undefined) ?? item.productType;
+      skuColorMap[item.sku] = resolveProductColor(productType, groupName);
     }
     return { item, quantity: ii.quantity };
   });
@@ -616,9 +589,13 @@ export function fromApiFullDetail(
       pd: depth,
     } = placedDimensions(p.item.width, p.item.height, p.item.length, p.rotation);
     const itemSku = p.item.sku || p.item.sKU || p.itemId;
-    const color = skuColorMap[itemSku] ?? palette[0];
     const rawType = p.item.productType?.toLowerCase();
     const productType = rawType === 'varil' ? 'varil' : rawType === 'palet' ? 'palet' : 'koli';
+    const rawItem = p.item as Record<string, unknown>;
+    const groupName = (rawItem.groupName ?? rawItem.categoryName ?? rawItem.category) as
+      | string
+      | undefined;
+    const color = skuColorMap[itemSku] ?? resolveProductColor(productType, groupName);
     return {
       itemId: p.itemId,
       positionX: p.positionX,

--- a/apps/frontend/src/lib/config/productColors.ts
+++ b/apps/frontend/src/lib/config/productColors.ts
@@ -1,0 +1,77 @@
+// ─── Cargo Pilot Renk Standartı ──────────────────────────────────────────────
+// Renk; (ürün tipi × yük grubu) kombinasyonuna göre belirlenir.
+// Aynı kombinasyon 3D sahnede ve ürün yönetimi ekranında aynı rengi kullanır.
+
+export type ProductType = 'koli' | 'varil' | 'palet';
+
+// (productType, loadGroup) → hex renk
+const PRODUCT_GROUP_COLOR: Record<ProductType, Record<string, string>> = {
+  koli: {
+    Gıda: '#34D399', // Cargo Emerald
+    Kimya: '#FBBF24', // Modern Amber
+    'Tehlikeli Madde': '#FB923C', // Safety Orange
+    Elektronik: '#A855F7', // Cyber Violet
+    Tekstil: '#D97706', // Desert Sand
+    Genel: '#94A3B8', // Slate 400
+  },
+  varil: {
+    Gıda: '#A7F3D0', // Mint Frost
+    Kimya: '#2DD4BF', // Industrial Teal
+    'Tehlikeli Madde': '#E11D48', // Crimson Edge
+    Elektronik: '#84CC16', // Electric Lime
+    Tekstil: '#818CF8', // Logistics Indigo
+    Genel: '#2DD4BF', // Industrial Teal
+  },
+  palet: {
+    // Palet için yük grubundan bağımsız tek renk
+    _default: '#4338CA', // Midnight Cobalt
+  },
+};
+
+// Bilinmeyen kombinasyonlar için fallback
+export const COLOR_FALLBACK = '#FB7185'; // Steel Rose
+export const COLOR_FALLBACK_2 = '#0EA5E9'; // Deep Ocean — rezerv
+
+function normalize(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+export function resolveProductColor(
+  productType: string | null | undefined,
+  groupName: string | null | undefined,
+): string {
+  const type = normalize(productType ?? '') as ProductType;
+  const group = groupName?.trim() ?? '';
+
+  if (type === 'palet') return PRODUCT_GROUP_COLOR.palet._default;
+
+  const typeMap = type === 'varil' ? PRODUCT_GROUP_COLOR.varil : PRODUCT_GROUP_COLOR.koli; // koli + bilinmeyen tipler
+
+  if (!group) return COLOR_FALLBACK;
+
+  // Tam eşleşme
+  if (typeMap[group]) return typeMap[group];
+
+  // Büyük/küçük harf toleransı
+  const lowerGroup = normalize(group);
+  const match = Object.entries(typeMap).find(([k]) => normalize(k) === lowerGroup);
+  if (match) return match[1];
+
+  return COLOR_FALLBACK;
+}
+
+// Ürün yönetimi ekranı için sadece load group adından renk döner (type bilinmiyorsa koli varsayılır)
+export function resolveLoadGroupColor(
+  groupName: string | null | undefined,
+  productType?: string | null,
+): string {
+  return resolveProductColor(productType ?? 'koli', groupName);
+}
+
+// Tüm renk referansları için export — UI'da chip/badge rengi olarak kullanılır
+export const ALL_PRODUCT_COLORS = {
+  ...PRODUCT_GROUP_COLOR.koli,
+  ...PRODUCT_GROUP_COLOR.varil,
+  palet: PRODUCT_GROUP_COLOR.palet._default,
+  fallback: COLOR_FALLBACK,
+} as const;

--- a/apps/frontend/src/lib/config/scene-config.ts
+++ b/apps/frontend/src/lib/config/scene-config.ts
@@ -28,14 +28,14 @@ export const SCENE = {
   CONTACT_SHADOW_SCALE_FACTOR: 2,
 
   COLORS: {
-    VIOLATION: 0xdc2626,
-    VIOLATION_STR: '#dc2626',
-    SELECTED: 0xfbbf24,
-    SELECTED_STR: '#fbbf24',
+    VIOLATION: 0xe11d48, // Crimson Edge
+    VIOLATION_STR: '#E11D48',
+    SELECTED: 0xa7f3d0, // Mint Frost
+    SELECTED_STR: '#A7F3D0',
     COG_NORMAL: 0xfbbf24,
-    COG_WARNING: 0xdc2626,
-    NORMAL: 0x2563eb,
-    NORMAL_STR: '#2563eb',
+    COG_WARNING: 0xe11d48,
+    NORMAL: 0x2dd4bf, // Industrial Teal
+    NORMAL_STR: '#2DD4BF',
     CONTAINER_EDGE: '#334155',
     CONTAINER_DOOR: '#f59e0b',
     CONTAINER_INSIDE: '#d4c9a8',
@@ -46,19 +46,21 @@ export const SCENE = {
       C: 0xf59e0b,
       D: 0x22c55e,
     },
+    // Yük grubu bilinmediğinde fallback olarak kullanılan palet
     SKU_PALETTE: [
-      '#6366f1',
-      '#0ea5e9',
-      '#f59e0b',
-      '#f43f5e',
-      '#8b5cf6',
-      '#fb923c',
-      '#22c55e',
-      '#3b82f6',
-      '#ef4444',
-      '#14b8a6',
-      '#ec4899',
-      '#84cc16',
+      '#34D399', // Cargo Emerald  — Gıda
+      '#FBBF24', // Modern Amber   — Kimya
+      '#FB923C', // Safety Orange  — Tehlikeli Madde
+      '#A855F7', // Cyber Violet   — Elektronik
+      '#D97706', // Desert Sand    — Tekstil
+      '#94A3B8', // Slate 400      — Genel
+      '#2DD4BF', // Industrial Teal
+      '#818CF8', // Logistics Indigo
+      '#FB7185', // Steel Rose
+      '#0EA5E9', // Deep Ocean
+      '#84CC16', // Electric Lime
+      '#4338CA', // Midnight Cobalt
+      '#334155', // Volcanic Grey
     ] as string[],
   },
 


### PR DESCRIPTION
Koli+Genel: #64748B → #94A3B8 (Slate 400)
Varil+Genel: #334155 → #2DD4BF (Industrial Teal)

Also fixes ProductForm 3D preview not reacting to load group changes by passing stackGroup prop through PreviewPanel.

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
