### PR TITLE
fix(3d): yükleme animasyonu kapı girişi ve sıra düzeltildi

### DIFF
--- a/apps/frontend/src/features/planning/components/scene/CargoMeshInstanced.tsx
+++ b/apps/frontend/src/features/planning/components/scene/CargoMeshInstanced.tsx
@@ -572,7 +572,14 @@ function InstancedBoxes() {
     }
   }, [placements, boxIndices, cylIndices, loadOrder, atlas, writeLabelPlaneMatrices]);
 
-  useLoadingAnimation(placements, loadOrder, setAnimPosition, onFrameUpdate, vehicle?.length);
+  useLoadingAnimation(
+    placements,
+    loadOrder,
+    setAnimPosition,
+    onFrameUpdate,
+    vehicle?.length,
+    vehicle?.width,
+  );
 
   // Animasyon idle'a döndüğünde pozisyon cache'ini temizle
   useEffect(() => {
@@ -1044,7 +1051,14 @@ function BoxPathBoxes() {
     // setAnimPosition zaten state update tetikliyor — ek forceUpdate gerekmez
   }, []);
 
-  useLoadingAnimation(placements, loadOrder, setAnimPosition, onFrameUpdate, vehicle?.length);
+  useLoadingAnimation(
+    placements,
+    loadOrder,
+    setAnimPosition,
+    onFrameUpdate,
+    vehicle?.length,
+    vehicle?.width,
+  );
 
   return (
     <>

--- a/apps/frontend/src/features/planning/components/scene/useLoadingAnimation.ts
+++ b/apps/frontend/src/features/planning/components/scene/useLoadingAnimation.ts
@@ -59,8 +59,10 @@ export function useLoadingAnimation(
   loadOrder: number[],
   setPosition: (globalIdx: number, x: number, y: number, z: number) => void,
   onFrameUpdate: () => void,
-  /** Araç Z derinliği (cm) — kapı ofseti hesabı için */
+  /** Araç Z derinliği (cm) — kapı Z konumu için */
   vehicleDepth?: number,
+  /** Araç X genişliği (cm) — kapı merkezi için */
+  vehicleWidth?: number,
 ) {
   const animationMode = useSceneStore((s) => s.animationMode);
   const animationStep = useSceneStore((s) => s.animationStep);
@@ -78,8 +80,11 @@ export function useLoadingAnimation(
 
     const { staggerMs, flightMs } = computeScheduleParams(loadOrder.length);
 
-    // Kapı: aracın Z=0 yüzeyi → başlangıç Z'si daha negatif (dışarıda)
-    const doorZ = -(vehicleDepth ?? 0) / 2 - SCENE.ANIM_DOOR_OFFSET_CM;
+    // Kapı Z=length yüzünde (ContainerMesh ile aynı: position={[0,0,length]})
+    // Tüm kutular kapı merkezinden (width/2, 0, length+OFFSET) hedeflerine uçar
+    const doorZ = (vehicleDepth ?? 0) + SCENE.ANIM_DOOR_OFFSET_CM;
+    const doorX = (vehicleWidth ?? 0) / 2;
+    const doorY = 0;
 
     const schedule = new Map<number, AnimEntry>();
     loadOrder.forEach((globalIdx, seqIdx) => {
@@ -94,14 +99,14 @@ export function useLoadingAnimation(
         startAt: seqIdx * staggerMs,
         flightMs,
         target: new THREE.Vector3(cx, cy, cz),
-        // X ve Y hedefle aynı — sadece Z ekseninde kapıdan içeri kayma efekti
-        from: new THREE.Vector3(cx, cy, doorZ),
+        // Tüm kutular kapı önünden (0,0,0 köşe referansıyla) hedeflerine gider
+        from: new THREE.Vector3(doorX, doorY, doorZ),
       });
     });
 
     scheduleRef.current = schedule;
     startTimeRef.current = null;
-  }, [animationMode, loadOrder, placements, vehicleDepth]);
+  }, [animationMode, loadOrder, placements, vehicleDepth, vehicleWidth]);
 
   useFrame(() => {
     if (animationMode === 'stepped') {

--- a/apps/frontend/src/lib/utils/loadOrder.ts
+++ b/apps/frontend/src/lib/utils/loadOrder.ts
@@ -1,8 +1,9 @@
 import type { PlacementWithDimensions } from '@/lib/types/loadingPlan';
 
 /**
- * Yükleme sırası: arka duvardan kapıya (Z büyük→küçük), alt kattan üst kata (Y küçük→büyük),
+ * Yükleme sırası: arka duvardan kapıya (Z küçük→büyük), alt kattan üst kata (Y küçük→büyük),
  * soldan sağa (X küçük→büyük).
+ * Z=0 arka duvar, Z=length kapı — içeridekiler önce yüklenir.
  *
  * Backend bu sırayı hesaplayıp gönderirse bu fonksiyon atlanabilir.
  * Şimdilik client-side sort ile simüle edilmektedir.
@@ -14,7 +15,7 @@ export function buildLoadOrder(placements: PlacementWithDimensions[]): number[] 
   return placements
     .map((p, i) => ({ p, i }))
     .sort((a, b) => {
-      if (b.p.positionZ !== a.p.positionZ) return b.p.positionZ - a.p.positionZ;
+      if (a.p.positionZ !== b.p.positionZ) return a.p.positionZ - b.p.positionZ;
       if (a.p.positionY !== b.p.positionY) return a.p.positionY - b.p.positionY;
       return a.p.positionX - b.p.positionX;
     })


### PR DESCRIPTION
- Kutular kapı önünden (Z=length+offset, width/2) başlayıp hedeflerine gider
- Yükleme sırası düzeltildi: Z küçük→büyük (arka duvar önce, kapı son)
- useLoadingAnimation vehicleWidth parametresi eklendi

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
