### PR TITLE
loading plan thumbnail MinIO ile yükleme implementasyonu eklendi

### DIFF
--- a/apps/backend/CargoPilot.Application/Abstractions/IStorageService.cs
+++ b/apps/backend/CargoPilot.Application/Abstractions/IStorageService.cs
@@ -1,0 +1,9 @@
+namespace CargoPilot.Application.Abstractions;
+
+public interface IStorageService {
+    Task<string> UploadAsync(
+        string objectKey,
+        Stream content,
+        string contentType,
+        CancellationToken cancellationToken = default);
+}

--- a/apps/backend/CargoPilot.Application/Common/Settings/MinioSettings.cs
+++ b/apps/backend/CargoPilot.Application/Common/Settings/MinioSettings.cs
@@ -1,0 +1,9 @@
+namespace CargoPilot.Application.Common.Settings;
+
+public sealed class MinioSettings {
+    public string Endpoint { get; set; } = null!;
+    public string AccessKey { get; set; } = null!;
+    public string SecretKey { get; set; } = null!;
+    public string BucketName { get; set; } = "cargo-pilot";
+    public bool UseSSL { get; set; }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/PlanDetailDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/GetPlanById/PlanDetailDto.cs
@@ -21,6 +21,7 @@ public sealed record PlanDetailDto(
     decimal? WeightBalanceOffsetZ,
     DateTime CreatedAtUtc,
     ErpExportStatus? ErpExportStatus,
+    string? ThumbnailUrl,
     VehicleInPlanDto Vehicle,
     IReadOnlyList<PlacementDto> Placements,
     IReadOnlyList<UnplacedItemDto> UnplacedItems,

--- a/apps/backend/CargoPilot.Application/Features/Plans/GetPlans/PlanSummaryDto.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/GetPlans/PlanSummaryDto.cs
@@ -14,4 +14,5 @@ public sealed record PlanSummaryDto(
     int UnplacedQuantity,
     Guid VehicleId,
     string VehicleName,
-    DateTime CreatedAtUtc);
+    DateTime CreatedAtUtc,
+    string? ThumbnailUrl);

--- a/apps/backend/CargoPilot.Application/Features/Plans/UploadPlanThumbnail/UploadPlanThumbnailCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/UploadPlanThumbnail/UploadPlanThumbnailCommand.cs
@@ -1,0 +1,6 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.UploadPlanThumbnail;
+
+public sealed record UploadPlanThumbnailCommand(Guid PlanId, string ImageBase64) : IRequest<Result<string>>;

--- a/apps/backend/CargoPilot.Application/Features/Plans/UploadPlanThumbnail/UploadPlanThumbnailCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/UploadPlanThumbnail/UploadPlanThumbnailCommandHandler.cs
@@ -1,0 +1,71 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Plans.UploadPlanThumbnail;
+
+internal sealed class UploadPlanThumbnailCommandHandler : IRequestHandler<UploadPlanThumbnailCommand, Result<string>>
+{
+    private readonly ILoadingPlanRepository _planRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IStorageService _storageService;
+    private readonly IValidator<UploadPlanThumbnailCommand> _validator;
+
+    public UploadPlanThumbnailCommandHandler(
+        ILoadingPlanRepository planRepository,
+        ICurrentUserService currentUserService,
+        IStorageService storageService,
+        IValidator<UploadPlanThumbnailCommand> validator)
+    {
+        _planRepository = planRepository;
+        _currentUserService = currentUserService;
+        _storageService = storageService;
+        _validator = validator;
+    }
+
+    public async Task<Result<string>> Handle(UploadPlanThumbnailCommand request, CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<string>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var companyId = _currentUserService.CompanyId;
+        var plan = await _planRepository.GetByIdAsync(request.PlanId, companyId, cancellationToken);
+        if (plan is null)
+            return Result<string>.Failure(
+                new Error(ErrorType.NotFound, "Plan.NotFound", "Yükleme planı bulunamadı."));
+
+        var commaIndex = request.ImageBase64.IndexOf(',');
+        var base64Data = request.ImageBase64[(commaIndex + 1)..];
+        var imageBytes = Convert.FromBase64String(base64Data);
+
+        var contentType = ExtractContentType(request.ImageBase64);
+        var extension = contentType == "image/png" ? "png" : "jpeg";
+        var objectKey = $"thumbnails/{plan.Id}.{extension}";
+
+        using var stream = new MemoryStream(imageBytes);
+        var url = await _storageService.UploadAsync(objectKey, stream, contentType, cancellationToken);
+
+        plan.SetThumbnailUrl(url);
+        await _planRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<string>.Success(url);
+    }
+
+    private static string ExtractContentType(string dataUrl)
+    {
+        var start = dataUrl.IndexOf(':') + 1;
+        var end = dataUrl.IndexOf(';');
+        if (start > 0 && end > start)
+            return dataUrl[start..end];
+        return "image/png";
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Plans/UploadPlanThumbnail/UploadPlanThumbnailCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/UploadPlanThumbnail/UploadPlanThumbnailCommandValidator.cs
@@ -1,0 +1,32 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Plans.UploadPlanThumbnail;
+
+public sealed class UploadPlanThumbnailCommandValidator : AbstractValidator<UploadPlanThumbnailCommand>
+{
+    public UploadPlanThumbnailCommandValidator()
+    {
+        RuleFor(x => x.PlanId)
+            .NotEmpty().WithErrorCode("Plan.IdRequired");
+
+        RuleFor(x => x.ImageBase64)
+            .NotEmpty().WithErrorCode("Thumbnail.ImageRequired")
+            .Must(BeAValidBase64DataUrl).WithErrorCode("Thumbnail.InvalidFormat")
+                .WithMessage("imageBase64 geçerli bir base64 data URL olmalıdır (data:image/...;base64,...).");
+    }
+
+    private static bool BeAValidBase64DataUrl(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return false;
+        if (!value.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase)) return false;
+        var commaIndex = value.IndexOf(',');
+        if (commaIndex < 0) return false;
+        var base64Part = value[(commaIndex + 1)..];
+        try {
+            Convert.FromBase64String(base64Part);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+}

--- a/apps/backend/CargoPilot.Domain/Entities/LoadingPlan.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/LoadingPlan.cs
@@ -41,6 +41,7 @@ public sealed class LoadingPlan : BaseEntity {
     public void MarkErpPending() => ErpExportStatus = Enums.ErpExportStatus.Pending;
     public void MarkErpSent()    => ErpExportStatus = Enums.ErpExportStatus.Sent;
     public void MarkErpFailed()  => ErpExportStatus = Enums.ErpExportStatus.Failed;
+    public void SetThumbnailUrl(string url) => ReportUrl = url;
 
     public void ApplyOptimizationResult(
         LoadingPlanOptimizationStatus status,

--- a/apps/backend/CargoPilot.Domain/Entities/LoadingPlan.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/LoadingPlan.cs
@@ -21,6 +21,7 @@ public sealed class LoadingPlan : BaseEntity {
     public Guid? CompanyId { get; private set; }
     public Guid? ReportId { get; private set; }
     public string? ReportUrl { get; private set; }
+    public string? ThumbnailUrl { get; private set; }
     public ErpExportStatus? ErpExportStatus { get; private set; }
 #pragma warning restore S1144
 
@@ -41,7 +42,7 @@ public sealed class LoadingPlan : BaseEntity {
     public void MarkErpPending() => ErpExportStatus = Enums.ErpExportStatus.Pending;
     public void MarkErpSent()    => ErpExportStatus = Enums.ErpExportStatus.Sent;
     public void MarkErpFailed()  => ErpExportStatus = Enums.ErpExportStatus.Failed;
-    public void SetThumbnailUrl(string url) => ReportUrl = url;
+    public void SetThumbnailUrl(string url) => ThumbnailUrl = url;
 
     public void ApplyOptimizationResult(
         LoadingPlanOptimizationStatus status,

--- a/apps/backend/CargoPilot.Infrastructure/CargoPilot.Infrastructure.csproj
+++ b/apps/backend/CargoPilot.Infrastructure/CargoPilot.Infrastructure.csproj
@@ -19,6 +19,8 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.25" />
 
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.3.1" />
+
+    <PackageReference Include="Minio" Version="7.0.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.25">
       <PrivateAssets>all</PrivateAssets>

--- a/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
+++ b/apps/backend/CargoPilot.Infrastructure/DependencyInjection.cs
@@ -15,6 +15,7 @@ using Hangfire.SqlServer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Minio;
 
 namespace CargoPilot.Infrastructure;
 
@@ -64,6 +65,23 @@ public static class DependencyInjection {
         services.AddOptions<SubscriptionPlanSettings>()
             .Bind(configuration.GetSection("SubscriptionPlans"))
             .ValidateOnStart();
+
+        services.AddOptions<MinioSettings>()
+            .Bind(configuration.GetSection("Minio"))
+            .Validate(s => !string.IsNullOrWhiteSpace(s.Endpoint), "Minio:Endpoint is required.")
+            .Validate(s => !string.IsNullOrWhiteSpace(s.AccessKey), "Minio:AccessKey is required.")
+            .Validate(s => !string.IsNullOrWhiteSpace(s.SecretKey), "Minio:SecretKey is required.")
+            .ValidateOnStart();
+
+        services.AddMinio(configureClient => {
+            var minioSettings = configuration.GetSection("Minio").Get<MinioSettings>()!;
+            configureClient
+                .WithEndpoint(minioSettings.Endpoint)
+                .WithCredentials(minioSettings.AccessKey, minioSettings.SecretKey)
+                .WithSSL(minioSettings.UseSSL)
+                .Build();
+        });
+        services.AddScoped<IStorageService, MinioStorageService>();
 
         services.AddScoped<ICurrentUserService, AnonymousCurrentUserService>();
         services.AddScoped<IPasswordHasher, BCryptPasswordHasher>();

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260516202341_AddThumbnailUrlToLoadingPlan.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260516202341_AddThumbnailUrlToLoadingPlan.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260516202341_AddThumbnailUrlToLoadingPlan")]
+    partial class AddThumbnailUrlToLoadingPlan
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260516202341_AddThumbnailUrlToLoadingPlan.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260516202341_AddThumbnailUrlToLoadingPlan.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddThumbnailUrlToLoadingPlan : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ThumbnailUrl",
+                table: "LoadingPlans",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ThumbnailUrl",
+                table: "LoadingPlans");
+        }
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
@@ -81,7 +81,7 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
                 p.VehicleId,
                 p.Vehicle.VehicleName,
                 p.CreatedAtUtc,
-                p.ReportUrl))
+                p.ThumbnailUrl))
             .ToListAsync(cancellationToken);
 
         return new PagedResult<PlanSummaryDto>(items, totalCount, page, pageSize);
@@ -273,7 +273,7 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
             CalcBalanceOffset(plan.CenterOfGravityZ, plan.Vehicle.InternalLength),
             plan.CreatedAtUtc,
             plan.ErpExportStatus,
-            plan.ReportUrl,
+            plan.ThumbnailUrl,
             vehicleDto,
             placementDtos,
             unplacedItemDtos,

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs
@@ -80,7 +80,8 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
                 p.UnplacedQuantity,
                 p.VehicleId,
                 p.Vehicle.VehicleName,
-                p.CreatedAtUtc))
+                p.CreatedAtUtc,
+                p.ReportUrl))
             .ToListAsync(cancellationToken);
 
         return new PagedResult<PlanSummaryDto>(items, totalCount, page, pageSize);
