### PR TITLE
feat(3d): apply label texture to pallet cargo box (5 faces, no bottom)

### DIFF
--- a/apps/frontend/src/components/shared/BoxWrapper.tsx
+++ b/apps/frontend/src/components/shared/BoxWrapper.tsx
@@ -60,6 +60,7 @@ function PaletContent({
   opacity,
   isSelected,
   isGhosted,
+  labelTexture,
 }: {
   width: number;
   height: number;
@@ -68,6 +69,7 @@ function PaletContent({
   opacity: number;
   isSelected: boolean;
   isGhosted: boolean;
+  labelTexture?: THREE.Texture | null;
 }) {
   // Backend toplam yüksekliği gönderir: paletH sabit, cargoH = kalan
   const paletH = Math.min(PALLET_H_CM, height);
@@ -149,11 +151,38 @@ function PaletContent({
           </mesh>
         )),
       )}
-      {/* Kargo kutusu: palet üstünde, ürün rengiyle */}
+      {/* Kargo kutusu: palet üstünde, taban hariç 5 yüze label */}
       {cargoH > 0 && (
         <mesh position={[0, cargoCenterY, 0]}>
           <boxGeometry args={[width, cargoH, depth]} />
-          <PaletMat color={color} opacity={opacity} isSelected={isSelected} />
+          {labelTexture ? (
+            // BoxGeometry yüz sırası: +X(0), -X(1), +Y(2), -Y(3/taban), +Z(4), -Z(5)
+            // Taban (-Y, index 3) düz renk; diğer 5 yüze texture
+            <>
+              {[0, 1, 2, 3, 4, 5].map((face) =>
+                face === 3 ? (
+                  <meshStandardMaterial
+                    key={face}
+                    attach={`material-${face}`}
+                    color={color}
+                    transparent
+                    opacity={isSelected ? 0.95 : opacity}
+                    emissive={isSelected ? color : '#000000'}
+                    emissiveIntensity={isSelected ? 0.25 : 0}
+                  />
+                ) : (
+                  <meshStandardMaterial
+                    key={face}
+                    attach={`material-${face}`}
+                    map={labelTexture}
+                    color="#ffffff"
+                  />
+                ),
+              )}
+            </>
+          ) : (
+            <PaletMat color={color} opacity={opacity} isSelected={isSelected} />
+          )}
         </mesh>
       )}
     </>
@@ -274,6 +303,7 @@ export function BoxWrapper({
           opacity={opacity}
           isSelected={isSelected}
           isGhosted={isGhosted}
+          labelTexture={labelTexture}
         />
       </group>
     );

--- a/apps/frontend/src/features/planning/components/scene/CargoMeshInstanced.tsx
+++ b/apps/frontend/src/features/planning/components/scene/CargoMeshInstanced.tsx
@@ -334,6 +334,32 @@ function InstancedBoxes() {
     [labelPlaneGeo],
   );
 
+  // Palet kargo kutusu label texture'ları — globalIdx → CanvasTexture
+  const paletLabelTextures = useMemo<Map<number, THREE.CanvasTexture>>(() => {
+    const itemSkuMap = new Map(selectedItems.map(({ item }) => [item.id, item.sku]));
+    const instanceCounter = new Map<string, number>();
+    const map = new Map<number, THREE.CanvasTexture>();
+    loadOrder.forEach((globalIdx, seqIdx) => {
+      const p = placements[globalIdx];
+      if (!p || p.productType !== 'palet') return;
+      const sku = itemSkuMap.get(p.itemId) ?? p.itemId.slice(0, 6);
+      const instanceNo = (instanceCounter.get(p.itemId) ?? 0) + 1;
+      instanceCounter.set(p.itemId, instanceNo);
+      map.set(
+        globalIdx,
+        buildBoxLabel(sku, seqIdx + 1, instanceNo, p.color ?? SCENE.COLORS.NORMAL_STR),
+      );
+    });
+    return map;
+  }, [placements, loadOrder, selectedItems]);
+
+  useEffect(
+    () => () => {
+      paletLabelTextures.forEach((t) => t.dispose());
+    },
+    [paletLabelTextures],
+  );
+
   // setPosition callback — useLoadingAnimation tarafından her frame'de çağrılır
   const setAnimPosition = useCallback((globalIdx: number, x: number, y: number, z: number) => {
     let v = animPositionsRef.current.get(globalIdx);
@@ -874,6 +900,7 @@ function InstancedBoxes() {
             isSelected={isItemSelected}
             isGhosted={ghosted}
             productType={p.productType}
+            labelTexture={ghosted ? null : (paletLabelTextures.get(globalIdx) ?? null)}
             onClick={() => {
               setSelectedItemId(null);
               setSelectedInstanceId(selectedInstanceId === globalIdx ? null : globalIdx);
@@ -962,15 +989,14 @@ function BoxPathBoxes() {
   const isAnimActive = animationMode === 'playing' || animationMode === 'stepped';
 
   // Her placement için yükleme sıra no (1-based) ve aynı itemId içindeki instance no
-  // globalIdx → { seqNo, instanceNo, sku }
+  // globalIdx → { seqNo, instanceNo, sku } — varil hariç tüm tipler dahil
   const labelMap = useMemo(() => {
     const itemSkuMap = new Map(selectedItems.map(({ item }) => [item.id, item.sku]));
     const instanceCounter = new Map<string, number>();
-    // loadOrder sırasına göre seqNo ata — loadOrder fiziksel yükleme sırasıdır
     const result = new Map<number, { seqNo: number; instanceNo: number; sku: string }>();
     loadOrder.forEach((globalIdx, seqIdx) => {
       const p = placements[globalIdx];
-      if (!p) return;
+      if (!p || p.productType === 'varil') return;
       const sku = itemSkuMap.get(p.itemId) ?? p.itemId.slice(0, 6);
       const instanceNo = (instanceCounter.get(p.itemId) ?? 0) + 1;
       instanceCounter.set(p.itemId, instanceNo);
@@ -979,11 +1005,11 @@ function BoxPathBoxes() {
     return result;
   }, [placements, loadOrder, selectedItems]);
 
-  // Label texture cache: globalIdx → CanvasTexture (palet/varil için null)
+  // Label texture cache: globalIdx → CanvasTexture (varil için null, palet dahil)
   const labelTextures = useMemo(() => {
     const map = new Map<number, THREE.Texture>();
     placements.forEach((p, i) => {
-      if (p.productType === 'palet' || p.productType === 'varil') return;
+      if (p.productType === 'varil') return;
       const info = labelMap.get(i);
       if (!info) return;
       const color = p.color ?? SCENE.COLORS.NORMAL_STR;


### PR DESCRIPTION
Each pallet item's cargo box (total height minus 14cm pallet base) now receives the same SKU/seqNo/instanceNo label as koli boxes. Bottom face (-Y) stays plain color; remaining 5 faces get the texture. Textures are built per-pallet via buildBoxLabel and disposed on cleanup.

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
