### PR TITLE
infra: MinIO /media/ proxy ve MINIO_PUBLIC_ENDPOINT belgelendi

### DIFF
--- a/docs/devops/server-access.md
+++ b/docs/devops/server-access.md
@@ -109,6 +109,25 @@ fail2ban-client set sshd unbanip <IP>
 
 ---
 
+## Nginx Reverse Proxy
+
+Config: `/etc/nginx/sites-available/cargopilot`
+
+| Path | Yönlendirme | Açıklama |
+|------|-------------|----------|
+| `/api/` | `localhost:8081` | Backend API |
+| `/health` | `localhost:8081` | Backend health check |
+| `/media/` | `localhost:9002/cargo-pilot-test/` | MinIO dosyaları — public erişim |
+| `/` | `localhost:3001` | Frontend (catch-all) |
+
+{% hint style="info" %}
+`/media/` path'i MinIO S3 API (port 9002) üzerine reverse proxy yapılmıştır. Bucket policy public olduğundan authentication gerekmez. Dosyalar `https://cargopilot.divizyon.org/media/<path>` formatında erişilebilir.
+
+MinIO Console (port 9003) domain üzerinden değil, doğrudan `http://104.247.163.42:9003` adresinden erişilir.
+{% endhint %}
+
+---
+
 ## Ağ Yapısı
 
 ```
@@ -119,6 +138,11 @@ fail2ban-client set sshd unbanip <IP>
     │
     ├── UFW (deny incoming by default)
     │       └── İzin verilen portlar → Servislere yönlendirme
+    │
+    ├── Nginx → cargopilot.divizyon.org (443/80)
+    │       ├── /api/    → backend:8081
+    │       ├── /media/  → minio:9002/cargo-pilot-test/
+    │       └── /        → frontend:3001
     │
     ├── Docker bridge ağları
     │       ├── cargo-pilot-prod-network   (prod stack)

--- a/docs/setup/local-setup.md
+++ b/docs/setup/local-setup.md
@@ -124,7 +124,19 @@ Seed veriler yalnızca geliştirme ve test içindir. Production'da kontrollü ku
 | Frontend | `http://localhost:3001` |
 | Backend API | `http://localhost:8081` |
 | MinIO Console | `http://localhost:9003` |
+| MinIO S3 API | `http://localhost:9002` |
 | MSSQL | `localhost:1434` |
+
+{% hint style="info" %}
+`MINIO_PUBLIC_ENDPOINT` env değişkeni ortama göre farklı ayarlanır:
+
+| Ortam | Değer |
+|-------|-------|
+| Local | `http://localhost:9002` |
+| Test sunucu | `https://cargopilot.divizyon.org/media` |
+
+Sunucuda nginx `/media/` path'i MinIO S3 API'ye (port 9002) reverse proxy yapılmıştır.
+{% endhint %}
 
 ---
 

--- a/infra/env/.env.test.example
+++ b/infra/env/.env.test.example
@@ -47,8 +47,8 @@ MINIO_ROOT_USER=<CHANGE_ME_TEST_USER>
 MINIO_ROOT_PASSWORD=<CHANGE_ME_TEST_PASSWORD>
 MINIO_BUCKET=cargo-pilot-test
 # MinIO'nun tarayıcıdan erişilebilir public adresi — logo görselleri bu URL üzerinden yüklenir
-# Local:  localhost:9002
-# Sunucu: <sunucu-ip>:9002  (port 9002 dışarıya açık olmalı)
+# Local:      http://localhost:9002
+# Sunucu:     https://cargopilot.divizyon.org/media  (nginx /media/ → MinIO 9002)
 MINIO_PUBLIC_ENDPOINT=
 
 # ─── JWT ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- `.env.test.example`: `MINIO_PUBLIC_ENDPOINT` açıklaması local/sunucu farkını yansıtacak şekilde güncellendi
- `docs/devops/server-access.md`: nginx reverse proxy tablosu ve ağ şeması güncellendi (`/media/` → MinIO 9002)
- `docs/setup/local-setup.md`: `MINIO_PUBLIC_ENDPOINT` local vs sunucu değeri tablosu eklendi

## Test plan

- [ ] Dokümanlarda nginx `/media/` proxy açıklaması doğru görünüyor mu?
- [ ] `MINIO_PUBLIC_ENDPOINT` local/sunucu farkı anlaşılır mı?

🤖 Generated with [Claude Code](https://claude.com/claude-code)