@@ -272,6 +273,7 @@ internal sealed class LoadingPlanRepository : ILoadingPlanRepository
             CalcBalanceOffset(plan.CenterOfGravityZ, plan.Vehicle.InternalLength),
             plan.CreatedAtUtc,
             plan.ErpExportStatus,
+            plan.ReportUrl,
             vehicleDto,
             placementDtos,
             unplacedItemDtos,

--- a/apps/backend/CargoPilot.Infrastructure/Services/MinioStorageService.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/MinioStorageService.cs
@@ -1,0 +1,62 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Settings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Minio;
+using Minio.DataModel.Args;
+
+namespace CargoPilot.Infrastructure.Services;
+
+internal sealed partial class MinioStorageService : IStorageService
+{
+    private readonly IMinioClient _client;
+    private readonly string _bucketName;
+    private readonly string _endpoint;
+    private readonly bool _useSSL;
+    private readonly ILogger<MinioStorageService> _logger;
+
+    public MinioStorageService(IMinioClient client, IOptions<MinioSettings> options, ILogger<MinioStorageService> logger)
+    {
+        _client = client;
+        _bucketName = options.Value.BucketName;
+        _endpoint = options.Value.Endpoint;
+        _useSSL = options.Value.UseSSL;
+        _logger = logger;
+    }
+
+    public async Task<string> UploadAsync(
+        string objectKey,
+        Stream content,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureBucketExistsAsync(cancellationToken);
+
+        var putArgs = new PutObjectArgs()
+            .WithBucket(_bucketName)
+            .WithObject(objectKey)
+            .WithStreamData(content)
+            .WithObjectSize(content.Length)
+            .WithContentType(contentType);
+
+        await _client.PutObjectAsync(putArgs, cancellationToken);
+
+        var scheme = _useSSL ? "https" : "http";
+        return $"{scheme}://{_endpoint}/{_bucketName}/{objectKey}";
+    }
+
+    private async Task EnsureBucketExistsAsync(CancellationToken cancellationToken)
+    {
+        var existsArgs = new BucketExistsArgs().WithBucket(_bucketName);
+        var exists = await _client.BucketExistsAsync(existsArgs, cancellationToken);
+        if (!exists)
+        {
+            LogBucketCreating(_bucketName);
+            var makeArgs = new MakeBucketArgs().WithBucket(_bucketName);
+            await _client.MakeBucketAsync(makeArgs, cancellationToken);
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "MinIO bucket '{Bucket}' oluşturuluyor.")]
+    private partial void LogBucketCreating(string bucket);
+}

