### PR TITLE
feat(3d): render pallet as 14cm base + cargo box on top

### DIFF
--- a/apps/frontend/src/components/shared/BoxWrapper.tsx
+++ b/apps/frontend/src/components/shared/BoxWrapper.tsx
@@ -26,7 +26,11 @@ interface BoxWrapperProps {
 
 // ─── PaletContent ──────────────────────────────────────────────────────────────
 // Tahtalı palet yapısı — center-relative koordinatlarda (origin = bounding box merkezi).
-// Üst deck (6 tahta) + bağlantı blokları (3×3) + alt stringer (3 tahta).
+// Backend toplam yüksekliği (palet + kargo) gönderir.
+// Palet: sabit PALLET_H_CM yüksekliğinde tahtalı yapı (alt kısım).
+// Kargo: kalan yükseklikte düz kutu (üst kısım), ürün rengiyle.
+
+const PALLET_H_CM = 14;
 
 function PaletMat({
   color,
@@ -65,19 +69,23 @@ function PaletContent({
   isSelected: boolean;
   isGhosted: boolean;
 }) {
-  // Yükseklik dağılımı: %20 üst deck, %60 bloklar, %20 alt stringer
-  const deckH = height * 0.2;
-  const blockH = height * 0.6;
+  // Backend toplam yüksekliği gönderir: paletH sabit, cargoH = kalan
+  const paletH = Math.min(PALLET_H_CM, height);
+  const cargoH = Math.max(0, height - paletH);
 
-  // Genişlik: 6 tahta + 5 boşluk, tahta=3x, boşluk=x → 23x=width
+  // Palet geometrisi için oransal hesaplar (paletH üzerinden)
+  const deckH = paletH * 0.2;
+  const blockH = paletH * 0.6;
+
+  // Genişlik: 6 tahta + 5 boşluk → 23x=width
   const xUnit = width / 23;
   const slatW = 3 * xUnit;
 
-  // Derinlik: 3 stringer (ProductPreview3D ile aynı oran: yUnit = depth/3.5)
+  // Derinlik: 3 stringer
   const yUnit = depth / 3.5;
   const crossD = 0.5 * yUnit;
 
-  // 6 üst tahta merkez X (center-relative)
+  // 6 üst tahta merkez X (center-relative, tüm bounding box merkezine göre)
   const slatCentersX = useMemo(() => {
     const unit = width / 23;
     const sw = 3 * unit;
@@ -91,8 +99,15 @@ function PaletContent({
     return Array.from({ length: 3 }, (_, i) => -depth / 2 + i * (cd + unit) + cd / 2);
   }, [depth]);
 
-  const topY = height / 2 - deckH / 2;
-  const btmY = -height / 2 + deckH / 2;
+  // Bounding box merkezi = Y:0. Palet altta, kargo üstte.
+  // Palet alt kenarı: -height/2, üst kenarı: -height/2 + paletH
+  // Kargo alt kenarı: -height/2 + paletH, üst kenarı: +height/2
+  const paletBottomY = -height / 2;
+  const paletCenterY = paletBottomY + paletH / 2;
+  const cargoCenterY = paletBottomY + paletH + cargoH / 2;
+
+  const topDeckY = paletCenterY + paletH / 2 - deckH / 2;
+  const btmDeckY = paletCenterY - paletH / 2 + deckH / 2;
 
   if (isGhosted) {
     return (
@@ -111,16 +126,16 @@ function PaletContent({
 
   return (
     <>
-      {/* Üst deck: 6 tahta, tam derinlikte */}
+      {/* Üst deck: 6 tahta */}
       {slatCentersX.map((bx, i) => (
-        <mesh key={`ts${i}`} position={[bx, topY, 0]}>
+        <mesh key={`ts${i}`} position={[bx, topDeckY, 0]}>
           <boxGeometry args={[slatW, deckH, depth]} />
           <PaletMat color={color} opacity={opacity} isSelected={isSelected} />
         </mesh>
       ))}
-      {/* Alt stringer: 3 tahta, tam genişlikte */}
+      {/* Alt stringer: 3 tahta */}
       {crossCentersZ.map((bz, i) => (
-        <mesh key={`bs${i}`} position={[0, btmY, bz]}>
+        <mesh key={`bs${i}`} position={[0, btmDeckY, bz]}>
           <boxGeometry args={[width, deckH, crossD]} />
           <PaletMat color={color} opacity={opacity} isSelected={isSelected} />
         </mesh>
@@ -128,11 +143,18 @@ function PaletContent({
       {/* Bağlantı blokları: 3×3 ızgara */}
       {crossCentersZ.map((bz, zi) =>
         [slatCentersX[0], slatCentersX[2], slatCentersX[5]].map((bx, xi) => (
-          <mesh key={`bl${zi}${xi}`} position={[bx, 0, bz]}>
+          <mesh key={`bl${zi}${xi}`} position={[bx, paletCenterY, bz]}>
             <boxGeometry args={[slatW, blockH, crossD]} />
             <PaletMat color={color} opacity={opacity} isSelected={isSelected} />
           </mesh>
         )),
+      )}
+      {/* Kargo kutusu: palet üstünde, ürün rengiyle */}
+      {cargoH > 0 && (
+        <mesh position={[0, cargoCenterY, 0]}>
+          <boxGeometry args={[width, cargoH, depth]} />
+          <PaletMat color={color} opacity={opacity} isSelected={isSelected} />
+        </mesh>
       )}
     </>
   );

--- a/apps/frontend/src/features/data-management/components/ProductPreview3D.tsx
+++ b/apps/frontend/src/features/data-management/components/ProductPreview3D.tsx
@@ -147,9 +147,9 @@ function VarilScene({ widthCm, heightCm, color }: ShapeProps) {
 const PALLET_HEIGHT_CM = 14;
 
 function PaletScene({ widthCm, heightCm, depthCm, color }: ShapeProps) {
-  // heightCm = kargo yüksekliği (palet üstündeki ürün); palet her zaman PALLET_HEIGHT_CM sabittir
-  const paletH = PALLET_HEIGHT_CM;
-  const cargoH = Math.max(0, heightCm);
+  // heightCm = kullanıcının girdiği toplam yükseklik; palet sabit 14 cm, kargo = kalan
+  const paletH = Math.min(PALLET_HEIGHT_CM, heightCm);
+  const cargoH = Math.max(0, heightCm - paletH);
   const totalH = paletH + cargoH;
   const maxDim = Math.max(widthCm, totalH, depthCm);
 


### PR DESCRIPTION
BoxWrapper/PaletContent and ProductPreview3D/PaletScene now treat incoming height as total: fixed 14cm pallet structure at the bottom, remaining height rendered as cargo box on top with product color.

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
