### PR TITLE
ci: test PR için dev PR zorunluluğu eklendi

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -84,6 +84,31 @@ jobs:
 
           echo "OK: Tüm feature commit'leri origin/dev'de mevcut."
 
+      - name: Bu branch'ten dev'e merge edilmiş PR zorunlu
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          HEAD="${{ github.head_ref }}"
+
+          # GitHub API: bu branch'ten dev'e merge edilmiş PR var mı?
+          MERGED_PR=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --base dev \
+            --head "${HEAD}" \
+            --state merged \
+            --json number,mergedAt \
+            --jq '.[0].number // empty')
+
+          if [ -z "$MERGED_PR" ]; then
+            echo "::error::Branch '${HEAD}' için dev'e merge edilmiş bir PR bulunamadı."
+            echo "::error::Kural: test'e PR açmadan önce aynı branch'ten dev'e PR açılmalı ve merge edilmelidir."
+            echo "::error::Adım 1: gh pr create --base dev --head ${HEAD}"
+            echo "::error::Adım 2: PR onaylanıp merge edildikten sonra test'e PR açın."
+            exit 1
+          fi
+
+          echo "OK: Branch '${HEAD}' için dev'e merge edilmiş PR #${MERGED_PR} bulundu."
+
   # ─── Migration kontrolü: model değişmiş ama migration oluşturulmamışsa fail ──
   # Sadece test'e giden PR'larda veya test'e push'ta çalışır (feature push'larda gereksiz)
   migration-check:


### PR DESCRIPTION
## Summary

- `enforce-test-base` job'una yeni adım eklendi: test'e PR açılmadan önce aynı branch'ten dev'e merge edilmiş PR zorunlu
- `gh pr list --base dev --head <branch> --state merged` ile kontrol yapılır
- Merge edilmiş dev PR bulunamazsa CI hata verir ve açıklayıcı mesaj gösterir
- BRANCHING.md'ye iki PR kuralı için danger hint eklendi

## Test plan

- [ ] feature branch'ten dev'e PR açmadan test'e PR aç → CI fail olmalı
- [ ] dev'e merge ettikten sonra test'e PR aç → CI pass olmalı

🤖 Generated with [Claude Code](https://claude.com/claude-code)