--- a/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
@@ -10,6 +10,7 @@ using CargoPilot.Application.Features.Plans.Groups.DeleteGroup;
 using CargoPilot.Application.Features.Plans.Groups.UpdateGroup;
 using CargoPilot.Application.Features.Plans.ReOptimizePlan;
 using CargoPilot.Application.Features.Plans.UpdatePlanName;
+using CargoPilot.Application.Features.Plans.UploadPlanThumbnail;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -304,6 +305,29 @@ public sealed class PlansController : BaseController
     }
 
     /// <summary>
+    /// Yükleme planına thumbnail yükler.
+    /// </summary>
+    /// <param name="id">Planın ID'si.</param>
+    /// <param name="request">Base64 formatında görüntü.</param>
+    /// <param name="cancellationToken">İptal token'ı.</param>
+    /// <response code="200">Thumbnail URL döndürüldü.</response>
+    /// <response code="400">Geçersiz görüntü formatı.</response>
+    /// <response code="404">Plan bulunamadı.</response>
+    [HttpPost("{id:guid}/thumbnail")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UploadThumbnail(
+        [FromRoute] Guid id,
+        [FromBody] UploadThumbnailRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new UploadPlanThumbnailCommand(id, request.ImageBase64);
+        var result = await _mediator.Send(command, cancellationToken);
+        return HandleResult(result);
+    }
+
+    /// <summary>
     /// Yükleme planını soft-delete ile siler.
     /// </summary>
     /// <param name="id">Silinecek planın ID'si.</param>
@@ -345,4 +369,7 @@ public sealed record DeleteGroupRequest(
 
 /// <summary>PUT /items/{inputItemId}/group request body.</summary>
 public sealed record AssignItemToGroupRequest(Guid? GroupId);
+
+/// <summary>POST /{id}/thumbnail request body.</summary>
+public sealed record UploadThumbnailRequest(string ImageBase64);
 

--- a/apps/backend/CargoPilot.WebAPI/appsettings.Development.json
+++ b/apps/backend/CargoPilot.WebAPI/appsettings.Development.json
@@ -20,6 +20,12 @@
     "BackendBaseUrl": "http://localhost:8081",
     "TokenExpiryMinutes": 10
   },
+  "Minio": {
+    "Endpoint": "localhost:9000",
+    "AccessKey": "minioadmin",
+    "SecretKey": "minioadmin",
+    "BucketName": "cargo-pilot"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Debug",

--- a/apps/backend/CargoPilot.WebAPI/appsettings.json
+++ b/apps/backend/CargoPilot.WebAPI/appsettings.json
@@ -42,6 +42,12 @@
       "ClientId": ""
     }
   },
