### PR TITLE
Feature/3d selection dim cog anim

### DIFF
--- a/apps/frontend/src/components/shared/BoxWrapper.tsx
+++ b/apps/frontend/src/components/shared/BoxWrapper.tsx
@@ -19,6 +19,7 @@ interface BoxWrapperProps {
   isSelected?: boolean;
   isHidden?: boolean;
   isGhosted?: boolean;
+  isDimmed?: boolean;
   productType?: ProductType;
   /** +Z yüzüne (kapıya bakan) uygulanacak etiket texture'ı */
   labelTexture?: THREE.Texture | null;
@@ -37,18 +38,20 @@ function PaletMat({
   color,
   opacity,
   isSelected,
+  isDimmed,
 }: {
   color: string;
   opacity: number;
   isSelected: boolean;
+  isDimmed: boolean;
 }) {
   return (
     <meshStandardMaterial
       color={color}
       transparent
-      opacity={isSelected ? 0.95 : opacity}
-      emissive={isSelected ? color : '#000000'}
-      emissiveIntensity={isSelected ? 0.25 : 0}
+      opacity={isDimmed ? 0.12 : isSelected ? 0.95 : opacity}
+      emissive={isSelected && !isDimmed ? color : '#000000'}
+      emissiveIntensity={isSelected && !isDimmed ? 0.25 : 0}
     />
   );
 }
@@ -61,6 +64,7 @@ function PaletContent({
   opacity,
   isSelected,
   isGhosted,
+  isDimmed,
   labelTexture,
 }: {
   width: number;
@@ -70,6 +74,7 @@ function PaletContent({
   opacity: number;
   isSelected: boolean;
   isGhosted: boolean;
+  isDimmed: boolean;
   labelTexture?: THREE.Texture | null;
 }) {
   // Backend toplam yüksekliği gönderir: paletH sabit, cargoH = kalan
@@ -133,14 +138,24 @@ function PaletContent({
       {slatCentersX.map((bx, i) => (
         <mesh key={`ts${i}`} position={[bx, topDeckY, 0]}>
           <boxGeometry args={[slatW, deckH, depth]} />
-          <PaletMat color={PALLET_WOOD_COLOR} opacity={opacity} isSelected={isSelected} />
+          <PaletMat
+            color={PALLET_WOOD_COLOR}
+            opacity={opacity}
+            isSelected={isSelected}
+            isDimmed={isDimmed}
+          />
         </mesh>
       ))}
       {/* Alt stringer: 3 tahta */}
       {crossCentersZ.map((bz, i) => (
         <mesh key={`bs${i}`} position={[0, btmDeckY, bz]}>
           <boxGeometry args={[width, deckH, crossD]} />
-          <PaletMat color={PALLET_WOOD_COLOR} opacity={opacity} isSelected={isSelected} />
+          <PaletMat
+            color={PALLET_WOOD_COLOR}
+            opacity={opacity}
+            isSelected={isSelected}
+            isDimmed={isDimmed}
+          />
         </mesh>
       ))}
       {/* Bağlantı blokları: 3×3 ızgara */}
@@ -148,7 +163,12 @@ function PaletContent({
         [slatCentersX[0], slatCentersX[2], slatCentersX[5]].map((bx, xi) => (
           <mesh key={`bl${zi}${xi}`} position={[bx, paletCenterY, bz]}>
             <boxGeometry args={[slatW, blockH, crossD]} />
-            <PaletMat color={PALLET_WOOD_COLOR} opacity={opacity} isSelected={isSelected} />
+            <PaletMat
+              color={PALLET_WOOD_COLOR}
+              opacity={opacity}
+              isSelected={isSelected}
+              isDimmed={isDimmed}
+            />
           </mesh>
         )),
       )}
@@ -167,9 +187,9 @@ function PaletContent({
                     attach={`material-${face}`}
                     color={color}
                     transparent
-                    opacity={isSelected ? 0.95 : opacity}
-                    emissive={isSelected ? color : '#000000'}
-                    emissiveIntensity={isSelected ? 0.25 : 0}
+                    opacity={isDimmed ? 0.12 : isSelected ? 0.95 : opacity}
+                    emissive={isSelected && !isDimmed ? color : '#000000'}
+                    emissiveIntensity={isSelected && !isDimmed ? 0.25 : 0}
                   />
                 ) : (
                   <meshStandardMaterial
@@ -182,7 +202,7 @@ function PaletContent({
               )}
             </>
           ) : (
-            <PaletMat color={color} opacity={opacity} isSelected={isSelected} />
+            <PaletMat color={color} opacity={opacity} isSelected={isSelected} isDimmed={isDimmed} />
           )}
         </mesh>
       )}
@@ -206,6 +226,7 @@ export function BoxWrapper({
   isSelected = false,
   isHidden = false,
   isGhosted = false,
+  isDimmed = false,
   productType,
   labelTexture = null,
 }: BoxWrapperProps) {
@@ -259,6 +280,12 @@ export function BoxWrapper({
   // Sadece koli + labelTexture varsa kullanılır; varil/palet/ghosted için gerekmez.
   const boxMaterials = useMemo(() => {
     if (isPalet || isVaril || !labelTexture) return null;
+    if (isDimmed) {
+      return Array.from({ length: 6 }, () => {
+        const mat = new THREE.MeshStandardMaterial({ color, transparent: true, opacity: 0.12 });
+        return mat;
+      });
+    }
     const base = {
       color,
       transparent: true,
@@ -276,7 +303,7 @@ export function BoxWrapper({
       mat.emissiveIntensity = 0;
       return mat;
     });
-  }, [isPalet, isVaril, labelTexture, color, opacity, isSelected]);
+  }, [isPalet, isVaril, labelTexture, color, opacity, isSelected, isDimmed]);
 
   // Dispose — boxMaterials manuel THREE nesnesi
   useEffect(
@@ -304,6 +331,7 @@ export function BoxWrapper({
           opacity={opacity}
           isSelected={isSelected}
           isGhosted={isGhosted}
+          isDimmed={isDimmed}
           labelTexture={labelTexture}
         />
       </group>
@@ -323,9 +351,9 @@ export function BoxWrapper({
             <meshStandardMaterial
               color={color}
               transparent
-              opacity={isSelected ? 0.95 : opacity}
-              emissive={isSelected ? color : '#000000'}
-              emissiveIntensity={isSelected ? 0.25 : 0}
+              opacity={isDimmed ? 0.12 : isSelected ? 0.95 : opacity}
+              emissive={isSelected && !isDimmed ? color : '#000000'}
+              emissiveIntensity={isSelected && !isDimmed ? 0.25 : 0}
             />
           )}
         </mesh>

--- a/apps/frontend/src/features/planning/components/PlanLeftPanel.tsx
+++ b/apps/frontend/src/features/planning/components/PlanLeftPanel.tsx
@@ -223,6 +223,8 @@ interface StoreItemRowProps {
   groups?: GroupOption[];
   onToggleExpand: () => void;
   onToggleVisibility?: () => void;
+  onSelect?: () => void;
+  isSelected?: boolean;
   isHidden?: boolean;
   onPlace: (qty: number) => void;
   onUpdateQty?: (qty: number) => void;
@@ -243,6 +245,8 @@ function StoreItemRow({
   groups,
   onToggleExpand,
   onToggleVisibility,
+  onSelect,
+  isSelected = false,
   isHidden = false,
   onPlace,
   onUpdateQty,
@@ -267,11 +271,12 @@ function StoreItemRow({
       )}
     >
       <div
-        onClick={onToggleVisibility ?? onToggleExpand}
+        onClick={onSelect ?? onToggleVisibility ?? onToggleExpand}
         className={cn(
           'flex items-center gap-1.5 px-2.5 py-1.5 cursor-pointer select-none transition-colors',
           isPlaced ? 'bg-muted/40' : 'hover:bg-accent',
           isExpanded && 'bg-muted/40',
+          isSelected && 'ring-1 ring-inset ring-primary/40 bg-primary/5',
           isHidden && 'opacity-40',
         )}
       >
@@ -611,6 +616,9 @@ export function PlanLeftPanel({ planId }: PlanLeftPanelProps) {
   const setHiddenItemIds = useSceneStore((s) => s.setHiddenItemIds);
   const toggleHiddenItem = useSceneStore((s) => s.toggleHiddenItem);
   const selectedInstanceId = useSceneStore((s) => s.selectedInstanceId);
+  const selectedItemId = useSceneStore((s) => s.selectedItemId);
+  const setSelectedItemId = useSceneStore((s) => s.setSelectedItemId);
+  const setSelectedInstanceId = useSceneStore((s) => s.setSelectedInstanceId);
 
   // Mevcut plan yüklendiğinde store'dan grupları geri yükle
   useEffect(() => {
@@ -651,14 +659,18 @@ export function PlanLeftPanel({ planId }: PlanLeftPanelProps) {
     prevSelectedLenRef.current = selectedItems.length;
   }, [selectedItems.length, placements.length]);
 
-  // 3D sahnede kutu seçilince → Yüklü Ürünler tabına geç ve o kartı expand et
+  // 3D sahnede kutu seçilince → Yüklü Ürünler tabına geç, kartı expand et, sol panelde highlight yap
   useEffect(() => {
-    if (selectedInstanceId === null) return;
+    if (selectedInstanceId === null) {
+      setSelectedItemId(null);
+      return;
+    }
     const placement = usePlanStore.getState().placements[selectedInstanceId];
     if (!placement) return;
     setActiveTab('loaded');
     setExpandedId(placement.itemId);
-  }, [selectedInstanceId]);
+    setSelectedItemId(placement.itemId);
+  }, [selectedInstanceId, setSelectedItemId]);
 
   const prevPlanIdRef = useRef<string | undefined>(planId);
   useEffect(() => {
@@ -1483,6 +1495,11 @@ export function PlanLeftPanel({ planId }: PlanLeftPanelProps) {
                         iconColor={itemIconColorMap[id]}
                         onToggleVisibility={() => toggleHiddenItem(id)}
                         isHidden={hiddenItemIds.includes(id)}
+                        onSelect={() => {
+                          setSelectedInstanceId(null);
+                          setSelectedItemId(selectedItemId === id ? null : id);
+                        }}
+                        isSelected={selectedItemId === id}
                       />
                     </div>
                   );
@@ -1500,6 +1517,11 @@ export function PlanLeftPanel({ planId }: PlanLeftPanelProps) {
                       iconColor={itemIconColorMap[id]}
                       onToggleVisibility={() => toggleHiddenItem(id)}
                       isHidden={hiddenItemIds.includes(id)}
+                      onSelect={() => {
+                        setSelectedInstanceId(null);
+                        setSelectedItemId(selectedItemId === id ? null : id);
+                      }}
+                      isSelected={selectedItemId === id}
                     />
                   );
                 })}

--- a/apps/frontend/src/features/planning/components/scene/CargoMeshInstanced.tsx
+++ b/apps/frontend/src/features/planning/components/scene/CargoMeshInstanced.tsx
@@ -6,7 +6,7 @@ import { BoxWrapper } from '@/components/shared/BoxWrapper';
 import { LandingWireframe } from '@/components/shared/LandingWireframe';
 import { SCENE } from '@/lib/config/scene-config';
 import { applyOrientationQuaternion, rotatedDimensions } from '@/lib/utils/boxOrientations';
-import { isGhosted, isPlacementVisible } from '@/lib/utils/sceneFilter';
+import { isGhosted, isPlacementVisible, isSelectionDimmed } from '@/lib/utils/sceneFilter';
 import { useLandingAnimation } from '@/features/planning/components/scene/useLandingAnimation';
 import { useLoadingAnimation } from '@/features/planning/components/scene/useLoadingAnimation';
 import { buildLoadOrder } from '@/lib/utils/loadOrder';
@@ -146,23 +146,39 @@ function buildEdgesGeometry(
     hiddenItemIds: string[];
     activeLayer: number;
     focusedGroupItemIds: string[] | null;
+    showCog: boolean;
   },
-): THREE.BufferGeometry {
-  const { selectedInstanceId, selectedItemId, hiddenItemIds, activeLayer, focusedGroupItemIds } =
-    opts;
+): { normal: THREE.BufferGeometry; dim: THREE.BufferGeometry } {
+  const {
+    selectedInstanceId,
+    selectedItemId,
+    hiddenItemIds,
+    activeLayer,
+    focusedGroupItemIds,
+    showCog,
+  } = opts;
   const matrix = new THREE.Matrix4();
   const quaternion = new THREE.Quaternion();
   const position = new THREE.Vector3();
   const scale = new THREE.Vector3();
   const point = new THREE.Vector3();
-  const positions: number[] = [];
+  const normalPositions: number[] = [];
+  const dimPositions: number[] = [];
 
   placements.forEach((p, i) => {
-    // Palet kendi BoxWrapper'ı içinde kenar çizgileri çizer
     if (p.productType === 'palet') return;
     const visible = isPlacementVisible(p, i, { selectedInstanceId, selectedItemId, hiddenItemIds });
     const ghosted = isGhosted(p, activeLayer, focusedGroupItemIds);
     if (!visible || ghosted) return;
+
+    const selDimmed = isSelectionDimmed(p, i, {
+      selectedInstanceId,
+      selectedItemId,
+      focusedGroupItemIds,
+    });
+    const hasSelection =
+      selectedInstanceId !== null || selectedItemId !== null || focusedGroupItemIds !== null;
+    const dimmed = selDimmed || (showCog && !hasSelection);
 
     const base = rotatedDimensions(p.width, p.height, p.depth, p.orientationIndex);
     applyOrientationQuaternion(quaternion, p.orientationIndex);
@@ -170,17 +186,20 @@ function buildEdgesGeometry(
     scale.set(base.width, base.height, base.depth);
     matrix.compose(position, quaternion, scale);
 
+    const target = dimmed ? dimPositions : normalPositions;
     for (const [x1, y1, z1, x2, y2, z2] of UNIT_EDGES) {
       point.set(x1, y1, z1).applyMatrix4(matrix);
-      positions.push(point.x, point.y, point.z);
+      target.push(point.x, point.y, point.z);
       point.set(x2, y2, z2).applyMatrix4(matrix);
-      positions.push(point.x, point.y, point.z);
+      target.push(point.x, point.y, point.z);
     }
   });
 
-  const geo = new THREE.BufferGeometry();
-  geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
-  return geo;
+  const normal = new THREE.BufferGeometry();
+  normal.setAttribute('position', new THREE.Float32BufferAttribute(normalPositions, 3));
+  const dim = new THREE.BufferGeometry();
+  dim.setAttribute('position', new THREE.Float32BufferAttribute(dimPositions, 3));
+  return { normal, dim };
 }
 
 interface CargoMeshInstancedProps {
@@ -194,10 +213,12 @@ function InstancedBoxes() {
   const opaqueRef = useRef<THREE.InstancedMesh>(null);
   const ghostWireRef = useRef<THREE.InstancedMesh>(null);
   const violationRef = useRef<THREE.InstancedMesh>(null);
+  const dimRef = useRef<THREE.InstancedMesh>(null);
   // Cylinder (varil) refs
   const opaqueCylRef = useRef<THREE.InstancedMesh>(null);
   const ghostWireCylRef = useRef<THREE.InstancedMesh>(null);
   const violationCylRef = useRef<THREE.InstancedMesh>(null);
+  const dimCylRef = useRef<THREE.InstancedMesh>(null);
 
   const rawPlacements = usePlanStore((s) => s.placements);
   const previewItemId = usePlanStore((s) => s.previewItemId);
@@ -246,6 +267,7 @@ function InstancedBoxes() {
   const xRayMode = useSceneStore((s) => s.xRayMode);
   const focusedGroupItemIds = useSceneStore((s) => s.focusedGroupItemIds);
   const animationMode = useSceneStore((s) => s.animationMode);
+  const showCog = useSceneStore((s) => s.showCog);
   const setSelectedItemId = useSceneStore((s) => s.setSelectedItemId);
   const setSelectedInstanceId = useSceneStore((s) => s.setSelectedInstanceId);
   // Animasyon için: globalIdx → geçerli pozisyon (cm, merkez)
@@ -255,7 +277,10 @@ function InstancedBoxes() {
   const [, forceUpdatePalets] = useState(0);
 
   // Animasyon için yükleme sırası (arka→ön, alt→üst, sol→sağ)
-  const loadOrder = useMemo(() => buildLoadOrder(placements), [placements]);
+  const loadOrder = useMemo(
+    () => buildLoadOrder(placements, vehicle?.doorDirection, vehicle?.doorSide),
+    [placements, vehicle?.doorDirection, vehicle?.doorSide],
+  );
 
   const isAnimActive = animationMode === 'playing' || animationMode === 'stepped';
 
@@ -546,14 +571,15 @@ function InstancedBoxes() {
       }
 
       // stepped: sadece animationStep'e kadar olanlar görünür
+      // playing: sadece animPos geldiyse (useFrame ilk frame'i yazdıysa) göster — henüz başlamamış kutular gizli
       const seqIdx = loadOrder.indexOf(globalIdx);
-      const visibleInStep = isStepped ? seqIdx < currentAnimStep : true;
-      const visibleInPlay = isPlaying; // playing modda hook pozisyon set ettiğinde görünür
+      const animPos = animPositionsRef.current.get(globalIdx);
+      const visibleInStep = isStepped ? seqIdx < currentAnimStep : false;
+      const visibleInPlay = isPlaying && animPos !== undefined;
 
       const show = visibleInStep || visibleInPlay;
 
       if (show) {
-        const animPos = animPositionsRef.current.get(globalIdx);
         if (animPos) {
           position.copy(animPos);
         } else {
@@ -576,11 +602,13 @@ function InstancedBoxes() {
       matrix.compose(position, quaternion, scale);
       oRef.current!.setMatrixAt(instanceIdx, matrix);
 
-      // Ghost ve violation her zaman gizli animasyon sırasında
+      // Ghost, dim ve violation her zaman gizli animasyon sırasında
       scale.copy(SCALE_ZERO);
       matrix.compose(position, quaternion, scale);
       gRef.current!.setMatrixAt(instanceIdx, matrix);
       vRef.current!.setMatrixAt(instanceIdx, matrix);
+      const dRef = isVaril ? dimCylRef : dimRef;
+      dRef.current!.setMatrixAt(instanceIdx, matrix);
 
       if (p.isViolation) {
         color.copy(COLOR_VIOLATION);
@@ -603,9 +631,11 @@ function InstancedBoxes() {
       opaqueRef,
       ghostWireRef,
       violationRef,
+      dimRef,
       opaqueCylRef,
       ghostWireCylRef,
       violationCylRef,
+      dimCylRef,
     ]) {
       if (ref.current) ref.current.instanceMatrix.needsUpdate = true;
     }
@@ -648,9 +678,11 @@ function InstancedBoxes() {
       opaqueRef,
       ghostWireRef,
       violationRef,
+      dimRef,
       opaqueCylRef,
       ghostWireCylRef,
       violationCylRef,
+      dimCylRef,
       labelPlaneRef,
     ]) {
       if (ref.current) {
@@ -688,6 +720,15 @@ function InstancedBoxes() {
         hiddenItemIds,
       });
       const ghosted = isGhosted(p, activeLayer, focusedGroupItemIds);
+      const selectionDimmed = isSelectionDimmed(p, globalIdx, {
+        selectedInstanceId,
+        selectedItemId,
+        focusedGroupItemIds,
+      });
+      // CoG aktifken seçim yoksa tüm kutular dim; seçim varsa seçim dim öncelikli
+      const hasSelection =
+        selectedInstanceId !== null || selectedItemId !== null || focusedGroupItemIds !== null;
+      const dimmed = selectionDimmed || (showCog && !hasSelection);
 
       const base = rotatedDimensions(p.width, p.height, p.depth, p.orientationIndex);
       let sw: number, sh: number, sd: number;
@@ -708,13 +749,15 @@ function InstancedBoxes() {
       const oRef = isVaril ? opaqueCylRef : opaqueRef;
       const gRef = isVaril ? ghostWireCylRef : ghostWireRef;
       const vRef = isVaril ? violationCylRef : violationRef;
+      const dRef = isVaril ? dimCylRef : dimRef;
 
-      if (visible && !ghosted) scale.set(sw, sh, sd);
+      // Dim: seçim varken seçili olmayan kutular dimRef'e gider, opaqueRef'ten çıkar
+      if (visible && !ghosted && !dimmed) scale.set(sw, sh, sd);
       else scale.copy(SCALE_ZERO);
       matrix.compose(position, quaternion, scale);
       oRef.current!.setMatrixAt(instanceIdx, matrix);
 
-      if (visible && ghosted) scale.set(sw, sh, sd);
+      if (visible && ghosted && !dimmed) scale.set(sw, sh, sd);
       else scale.copy(SCALE_ZERO);
       matrix.compose(position, quaternion, scale);
       gRef.current!.setMatrixAt(instanceIdx, matrix);
@@ -723,6 +766,11 @@ function InstancedBoxes() {
       else scale.copy(SCALE_ZERO);
       matrix.compose(position, quaternion, scale);
       vRef.current!.setMatrixAt(instanceIdx, matrix);
+
+      if (visible && dimmed) scale.set(sw, sh, sd);
+      else scale.copy(SCALE_ZERO);
+      matrix.compose(position, quaternion, scale);
+      dRef.current!.setMatrixAt(instanceIdx, matrix);
 
       if (p.isViolation) {
         color.copy(COLOR_VIOLATION);
@@ -743,9 +791,11 @@ function InstancedBoxes() {
       opaqueRef,
       ghostWireRef,
       violationRef,
+      dimRef,
       opaqueCylRef,
       ghostWireCylRef,
       violationCylRef,
+      dimCylRef,
     ]) {
       if (ref.current) ref.current.instanceMatrix.needsUpdate = true;
     }
@@ -762,6 +812,7 @@ function InstancedBoxes() {
     activeLayer,
     xRayMode,
     focusedGroupItemIds,
+    showCog,
   ]);
 
   // Label plane matrislerini idle'da veya atlas/placements değişince güncelle
@@ -781,13 +832,14 @@ function InstancedBoxes() {
   // Build edge lineSegments geometry for all visible non-ghosted boxes.
   // InstancedMesh cannot render EdgesGeometry (line primitives), so we build
   // a single lineSegments with all box edges pre-transformed in world space.
-  const edgesLineGeo = useMemo(() => {
+  const edgesLineGeos = useMemo(() => {
     return buildEdgesGeometry(placements, {
       selectedInstanceId,
       selectedItemId,
       hiddenItemIds,
       activeLayer,
       focusedGroupItemIds,
+      showCog,
     });
   }, [
     placements,
@@ -796,9 +848,16 @@ function InstancedBoxes() {
     hiddenItemIds,
     activeLayer,
     focusedGroupItemIds,
+    showCog,
   ]);
 
-  useEffect(() => () => edgesLineGeo.dispose(), [edgesLineGeo]);
+  useEffect(
+    () => () => {
+      edgesLineGeos.normal.dispose();
+      edgesLineGeos.dim.dispose();
+    },
+    [edgesLineGeos],
+  );
 
   // Palet seçimini kendi BoxWrapper render döngüsü yönetir
   const selectedPlacements = useMemo(
@@ -853,6 +912,17 @@ function InstancedBoxes() {
       </instancedMesh>
 
       <instancedMesh
+        key={`dim-${placements.length}`}
+        ref={dimRef}
+        args={[undefined, undefined, Math.max(1, boxIndices.length)]}
+        frustumCulled={false}
+        matrixAutoUpdate={false}
+      >
+        <boxGeometry args={[1, 1, 1]} />
+        <meshStandardMaterial color="#888888" transparent opacity={0.15} depthWrite={false} />
+      </instancedMesh>
+
+      <instancedMesh
         key={`violation-${placements.length}`}
         ref={violationRef}
         args={[undefined, undefined, Math.max(1, boxIndices.length)]}
@@ -904,6 +974,17 @@ function InstancedBoxes() {
       </instancedMesh>
 
       <instancedMesh
+        key={`dim-cyl-${placements.length}`}
+        ref={dimCylRef}
+        args={[undefined, undefined, Math.max(1, cylIndices.length)]}
+        frustumCulled={false}
+        matrixAutoUpdate={false}
+      >
+        <cylinderGeometry args={[0.5, 0.5, 1, 16]} />
+        <meshStandardMaterial color="#888888" transparent opacity={0.15} depthWrite={false} />
+      </instancedMesh>
+
+      <instancedMesh
         key={`violation-cyl-${placements.length}`}
         ref={violationCylRef}
         args={[undefined, undefined, Math.max(1, cylIndices.length)]}
@@ -919,8 +1000,11 @@ function InstancedBoxes() {
       </instancedMesh>
 
       {/* Edge lines — animasyon sırasında gizle, kutular hareket ederken statik durmasın */}
-      <lineSegments geometry={edgesLineGeo} visible={!isAnimActive}>
+      <lineSegments geometry={edgesLineGeos.normal} visible={!isAnimActive}>
         <lineBasicMaterial color="#000000" />
+      </lineSegments>
+      <lineSegments geometry={edgesLineGeos.dim} visible={!isAnimActive}>
+        <lineBasicMaterial color="#000000" transparent opacity={0.08} depthWrite={false} />
       </lineSegments>
 
       {/* Landing wireframe — previewPlacements animasyon süresince */}
@@ -952,6 +1036,14 @@ function InstancedBoxes() {
         });
         if (!visible) return null;
         const ghosted = isGhosted(p, activeLayer, focusedGroupItemIds);
+        const selDimmedPalet = isSelectionDimmed(p, globalIdx, {
+          selectedInstanceId,
+          selectedItemId,
+          focusedGroupItemIds,
+        });
+        const hasSelectionPalet =
+          selectedInstanceId !== null || selectedItemId !== null || focusedGroupItemIds !== null;
+        const dimmed = selDimmedPalet || (showCog && !hasSelectionPalet);
         const isItemSelected =
           selectedInstanceId === globalIdx ||
           (selectedInstanceId === null && p.itemId === selectedItemId);
@@ -989,6 +1081,7 @@ function InstancedBoxes() {
             isSelected={isItemSelected}
             isHidden={hiddenByAnim}
             isGhosted={ghosted}
+            isDimmed={dimmed}
             productType={p.productType}
             labelTexture={ghosted ? null : (paletLabelTextures.get(globalIdx) ?? null)}
             onClick={() => {
@@ -1069,6 +1162,7 @@ function BoxPathBoxes() {
   const activeLayer = useSceneStore((s) => s.activeLayer);
   const focusedGroupItemIds = useSceneStore((s) => s.focusedGroupItemIds);
   const animationMode = useSceneStore((s) => s.animationMode);
+  const showCog = useSceneStore((s) => s.showCog);
   const setSelectedItemId = useSceneStore((s) => s.setSelectedItemId);
   const setSelectedInstanceId = useSceneStore((s) => s.setSelectedInstanceId);
 
@@ -1079,7 +1173,10 @@ function BoxPathBoxes() {
     handleAllSettled,
   );
 
-  const loadOrder = useMemo(() => buildLoadOrder(placements), [placements]);
+  const loadOrder = useMemo(
+    () => buildLoadOrder(placements, vehicle?.doorDirection, vehicle?.doorSide),
+    [placements, vehicle?.doorDirection, vehicle?.doorSide],
+  );
   const isAnimActive = animationMode === 'playing' || animationMode === 'stepped';
 
   // Her placement için yükleme sıra no (1-based) ve aynı itemId içindeki instance no
@@ -1198,16 +1295,24 @@ function BoxPathBoxes() {
         const isInstanceSelected = selectedInstanceId === i;
         const isItemSelected = p.itemId === selectedItemId;
         const ghosted = isGhosted(p, activeLayer, focusedGroupItemIds);
+        const selDimmed = isSelectionDimmed(p, i, {
+          selectedInstanceId,
+          selectedItemId,
+          focusedGroupItemIds,
+        });
+        const hasSelection =
+          selectedInstanceId !== null || selectedItemId !== null || focusedGroupItemIds !== null;
+        const dimmed = selDimmed || (showCog && !hasSelection);
 
         // Animasyon aktifken stepped modda henüz gelmemiş kutuları gizle
+        // Playing modda animPos gelmemişse (henüz başlamamış) da gizle
         const seqIdx = isAnimActive ? loadOrder.indexOf(i) : -1;
-        const hiddenByAnim =
-          animationMode === 'stepped' &&
-          seqIdx >= 0 &&
-          seqIdx >= useSceneStore.getState().animationStep;
-
-        // Animasyon pozisyonunu al (playing modunda hook tarafından set edilir)
         const animPos = isAnimActive ? animPositions.get(i) : undefined;
+        const hiddenByAnim =
+          (animationMode === 'stepped' &&
+            seqIdx >= 0 &&
+            seqIdx >= useSceneStore.getState().animationStep) ||
+          (animationMode === 'playing' && animPos === undefined);
 
         // AnimPos merkez koordinatı — BoxWrapper bottom-left-rear bekliyor, ters çevir
         let px: number, py: number, pz: number;
@@ -1241,6 +1346,7 @@ function BoxPathBoxes() {
             isSelected={isInstanceSelected || isItemSelected}
             isHidden={hiddenItemIds.includes(p.itemId) || hiddenByAnim}
             isGhosted={ghosted}
+            isDimmed={dimmed}
             productType={p.productType}
             labelTexture={labelTextures.get(i) ?? null}
             onClick={() => {

--- a/apps/frontend/src/features/planning/components/scene/useLoadingAnimation.ts
+++ b/apps/frontend/src/features/planning/components/scene/useLoadingAnimation.ts
@@ -92,36 +92,6 @@ export function useLoadingAnimation(
     const height = vehicleHeight ?? 0;
     const OFFSET = SCENE.ANIM_DOOR_OFFSET_CM;
 
-    let doorX: number;
-    let doorY: number;
-    let doorZ: number;
-
-    switch (doorDirection) {
-      case 'side':
-        // Yan kapı: kutular konteynerin sol veya sağ yanından girer
-        doorX = doorSide === 'right' ? width + OFFSET : -OFFSET;
-        doorY = height / 2;
-        doorZ = depth / 2;
-        break;
-      case 'top':
-        // Üst kapı: kutular tavandan aşağıya iner
-        doorX = width / 2;
-        doorY = height + OFFSET;
-        doorZ = depth / 2;
-        break;
-      case 'rear':
-        // Arka kapı: Z=0 yüzü önünden girer
-        doorX = width / 2;
-        doorY = height / 2;
-        doorZ = -OFFSET;
-        break;
-      default:
-        // 'front' veya undefined — ön yüz (Z=depth) önünden girer
-        doorX = width / 2;
-        doorY = 0;
-        doorZ = depth + OFFSET;
-    }
-
     const schedule = new Map<number, AnimEntry>();
     loadOrder.forEach((globalIdx, seqIdx) => {
       const p = placements[globalIdx];
@@ -131,12 +101,48 @@ export function useLoadingAnimation(
       const cy = p.positionY + p.height / 2;
       const cz = p.positionZ + p.depth / 2;
 
+      // Her kutu kapı ekseninde dışarıdan başlar, diğer eksenlerde hedef pozisyonunda.
+      // Böylece kutular kapı açıklığından düz çizgi halinde içeri kayar.
+      let fromX: number;
+      let fromY: number;
+      let fromZ: number;
+
+      switch (doorDirection) {
+        case 'side':
+          // Yan kapı: kapı X ekseninde, kutu Y/Z hedefinde başlar
+          fromX = doorSide === 'right' ? width + OFFSET : -OFFSET;
+          fromY = cy;
+          fromZ = cz;
+          break;
+        case 'top':
+          // Üst kapı: tavan Y + offset'ten iner, X/Z hedefinde
+          fromX = cx;
+          fromY = height + OFFSET;
+          fromZ = cz;
+          break;
+        case 'rear':
+          // Arka kapı: Z=0 önünden girer
+          fromX = cx;
+          fromY = cy;
+          fromZ = -OFFSET;
+          break;
+        case 'rearAndSide':
+          fromX = cx;
+          fromY = cy;
+          fromZ = -OFFSET;
+          break;
+        default:
+          // 'front' veya undefined — Z=depth önünden girer
+          fromX = cx;
+          fromY = cy;
+          fromZ = depth + OFFSET;
+      }
+
       schedule.set(globalIdx, {
         startAt: seqIdx * staggerMs,
         flightMs,
         target: new THREE.Vector3(cx, cy, cz),
-        // Tüm kutular kapı önünden (0,0,0 köşe referansıyla) hedeflerine gider
-        from: new THREE.Vector3(doorX, doorY, doorZ),
+        from: new THREE.Vector3(fromX, fromY, fromZ),
       });
     });
 

--- a/apps/frontend/src/lib/utils/loadOrder.ts
+++ b/apps/frontend/src/lib/utils/loadOrder.ts
@@ -1,23 +1,69 @@
 import type { PlacementWithDimensions } from '@/lib/types/loadingPlan';
+import type { DoorDirection } from '@/lib/types/vehicle';
 
 /**
- * Yükleme sırası: arka duvardan kapıya (Z küçük→büyük), alt kattan üst kata (Y küçük→büyük),
- * soldan sağa (X küçük→büyük).
- * Z=0 arka duvar, Z=length kapı — içeridekiler önce yüklenir.
+ * Yükleme sırası — kapı yönüne göre "kapıya en uzak" kutular önce girilir.
  *
- * Backend bu sırayı hesaplayıp gönderirse bu fonksiyon atlanabilir.
- * Şimdilik client-side sort ile simüle edilmektedir.
+ * rear  (Z=0):       Z büyük→küçük, sonra Y küçük→büyük (alt kat önce), X küçük→büyük
+ * front (Z=length):  Z küçük→büyük, sonra Y küçük→büyük, X küçük→büyük
+ * side  right (X=W): X küçük→büyük (sol duvar önce), sonra Y küçük→büyük, Z küçük→büyük
+ * side  left  (X=0): X büyük→küçük (sağ duvar önce), sonra Y küçük→büyük, Z küçük→büyük
+ * top   (Y=H):       Y küçük→büyük (alt kat önce), sonra Z büyük→küçük, X küçük→büyük
  *
- * Döndürülen değer: orijinal `placements` dizisindeki global index listesi,
- * yükleme sırasına göre sıralı.
+ * Her yön için "katman" tanımı:
+ *   rear/front → Z katmanı  (kutunun kapıya olan Z mesafesi)
+ *   side       → X katmanı
+ *   top        → Y katmanı
+ *
+ * Aynı katmandaki kutular Y küçük→büyük (alt önce), ardından diğer eksen küçük→büyük.
  */
-export function buildLoadOrder(placements: PlacementWithDimensions[]): number[] {
+export function buildLoadOrder(
+  placements: PlacementWithDimensions[],
+  doorDirection?: DoorDirection,
+  doorSide?: 'right' | 'left',
+): number[] {
   return placements
     .map((p, i) => ({ p, i }))
     .sort((a, b) => {
-      if (a.p.positionZ !== b.p.positionZ) return a.p.positionZ - b.p.positionZ;
-      if (a.p.positionY !== b.p.positionY) return a.p.positionY - b.p.positionY;
-      return a.p.positionX - b.p.positionX;
+      const pa = a.p;
+      const pb = b.p;
+
+      switch (doorDirection) {
+        case 'rear':
+          // Kapı Z=0 — Z büyükten küçüğe (arka duvar son, kapı önce)
+          if (pa.positionZ !== pb.positionZ) return pb.positionZ - pa.positionZ;
+          if (pa.positionY !== pb.positionY) return pa.positionY - pb.positionY;
+          return pa.positionX - pb.positionX;
+
+        case 'side': {
+          // Sağ kapı X=width → X küçük→büyük (sol duvar önce girer)
+          // Sol kapı X=0    → X büyük→küçük (sağ duvar önce girer)
+          const xSign = doorSide === 'left' ? -1 : 1;
+          const xDiff = xSign * (pa.positionX - pb.positionX);
+          if (xDiff !== 0) return xDiff;
+          if (pa.positionY !== pb.positionY) return pa.positionY - pb.positionY;
+          return pa.positionZ - pb.positionZ;
+        }
+
+        case 'top':
+          // Kapı Y=height — Y küçük→büyük (zemin katı önce girer)
+          if (pa.positionY !== pb.positionY) return pa.positionY - pb.positionY;
+          if (pa.positionZ !== pb.positionZ) return pb.positionZ - pa.positionZ;
+          return pa.positionX - pb.positionX;
+
+        case 'rearAndSide': {
+          // Hem arka hem yan kapı — rear öncelikli
+          if (pa.positionZ !== pb.positionZ) return pb.positionZ - pa.positionZ;
+          if (pa.positionY !== pb.positionY) return pa.positionY - pb.positionY;
+          return pa.positionX - pb.positionX;
+        }
+
+        default:
+          // 'front' veya undefined — kapı Z=length, Z küçük→büyük (arka duvar önce, kapıya yakın son)
+          if (pa.positionZ !== pb.positionZ) return pa.positionZ - pb.positionZ;
+          if (pa.positionY !== pb.positionY) return pa.positionY - pb.positionY;
+          return pa.positionX - pb.positionX;
+      }
     })
     .map(({ i }) => i);
 }

--- a/apps/frontend/src/lib/utils/sceneFilter.ts
+++ b/apps/frontend/src/lib/utils/sceneFilter.ts
@@ -27,6 +27,38 @@ export function isGhosted(
 }
 
 /**
+ * Seçim dim modu — seçim veya grup fokus aktifken seçili olmayan kutular için true döner.
+ *
+ * Koşullar:
+ * 1. selectedInstanceId dolu → sadece o index seçili, diğerleri dim
+ * 2. selectedItemId dolu → aynı itemId seçili, diğerleri dim
+ * 3. focusedGroupItemIds dolu → gruptaki itemId'ler aktif, dışındakiler dim
+ *    (bu durum isGhosted ile çakışır; dim öncelikli — wireframe yerine yarı saydam render)
+ */
+export function isSelectionDimmed(
+  p: PositionedBox,
+  index: number,
+  state: {
+    selectedInstanceId: number | null;
+    selectedItemId: string | null;
+    focusedGroupItemIds: string[] | null;
+  },
+): boolean {
+  const { selectedInstanceId, selectedItemId, focusedGroupItemIds } = state;
+
+  if (focusedGroupItemIds !== null) {
+    return !focusedGroupItemIds.includes(p.itemId);
+  }
+  if (selectedInstanceId !== null) {
+    return selectedInstanceId !== index;
+  }
+  if (selectedItemId !== null) {
+    return p.itemId !== selectedItemId;
+  }
+  return false;
+}
+
+/**
  * Bir placement'ın InstancedMesh'te scale=0 ile tamamen gizlenip gizlenmeyeceğini hesaplar.
  *
  * Gizleme nedenleri:


### PR DESCRIPTION
…r direction

- Seçili kutu parlak kalır, diğerleri dim olur (selection dim inversion)
- Grup fokusunda aynı mantık: gruba ait kutular parlak, diğerleri dim
- Sol panelden ürün tıklaması 3D'de dim efekti tetikler, tekrar tıklama deselect
- Dim kutulardaki kenar çizgilerinin opacity'si düşürüldü (0.08)
- showCog=true olduğunda tüm kutular dim olur, ağırlık merkezi öne çıkar
- Animasyon başlangıç noktası kapı yönüne göre düzeltildi (yan/üst/arka/ön)
- Yükleme sırası kapı yönüne göre düzeltildi (front: küçük Z önce)
- Animasyon başlamadan kutular dışarıda görünmüyordu — gizlendi

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
