### PR TITLE
refresh 401 hatası alındığında oturum sonlandirma eklendi

### DIFF
--- a/apps/frontend/src/lib/hooks/useSessionTimeout.ts
+++ b/apps/frontend/src/lib/hooks/useSessionTimeout.ts
@@ -78,11 +78,14 @@ export function useSessionTimeout() {
         { baseURL: API_BASE_URL, withCredentials: true },
       );
       setAccessToken(data.data.accessToken);
+      updateActivity();
+      setShowWarning(false);
     } catch {
-      // Token yenileme başarısız olsa bile zamanlayıcıyı sıfırla
+      clearAllTimers();
+      clearAuth();
+      sessionStorage.setItem('logout_reason', 'token_expired');
+      window.location.href = '/auth/login';
     }
-    updateActivity();
-    setShowWarning(false);
   }
 
   return { showWarning, countdown, extendSession };


### PR DESCRIPTION
extendSession() icinde refresh basarisiz olunca kullanici login sayfasina yonlendirilmiyor, bozuk oturum devam ediyordu. updateActivity ve setShowWarning try bloguna tasinip, catch'e clearAuth + redirect eklendi.

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