+  "Minio": {
+    "Endpoint": "",
+    "AccessKey": "",
+    "SecretKey": "",
+    "BucketName": "cargo-pilot"
+  },
   "SubscriptionPlans": {
     "Baslangic": {
       "MonthlyPrice": 299.00,

--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -22,6 +22,10 @@ services:
       MINIO_BUCKET: ${MINIO_BUCKET}
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+      Minio__Endpoint: minio:9000
+      Minio__AccessKey: ${MINIO_ROOT_USER}
+      Minio__SecretKey: ${MINIO_ROOT_PASSWORD}
+      Minio__BucketName: ${MINIO_BUCKET}
       Seed__DefaultAdminPassword: ${Seed__DefaultAdminPassword}
       Jwt__Secret: ${JWT_SECRET}
       OAuth__Google__ClientId: ${GOOGLE_CLIENT_ID:-}


### PR DESCRIPTION
## Özet

Loading plan için frontend'den gelen PNG/JPEG base64 görselinin MinIO'ya yüklenip URL'inin veritabanında saklanması sağlandı.

## İlgili User Story / Issue


## Değişiklik Tipi

- [x] 🌿 Yeni özellik (feature)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [x] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

- `LoadingPlan` entity'sine `ThumbnailUrl` alanı eklendi; `SetThumbnailUrl` metodu yanlış field'a (`ReportUrl`) yazıyordu, düzeltildi
- `PlanSummaryDto` ve `PlanDetailDto` mapping'leri `ThumbnailUrl` kullanacak şekilde güncellendi
- `AddThumbnailUrlToLoadingPlan` migration'ı eklendi
