### PR TITLE
fix(vehicle): araç kapı yönü mapping ve konteyner üst kapı desteği

### DIFF
--- a/apps/frontend/src/features/data-management/components/VehicleDoorDirectionField.tsx
+++ b/apps/frontend/src/features/data-management/components/VehicleDoorDirectionField.tsx
@@ -12,11 +12,11 @@ interface VehicleDoorDirectionFieldProps {
   hideHeading?: boolean;
 }
 
-const KONTEYNER_DIRECTIONS = [DoorDirection.Rear, DoorDirection.Side] as const;
+const KONTEYNER_DIRECTIONS = [DoorDirection.Rear, DoorDirection.Side, DoorDirection.Top] as const;
 const OTHER_DIRECTIONS = [DoorDirection.Rear, DoorDirection.Side, DoorDirection.Top] as const;
 
-function getDirectionLabel(dir: string, isKonteyner: boolean): string {
-  if (dir === DoorDirection.Rear) return isKonteyner ? 'Ön' : 'Arka';
+function getDirectionLabel(dir: string): string {
+  if (dir === DoorDirection.Rear) return 'Arka';
   if (dir === DoorDirection.Side) return 'Yan';
   return 'Üst';
 }
@@ -45,10 +45,10 @@ export function VehicleDoorDirectionField({ form, vehicleType }: VehicleDoorDire
               <ToggleGroupItem
                 key={dir}
                 value={dir}
-                aria-label={getDirectionLabel(dir, isKonteyner)}
+                aria-label={getDirectionLabel(dir)}
                 className="h-12 flex-1 flex-row gap-2.5 rounded-md px-4 text-sm font-medium text-muted-foreground data-[state=on]:border-primary data-[state=on]:bg-primary/10 data-[state=on]:text-primary"
               >
-                {getDirectionLabel(dir, isKonteyner)}
+                {getDirectionLabel(dir)}
               </ToggleGroupItem>
             ))}
           </ToggleGroup>

--- a/apps/frontend/src/features/data-management/components/VehicleForm.tsx
+++ b/apps/frontend/src/features/data-management/components/VehicleForm.tsx
@@ -94,7 +94,7 @@ export function VehicleForm({
                   form.setValue('plate', '');
                   form.clearErrors('plate');
                   const dir = form.getValues('doorDirection');
-                  if (dir === 'top' || dir === 'rearAndSide') {
+                  if (dir === 'rearAndSide') {
                     form.setValue('doorDirection', 'rear');
                   }
                 } else {

--- a/apps/frontend/src/lib/api/vehicleMappers.ts
+++ b/apps/frontend/src/lib/api/vehicleMappers.ts
@@ -27,15 +27,16 @@ export const VEHICLE_TYPE_FROM_INT: Record<number, VehicleType> = {
 };
 
 // loadingType int → { direction, doorSide }
+// Backend: Rear=0, SideRight=1, SideLeft=2, SideBoth=3, Top=4
 export const LOADING_TYPE_FROM_INT: Record<
   number,
   { direction: DoorDirection; doorSide?: 'right' | 'left' }
 > = {
-  0: { direction: DoorDirection.Front },
-  1: { direction: DoorDirection.Front },
-  2: { direction: DoorDirection.Front },
-  3: { direction: DoorDirection.Front },
-  4: { direction: DoorDirection.Front },
+  0: { direction: DoorDirection.Rear },
+  1: { direction: DoorDirection.Side, doorSide: 'right' },
+  2: { direction: DoorDirection.Side, doorSide: 'left' },
+  3: { direction: DoorDirection.RearAndSide },
+  4: { direction: DoorDirection.Top },
 };
 
 // ─── Backend response schema ──────────────────────────────────────────────────


### PR DESCRIPTION
- LOADING_TYPE_FROM_INT backend enum değerleriyle (Rear/Side/Top) doğru eşleştirildi
- Konteyner araçlara Top seçeneği eklendi
- getDirectionLabel'dan konteyner-özel 'Ön' etiketi kaldırıldı
- VehicleForm'da araç tipi değişiminde yalnızca rearAndSide sıfırlanıyor

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
