### PR TITLE
nginx: MinIO /media/ proxy eklendi

### DIFF
--- a/infra/nginx/cargopilot-test.conf
+++ b/infra/nginx/cargopilot-test.conf
@@ -70,6 +70,25 @@ server {
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
 
+    # ── MinIO Media (/media/* → minio:9002/cargo-pilot-test/) ──
+    location /media/ {
+        proxy_pass         http://127.0.0.1:9002/cargo-pilot-test/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              127.0.0.1:9002;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_buffering    off;
+
+        # Resim/dosya cache — tarayıcıda 7 gün tut
+        add_header Cache-Control "public, max-age=604800, immutable";
+        add_header X-Content-Type-Options nosniff always;
+
+        # Büyük dosyalar için timeout artır
+        proxy_read_timeout 120s;
+        client_max_body_size 50m;
+    }
+
     # ── Frontend (catch-all → frontend:3001) ────────────────
     location / {
         proxy_pass         http://127.0.0.1:3001;


### PR DESCRIPTION
## Özet

MinIO'daki dosyalar artık domain üzerinden herkese açık olarak erişilebilir.

## Dev Doğrulaması

PR #770 dev'e merge edildi ✅

## URL Yapısı

| Eski | Yeni (public) |
|------|---------------|
| `http://104.247.163.42:9003/api/v1/buckets/...` | `https://cargopilot.divizyon.org/media/thumbnails/<uuid>.png` |

## Notlar

- Sunucuya uygulandı ve test edildi ✅
- `.env.test`'te `MINIO_PUBLIC_ENDPOINT=cargopilot.divizyon.org/media` güncellenmeli