### PR TITLE
bugfix/logo-upload-enpoint

### DIFF
--- a/apps/backend/CargoPilot.Application/Common/Interfaces/ICompanyRepository.cs
+++ b/apps/backend/CargoPilot.Application/Common/Interfaces/ICompanyRepository.cs
@@ -10,4 +10,6 @@ public interface ICompanyRepository
     Task<IReadOnlyList<Company>> GetExpiringTrialCompaniesAsync(int daysAhead, CancellationToken cancellationToken = default);
 
     Task<IReadOnlyList<Company>> GetExpiredTrialCompaniesAsync(CancellationToken cancellationToken = default);
+
+    Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/apps/backend/CargoPilot.Application/Features/Settings/UploadReportingLogo/UploadReportingLogoCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Settings/UploadReportingLogo/UploadReportingLogoCommand.cs
@@ -1,0 +1,9 @@
+using CargoPilot.Application.Common.Models;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Settings.UploadReportingLogo;
+
+public sealed record UploadReportingLogoCommand(
+    byte[] FileBytes,
+    string ContentType,
+    string FileName) : IRequest<Result<string>>;

--- a/apps/backend/CargoPilot.Application/Features/Settings/UploadReportingLogo/UploadReportingLogoCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Settings/UploadReportingLogo/UploadReportingLogoCommandHandler.cs
@@ -1,0 +1,67 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Application.Common.Interfaces;
+using CargoPilot.Application.Common.Models;
+using FluentValidation;
+using MediatR;
+
+namespace CargoPilot.Application.Features.Settings.UploadReportingLogo;
+
+internal sealed class UploadReportingLogoCommandHandler
+    : IRequestHandler<UploadReportingLogoCommand, Result<string>>
+{
+    private readonly ICompanyRepository _companyRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IStorageService _storageService;
+    private readonly IValidator<UploadReportingLogoCommand> _validator;
+
+    public UploadReportingLogoCommandHandler(
+        ICompanyRepository companyRepository,
+        ICurrentUserService currentUserService,
+        IStorageService storageService,
+        IValidator<UploadReportingLogoCommand> validator)
+    {
+        _companyRepository = companyRepository;
+        _currentUserService = currentUserService;
+        _storageService = storageService;
+        _validator = validator;
+    }
+
+    public async Task<Result<string>> Handle(
+        UploadReportingLogoCommand request,
+        CancellationToken cancellationToken)
+    {
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var failures = validationResult.Errors
+                .Select(e => new ValidationFailure(e.PropertyName, e.ErrorMessage))
+                .ToList();
+            return Result<string>.Failure(
+                new Error(ErrorType.Validation, "Validation.Failed", "Doğrulama hatası.", failures));
+        }
+
+        var companyId = _currentUserService.CompanyId;
+        if (companyId is null)
+            return Result<string>.Failure(
+                new Error(ErrorType.Unauthorized, "Auth.NoCompany", "Şirket bilgisi bulunamadı."));
+
+        var company = await _companyRepository.GetByIdAsync(companyId.Value, cancellationToken);
+        if (company is null)
+            return Result<string>.Failure(
+                new Error(ErrorType.NotFound, "Company.NotFound", "Şirket bulunamadı."));
+
+        var extension = Path.GetExtension(request.FileName).TrimStart('.').ToLowerInvariant();
+        if (string.IsNullOrEmpty(extension))
+            extension = request.ContentType.Split('/').LastOrDefault() ?? "png";
+
+        var objectKey = $"logos/{companyId.Value}.{extension}";
+
+        using var stream = new MemoryStream(request.FileBytes);
+        var url = await _storageService.UploadAsync(objectKey, stream, request.ContentType, cancellationToken);
+
+        company.SetLogoUrl(url);
+        await _companyRepository.SaveChangesAsync(cancellationToken);
+
+        return Result<string>.Success(url);
+    }
+}

