### PR TITLE
Konteyner araç tipi için kapı yönü validasyonu eklendi

### DIFF
--- a/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommandValidator.cs
@@ -1,3 +1,4 @@
+using CargoPilot.Domain.Enums;
 using FluentValidation;
 
 namespace CargoPilot.Application.Features.Vehicles.CreateVehicle;
@@ -36,6 +37,11 @@ public sealed class CreateVehicleCommandValidator : AbstractValidator<CreateVehi
 
         RuleFor(x => x.LoadingType)
             .IsInEnum().WithMessage("Geçersiz yükleme tipi.");
+
+        When(x => x.VehicleType == VehicleType.Container, () =>
+            RuleFor(x => x.LoadingType)
+                .NotEqual(LoadingType.Top)
+                .WithMessage("Konteyner için üst yükleme yönü geçerli değildir."));
 
         When(x => x.KingPinDistanceMm.HasValue, () =>
             RuleFor(x => x.KingPinDistanceMm!.Value)

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommandValidator.cs
@@ -36,7 +36,8 @@ public sealed class CreateVehicleCommandValidator : AbstractValidator<CreateVehi
             .GreaterThanOrEqualTo(1).WithMessage("Kat sayısı en az 1 olmalıdır.");
 
         RuleFor(x => x.LoadingType)
-            .IsInEnum().WithMessage("Geçersiz yükleme tipi.");
+            .IsInEnum().WithMessage("Geçersiz yükleme tipi.")
+            .NotEqual(LoadingType.SideBoth).WithMessage("Yan kapı yönü sağ veya sol olarak ayrı belirtilmelidir.");
 
         When(x => x.VehicleType == VehicleType.Container, () =>
             RuleFor(x => x.LoadingType)

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/CreateVehicle/CreateVehicleCommandValidator.cs
@@ -36,8 +36,7 @@ public sealed class CreateVehicleCommandValidator : AbstractValidator<CreateVehi
             .GreaterThanOrEqualTo(1).WithMessage("Kat sayısı en az 1 olmalıdır.");
 
         RuleFor(x => x.LoadingType)
-            .IsInEnum().WithMessage("Geçersiz yükleme tipi.")
-            .NotEqual(LoadingType.SideBoth).WithMessage("Yan kapı yönü sağ veya sol olarak ayrı belirtilmelidir.");
+            .IsInEnum().WithMessage("Geçersiz yükleme tipi.");
 
         When(x => x.VehicleType == VehicleType.Container, () =>
             RuleFor(x => x.LoadingType)

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommandValidator.cs
@@ -1,3 +1,4 @@
+using CargoPilot.Domain.Enums;
 using FluentValidation;
 
 namespace CargoPilot.Application.Features.Vehicles.UpdateVehicle;
@@ -36,6 +37,11 @@ public sealed class UpdateVehicleCommandValidator : AbstractValidator<UpdateVehi
 
         RuleFor(x => x.LoadingType)
             .IsInEnum().WithMessage("Geçersiz yükleme tipi.");
+
+        When(x => x.VehicleType == VehicleType.Container, () =>
+            RuleFor(x => x.LoadingType)
+                .NotEqual(LoadingType.Top)
+                .WithMessage("Konteyner için üst yükleme yönü geçerli değildir."));
 
         When(x => x.KingPinDistanceMm.HasValue, () =>
             RuleFor(x => x.KingPinDistanceMm!.Value)

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommandValidator.cs
@@ -36,7 +36,8 @@ public sealed class UpdateVehicleCommandValidator : AbstractValidator<UpdateVehi
             .GreaterThanOrEqualTo(1).WithMessage("Kat sayısı en az 1 olmalıdır.");
 
         RuleFor(x => x.LoadingType)
-            .IsInEnum().WithMessage("Geçersiz yükleme tipi.");
+            .IsInEnum().WithMessage("Geçersiz yükleme tipi.")
+            .NotEqual(LoadingType.SideBoth).WithMessage("Yan kapı yönü sağ veya sol olarak ayrı belirtilmelidir.");
 
         When(x => x.VehicleType == VehicleType.Container, () =>
             RuleFor(x => x.LoadingType)

--- a/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Vehicles/UpdateVehicle/UpdateVehicleCommandValidator.cs
@@ -36,8 +36,7 @@ public sealed class UpdateVehicleCommandValidator : AbstractValidator<UpdateVehi
             .GreaterThanOrEqualTo(1).WithMessage("Kat sayısı en az 1 olmalıdır.");
 
         RuleFor(x => x.LoadingType)
-            .IsInEnum().WithMessage("Geçersiz yükleme tipi.")
-            .NotEqual(LoadingType.SideBoth).WithMessage("Yan kapı yönü sağ veya sol olarak ayrı belirtilmelidir.");
+            .IsInEnum().WithMessage("Geçersiz yükleme tipi.");
 
         When(x => x.VehicleType == VehicleType.Container, () =>
             RuleFor(x => x.LoadingType)


### PR DESCRIPTION
## Özet
Konteyner araç tipi için `LoadingType.Top` (Üst yükleme) yasağı eklendi.
`CreateVehicleCommandValidator` ve `UpdateVehicleCommandValidator`'a cross-field
FluentValidation kuralı eklendi. Container + Top kombinasyonu → `400 Bad Request` döner.

## İlgili User Story / Issue
KAPI YÖNÜ GÜNCEL

## Değişiklik Tipi
- [x] 🚀 Yeni özellik (feature)

## Test Edildi mi?
- [x] Manuel test yapıldı

## Kontrol Listesi
- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı

## Ek Notlar

