### PR TITLE
Feature/contamination ignore contamination feature

### DIFF
--- a/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommand.cs
@@ -10,7 +10,8 @@ public sealed record CreatePlanCommand(
     IReadOnlyList<CreatePlanItemRequest> Items,
     LoadingPlanOptimizationCriteria OptimizationCriteria = LoadingPlanOptimizationCriteria.VolumeFirst,
     IReadOnlyList<CreatePlanGroupDefinition>? Groups = null,
-    bool ClusterGroups = true)
+    bool ClusterGroups = true,
+    bool AllowContamination = false)
     : IRequest<Result<Guid>>;
 
 public sealed record CreatePlanGroupDefinition(

--- a/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandHandler.cs
@@ -146,7 +146,9 @@ public sealed class CreatePlanCommandHandler : IRequestHandler<CreatePlanCommand
 
         var optimizationInput = BuildInput(vehicle, activeItems, itemMap, combinedGroupMap, request.OptimizationCriteria, request.ClusterGroups);
 
-        var contamination = ContaminationFilter.Filter(optimizationInput.Items);
+        var contamination = request.AllowContamination
+            ? new ContaminationFilter.Result(optimizationInput.Items, [])
+            : ContaminationFilter.Filter(optimizationInput.Items);
         var finalInput = contamination.Contaminated.Count > 0
             ? optimizationInput with { Items = contamination.Passed }
             : optimizationInput;

--- a/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/CreatePlan/CreatePlanCommandHandler.cs
@@ -149,9 +149,14 @@ public sealed class CreatePlanCommandHandler : IRequestHandler<CreatePlanCommand
         var contamination = request.AllowContamination
             ? new ContaminationFilter.Result(optimizationInput.Items, [])
             : ContaminationFilter.Filter(optimizationInput.Items);
-        var finalInput = contamination.Contaminated.Count > 0
-            ? optimizationInput with { Items = contamination.Passed }
-            : optimizationInput;
+
+        var itemsForEngine = request.AllowContamination
+            ? optimizationInput.Items
+                .Select(i => i with { IncompatibleGroups = null })
+                .ToList()
+            : contamination.Passed;
+
+        var finalInput = optimizationInput with { Items = itemsForEngine };
 
         var engineResult = _optimizationEngine.Run(finalInput);
         var result = contamination.Contaminated.Count > 0

--- a/apps/backend/CargoPilot.Application/Features/Plans/ReOptimizePlan/ReOptimizePlanCommand.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/ReOptimizePlan/ReOptimizePlanCommand.cs
@@ -10,7 +10,8 @@ public sealed record ReOptimizePlanCommand(
     IReadOnlyList<ReOptimizePlanItemRequest> Items,
     LoadingPlanOptimizationCriteria OptimizationCriteria = LoadingPlanOptimizationCriteria.VolumeFirst,
     IReadOnlyList<ReOptimizePlanGroupDefinition>? Groups = null,
-    bool ClusterGroups = true)
+    bool ClusterGroups = true,
+    bool AllowContamination = false)
     : IRequest<Result<Guid>>;
 
 public sealed record ReOptimizePlanItemRequest(Guid ItemId, int Quantity, Guid? GroupId = null);

--- a/apps/backend/CargoPilot.Application/Features/Plans/ReOptimizePlan/ReOptimizePlanCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/ReOptimizePlan/ReOptimizePlanCommandHandler.cs
@@ -101,9 +101,14 @@ public sealed class ReOptimizePlanCommandHandler : IRequestHandler<ReOptimizePla
         var contamination = request.AllowContamination
             ? new ContaminationFilter.Result(optimizationInput.Items, [])
             : ContaminationFilter.Filter(optimizationInput.Items);