--- a/apps/backend/CargoPilot.Application/Features/Settings/UploadReportingLogo/UploadReportingLogoCommandValidator.cs
+++ b/apps/backend/CargoPilot.Application/Features/Settings/UploadReportingLogo/UploadReportingLogoCommandValidator.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+
+namespace CargoPilot.Application.Features.Settings.UploadReportingLogo;
+
+public sealed class UploadReportingLogoCommandValidator
+    : AbstractValidator<UploadReportingLogoCommand>
+{
+    private static readonly string[] AllowedContentTypes = ["image/jpeg", "image/png", "image/webp"];
+    private const int MaxFileSizeBytes = 2 * 1024 * 1024; // 2 MB
+
+    public UploadReportingLogoCommandValidator()
+    {
+        RuleFor(x => x.FileBytes)
+            .NotEmpty().WithErrorCode("Logo.FileRequired")
+            .Must(b => b.Length <= MaxFileSizeBytes)
+                .WithErrorCode("Logo.FileTooLarge")
+                .WithMessage("Logo dosyası 2 MB'dan büyük olamaz.");
+
+        RuleFor(x => x.ContentType)
+            .NotEmpty().WithErrorCode("Logo.ContentTypeRequired")
+            .Must(ct => AllowedContentTypes.Contains(ct.ToLowerInvariant()))
+                .WithErrorCode("Logo.InvalidContentType")
+                .WithMessage("Logo yalnızca JPEG, PNG veya WebP formatında olabilir.");
+    }
+}

--- a/apps/backend/CargoPilot.Domain/Entities/Company.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/Company.cs
@@ -32,4 +32,5 @@ public sealed class Company : BaseEntity {
 
     public void UpdateName(string name) => Name = name.Trim();
     public void SetTrial(DateTime trialEndsAt) => TrialEndsAt = trialEndsAt;
+    public void SetLogoUrl(string url) => LogoUrl = url;
 }

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/CompanyRepository.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Repositories/CompanyRepository.cs
@@ -46,4 +46,7 @@ internal sealed class CompanyRepository : ICompanyRepository
             .Where(c => c.TrialEndsAt != null && c.TrialEndsAt <= now)
             .ToListAsync(cancellationToken);
     }
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken = default)
+        => _dbContext.SaveChangesAsync(cancellationToken);
 }

--- a/apps/backend/CargoPilot.WebAPI/Controllers/SettingsController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/SettingsController.cs
@@ -1,0 +1,37 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Application.Features.Settings.UploadReportingLogo;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace CargoPilot.WebAPI.Controllers;
+
+[Route("api/v1/settings")]
+[Authorize(Policy = "CompanyMember")]
+public sealed class SettingsController : BaseController
+{
+    private readonly IMediator _mediator;
+
+    public SettingsController(IMediator mediator) => _mediator = mediator;
+
+    /// <summary>Raporlama logosunu yükler.</summary>
+    [HttpPost("reporting/logo")]
+    [Consumes("multipart/form-data")]
+    [ProducesResponseType(typeof(Result<string>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> UploadLogo(
+        IFormFile logo,
+        CancellationToken cancellationToken)
+    {
+        if (logo is null || logo.Length == 0)
+            return BadRequest(new { message = "Logo dosyası gereklidir." });
+
+        using var ms = new MemoryStream();
+        await logo.CopyToAsync(ms, cancellationToken);
+
+        var command = new UploadReportingLogoCommand(ms.ToArray(), logo.ContentType, logo.FileName);
+        var result = await _mediator.Send(command, cancellationToken);
+        return HandleResult(result);
+    }
+}


### PR DESCRIPTION
Özet
Raporlama ayarları ekranındaki logo yükleme özelliği çalışmıyordu. POST /api/v1/settings/reporting/logo endpoint'i backend'de mevcut değildi; bu nedenle frontend her zaman "Logo yüklenemedi" hatası gösteriyordu. Bu PR eksik endpoint'i ve gerekli altyapıyı ekler.

İlgili User Story / Issue
<!-- Örnek: US-105, #123 -->
Değişiklik Tipi
 🚀 Yeni özellik (feature)
 🐛 Bug düzeltme (bugfix)
Test Edildi mi?
 Manuel test yapıldı — curl ile multipart/form-data PNG yüklemesi yapıldı, isSuccess: true ve Minio URL'si döndü.
Kontrol Listesi
 Kod standartlarına uygun
 Commit mesajları [commit kurallarına](vscode-webview://0fqe5j111o39ctng830occ9l2q4o9h10unjt04h31j1ieurd5h0r/docs/conventions/COMMITS.md) uygun
 Linter hataları yok
 Self-review yapıldı
 Dokümantasyon güncellendi (gerekiyorsa)
Ek Notlar
Yapılan değişiklikler:

SettingsController — POST /api/v1/settings/reporting/logo endpoint'i eklendi (multipart/form-data, [Authorize(Policy = "CompanyMember")])
UploadReportingLogoCommand + Handler + Validator — MediatR pipeline'ına eklendi; max 2 MB, image/jpeg, image/png, image/webp formatları kabul edilir
Company.SetLogoUrl(string url) — domain metodunu eklendi
ICompanyRepository.SaveChangesAsync — interface ve implementasyona eklendi
