### PR TITLE
Bugfix/increase subscription limits

### DIFF
--- a/apps/backend/CargoPilot.Domain/Subscriptions/SubscriptionLimits.cs
+++ b/apps/backend/CargoPilot.Domain/Subscriptions/SubscriptionLimits.cs
@@ -6,32 +6,32 @@ public static class SubscriptionLimits
 {
     public static int? GetMaxUserCount(SubscriptionType type) => type switch
     {
-        SubscriptionType.Free       => 1,
-        SubscriptionType.Pro        => 10,
+        SubscriptionType.Free       => 1000,
+        SubscriptionType.Pro        => 1000,
         SubscriptionType.Enterprise => null,
         _                           => null
     };
 
     public static int? GetMaxLoadingPlanCount(SubscriptionType type) => type switch
     {
-        SubscriptionType.Free       => 10,
-        SubscriptionType.Pro        => 50,
+        SubscriptionType.Free       => 1000,
+        SubscriptionType.Pro        => 1000,
         SubscriptionType.Enterprise => null,
         _                           => null
     };
 
     public static int? GetMaxVehicleCount(SubscriptionType type) => type switch
     {
-        SubscriptionType.Free       => 5,
-        SubscriptionType.Pro        => 20,
+        SubscriptionType.Free       => 1000,
+        SubscriptionType.Pro        => 1000,
         SubscriptionType.Enterprise => null,
         _                           => null
     };
 
     public static int? GetMaxItemCount(SubscriptionType type) => type switch
     {
-        SubscriptionType.Free       => 100,
-        SubscriptionType.Pro        => 500,
+        SubscriptionType.Free       => 1000,
+        SubscriptionType.Pro        => 1000,
         SubscriptionType.Enterprise => null,
         _                           => null
     };


### PR DESCRIPTION
Özet
Free ve Pro abonelik planlarındaki tüm limitler (kullanıcı, araç, yükleme planı, ürün) test sürecinde limit kaynaklı 422 hatalarının önüne geçmek amacıyla geçici olarak 1000'e yükseltildi. Enterprise limitleri değiştirilmedi.

İlgili User Story / Issue
N/A

Değişiklik Tipi
 🚀 Yeni özellik (feature)
 🐛 Bug düzeltme (bugfix)
Test Edildi mi?
 Manuel test yapıldı
Kontrol Listesi
 Kod standartlarına uygun
 Commit mesajları [commit kurallarına](vscode-webview://0ilcntv8sbslvu68sa0t9b5eh1qit4kj0lja7aua65mnard4cqj3/docs/conventions/COMMITS.md) uygun
 Linter hataları yok
 Self-review yapıldı
 Dokümantasyon güncellendi (gerekiyorsa)
Ek Notlar
Bu değişiklik geçicidir. Test süreci tamamlandıktan sonra limitler orijinal değerlerine (Free: 5 araç / 10 plan / 100 ürün / 1 kullanıcı, Pro: 20 araç / 50 plan / 500 ürün / 10 kullanıcı) döndürülmelidir.