-        var finalInput = contamination.Contaminated.Count > 0
-            ? optimizationInput with { Items = contamination.Passed }
-            : optimizationInput;
+
+        var itemsForEngine = request.AllowContamination
+            ? optimizationInput.Items
+                .Select(i => i with { IncompatibleGroups = null })
+                .ToList()
+            : contamination.Passed;
+
+        var finalInput = optimizationInput with { Items = itemsForEngine };
 
         var engineResult = _optimizationEngine.Run(finalInput);
         var result = contamination.Contaminated.Count > 0

--- a/apps/backend/CargoPilot.Application/Features/Plans/ReOptimizePlan/ReOptimizePlanCommandHandler.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/ReOptimizePlan/ReOptimizePlanCommandHandler.cs
@@ -98,7 +98,9 @@ public sealed class ReOptimizePlanCommandHandler : IRequestHandler<ReOptimizePla
 
         var optimizationInput = BuildInput(vehicle, request.Items, itemMap, inlineGroupMap, request.OptimizationCriteria, request.ClusterGroups);
 
-        var contamination = ContaminationFilter.Filter(optimizationInput.Items);
+        var contamination = request.AllowContamination
+            ? new ContaminationFilter.Result(optimizationInput.Items, [])
+            : ContaminationFilter.Filter(optimizationInput.Items);
         var finalInput = contamination.Contaminated.Count > 0
             ? optimizationInput with { Items = contamination.Passed }
             : optimizationInput;

--- a/apps/backend/CargoPilot.Application/Features/Plans/ReOptimizePlan/ReOptimizePlanRequest.cs
+++ b/apps/backend/CargoPilot.Application/Features/Plans/ReOptimizePlan/ReOptimizePlanRequest.cs
@@ -7,7 +7,8 @@ public sealed record ReOptimizePlanRequest(
     IReadOnlyList<ReOptimizePlanItemRequest> Items,
     LoadingPlanOptimizationCriteria OptimizationCriteria = LoadingPlanOptimizationCriteria.VolumeFirst,
     IReadOnlyList<ReOptimizePlanGroupDefinition>? Groups = null,
-    bool ClusterGroups = true);
+    bool ClusterGroups = true,
+    bool AllowContamination = false);
 
 public sealed record ReOptimizePlanGroupDefinition(
     Guid ClientGroupId,

--- a/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
+++ b/apps/backend/CargoPilot.WebAPI/Controllers/PlansController.cs
@@ -128,7 +128,7 @@ public sealed class PlansController : BaseController
         [FromBody] ReOptimizePlanRequest request,
         CancellationToken cancellationToken = default)
     {
-        var command = new ReOptimizePlanCommand(id, request.VehicleId, request.Items, request.OptimizationCriteria, request.Groups, request.ClusterGroups);
+        var command = new ReOptimizePlanCommand(id, request.VehicleId, request.Items, request.OptimizationCriteria, request.Groups, request.ClusterGroups, request.AllowContamination);
         var result = await _mediator.Send(command, cancellationToken);
         return HandleResult(result);
     }


### PR DESCRIPTION
Başlık:
  feat: kontaminasyonu reddedip devam etme (AllowContamination) backend desteği eklendi

  Açıklama:
  ## Özet

  Backendde kontaminasyonu reddedip optimizasyona devam etme özelliği yoktu.
  `AllowContamination` bayrağı `CreatePlanCommand` ve `ReOptimizePlanCommand`'a eklendi.

  `AllowContamination = true` gönderildiğinde:
  - `ContaminationFilter` bypass edilir, tüm ürünler engine'e gönderilir
  - `IncompatibleGroups` alanı temizlenerek çakışma kontrolü devre dışı bırakılır

  ## Değişiklik Tipi

  - [x] 🚀 Yeni özellik (feature)

  ## Test Edildi mi?

  - [x] Manuel test yapıldı

  ## Kontrol Listesi

  - [x] Kod standartlarına uygun
  - [x] Commit mesajları commit kurallarına uygun
  - [x] Linter hataları yok
  - [x] Self-review yapıldı
  - [ ] Dokümantasyon güncellendi (gerekiyorsa)
