### PR TITLE
fix(planning): yeniden optimizasyonda çıkarılan ürünler API'ye gönder…

### DIFF
--- a/apps/frontend/src/pages/NewPlanPage.tsx
+++ b/apps/frontend/src/pages/NewPlanPage.tsx
@@ -180,13 +180,22 @@ export function NewPlanPage() {
 
   const handleReoptimize = useCallback(async () => {
     if (!fromPlanId) return;
-    const { selectedVehicle: vehicle, selectedItems: items, criteria } = usePlanStore.getState();
+    const {
+      selectedVehicle: vehicle,
+      selectedItems: items,
+      placements,
+      criteria,
+    } = usePlanStore.getState();
     if (!vehicle || items.length === 0) return;
+
+    const placedIds = new Set(placements.map((p) => p.itemId));
+    const itemsToSend = items.filter((si) => placedIds.has(si.item.id));
+    if (itemsToSend.length === 0) return;
 
     await reoptimizePlan({
       id: fromPlanId,
       vehicleId: vehicle.id,
-      items: items.map((si) => ({ itemId: si.item.id, quantity: si.quantity })),
+      items: itemsToSend.map((si) => ({ itemId: si.item.id, quantity: si.quantity })),
       optimizationCriteria: criteria,
     });
     pendingSnapshotPlanId.current = fromPlanId;


### PR DESCRIPTION
…ilmiyordu

handleReoptimize, selectedItems yerine placements üzerinden filtre uygulayarak çıkarılan ürünleri payload dışında bırakır — handleConfirmCreate ile aynı pattern.

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
