### PR TITLE
docs: 3D bin packing tasarım dokümanları arşive alındı

### DIFF
--- a/apps/backend/docs/bin_packing_implementation_plan.md
+++ b/apps/backend/docs/bin_packing_implementation_plan.md
@@ -1,0 +1,423 @@
+# 3D Bin Packing — Backend Geliştirme Faz Planı
+
+> **Durum: Tasarım arşivi — güncel implementasyonun birebir dokümantasyonu değildir.**
+>
+> Bu doküman `feature/3D_Packing_Algorithm` branch'inde (2026-05-05) üretildi. Branch, `test`'teki
+> `CargoPilot.Infrastructure/Services/OptimizationEngine.cs` implementasyonu tarafından geride
+> bırakıldığı için kapatılmaktadır; tasarım içeriği kaybolmasın diye doküman buraya taşınmıştır.
+>
+> Güncel kodla bilinen farklar:
+> - Koordinat ekseni adlandırması burada farklıdır. Güncel sözleşme: **X = genişlik, Y = yükseklik,
+>   Z = derinlik**, origin kutunun **sol-alt-arka** köşesi (`apps/frontend/.claude/CLAUDE.md`,
+>   `lib/config/scene-config.ts`).
+> - MediatR'a yapılan atıflar geçerli değildir; backend service-based yaklaşım kullanır
+>   (`apps/backend/docs/architecture.md`).
+> - `Packing/` klasörü ve `PackingEngine` sınıfı `test` branch'inde bulunmamaktadır.
+>
+> Algoritma çalışması yapılırken kavramsal referans olarak kullanılabilir; kod kaynağı olarak değil.
+
+---
+
+**Hedef:** "Optimize Et" komutu tetiklendiğinde EP tabanlı 3D Bin Packing algoritmasını çalıştırıp yerleşim sonucunu dönen, Clean Architecture uyumlu bir backend servisi.
+
+**Mevcut proje yapısı:** `CargoPilot.Domain` / `CargoPilot.Application` / `CargoPilot.Infrastructure` / `CargoPilot.WebAPI`  
+**Stack:** .NET 8, MediatR, FluentValidation, `Result<T>` pattern
+
+---
+
+## Faz 1 — Domain Modelleri ve Algoritma Kontratları
+
+> **Amaç:** Algoritmanın çalışacağı saf domain kavramlarını ve servis arayüzlerini tanımla. Hiç DB bağımlılığı yok.
+
+### 1.1 Domain Katmanı — Yeni Value Object'ler
+
+**`CargoPilot.Domain/Packing/`** klasörü altında:
+
+| Dosya | Sorumluluk |
+|---|---|
+| `ContainerSpec.cs` | `record ContainerSpec(decimal Length, decimal Width, decimal Height, decimal MaxWeight)` |
+| `ItemSpec.cs` | `record ItemSpec(string Id, string Name, decimal Length, decimal Width, decimal Height, decimal Weight, bool IsStackable, decimal MaxWeightOnTop, int? LifoIndex)` |
+| `PackingParameters.cs` | `record PackingParameters(bool LifoEnabled, decimal CgThresholdPercent = 15m)` |
+| `ExtremePoint.cs` | `record ExtremePoint(decimal X, decimal Y, decimal Z)` |
+| `Rotation.cs` | `record Rotation(decimal L, decimal W, decimal H)` — efektif boyutlar |
+| `PlacedItem.cs` | `record PlacedItem(string ItemId, ExtremePoint Position, Rotation Rotation, decimal CurrentStackLoad)` |
+| `PackingCandidate.cs` | `record PackingCandidate(ExtremePoint Ep, Rotation Rot, decimal DeltaX, decimal DeltaY, double Score, bool PassesCgConstraint)` |
+| `PackingPlacement.cs` | Çıktı: `record PackingPlacement(string ItemId, decimal X, decimal Y, decimal Z, Rotation Rotation)` |
+| `PackingWarning.cs` | `record PackingWarning(string ItemId, decimal DeltaX, decimal DeltaY, string Message)` |
+| `UnplacedItemResult.cs` | `record UnplacedItemResult(string ItemId, string Reason)` |
+| `PackingResult.cs` | Tüm çıktıyı kapsayan ana sonuç nesnesi (bkz. §1.2) |
+
+### 1.2 PackingResult Yapısı
+
+```csharp
+public sealed record PackingResult(
+    IReadOnlyList<PackingPlacement> Placements,
+    decimal CgFinalX,
+    decimal CgFinalY,
+    decimal CgFinalZ,
+    decimal CgDeviationX,   // yüzde
+    decimal CgDeviationY,   // yüzde
+    decimal TotalWeight,
+    decimal FillRatePercent,
+    IReadOnlyList<PackingWarning> Warnings,
+    IReadOnlyList<UnplacedItemResult> UnplacedItems
+);
+```
+
+### 1.3 Domain Servis Kontratı
+
+**`CargoPilot.Domain/Packing/IPackingEngine.cs`**
+
+```csharp
+public interface IPackingEngine
+{
+    PackingResult Optimize(
+        ContainerSpec container,
+        IReadOnlyList<ItemSpec> items,
+        PackingParameters parameters);
+}
+```
+
+**Teslimatlar:**
+- [ ] `CargoPilot.Domain/Packing/` klasörü ve tüm record/interface dosyaları
+- [ ] Domain katmanında sıfır dış bağımlılık (sadece BCL)
+
+---
+
+## Faz 2 — EP Algoritması — Çekirdek Motor
+
+> **Amaç:** `IPackingEngine` implementasyonunu tam algoritmaya sadık biçimde yaz. Infrastructure'a bağlı değil; unit test edilebilir.
+
+Implementasyon klasörü: **`CargoPilot.Infrastructure/Packing/`**
+
+### 2.1 Sıralama Katmanı (Katman A)
+
+**`ItemSorter.cs`**
+
+- LIFO kapalı: `V_i = l × w × h`, DESC sıralama
+- LIFO açık: `lifo_index` DESC, `null` olanlar kuyruğun sonu, kendi aralarında hacim DESC
+- Pure static metod; bağımlılık yok
+
+### 2.2 Geometri Yardımcıları
+
+**`GeometryHelper.cs`**
+
+| Metod | Açıklama |
+|---|---|
+| `GetRotations(ItemSpec)` | 6 rotasyonu üret |
+| `CheckBoundary(ep, rot, container)` | §5.1 konteyner sınırı |
+| `CheckAabbNoOverlap(ep, rot, placed)` | §5.2 AABB çakışma testi, `ε = 1e-6` |
+| `CheckGroundSupport(ep, rot, placed, container)` | §5.3 zemin desteği ≥ %80 |
+| `CheckStackingRules(ep, rot, item, placed)` | §5.4 istif kontrolü |
+| `ComputeRectIntersectionArea(...)` | Dikdörtgen kesişim alanı |
+
+### 2.3 CG Hesaplayıcı
+
+**`CgCalculator.cs`**
+
+| Metod | Açıklama |
+|---|---|
+| `ComputeTempCg(...)` | §6.2 geçici CG ve δ_x, δ_y hesabı |
+| `UpdateCg(...)` | §6.1 inkremental CG güncellemesi |
+
+### 2.4 Maliyet Fonksiyonu
+
+**`CostFunction.cs`**
+
+- `GroundProximity(z, Hc)` → `1 − z/Hc`
+- `SpaceQuality(epCountAfter)` → `1 − epCount/20`
+- `LifoAlignment(xCandidate, lifoIndex, lifoMax, Lc)` → `1 − |x − x_ideal|/Lc`
+- `ComputeScore(candidate, parameters, lifoMax, Hc, Lc)` → ağırlıklı toplam
+
+### 2.5 EP Yöneticisi
+
+**`ExtremePointManager.cs`**
+
+- `GenerateNew(ep, rot)` → 3 yeni EP üretir
+- `ApplyDominanceFilter(eps)` → dominance eleme (§4.3)
+- `Prune(eps, maxCount = 30)` → liste 30'u geçerse düşük kalitelileri temizle
+
+### 2.6 Ana Motor — PackingEngine
+
+**`PackingEngine.cs : IPackingEngine`**
+
+Pseudocode'u birebir uygula (§9 Ana Döngü):
+
+```
+1. ItemSorter ile sırala
+2. EP = {(0,0,0)}, yerleşimler = [], CG = (Lc/2, Wc/2, 0), M = 0
+3. Her P_i için:
+   a. Fiziksel kontrolleri geç
+   b. CG sapmasını hesapla → A_gecerli / A_tum
+   c. Seçim: argmax(Score) veya fallback
+   d. Yerleştir, CG güncelle, EP üret, dominance filtresi
+4. Sonucu hesapla (doluluk, final CG sapması) → PackingResult
+```
+
+**Teslimatlar:**
+- [ ] `GeometryHelper.cs` — 4 kontrol metodu
+- [ ] `CgCalculator.cs` — inkremental ve geçici CG
+- [ ] `CostFunction.cs` — 3 terim + ağırlık vektörü
+- [ ] `ExtremePointManager.cs` — üretim + dominance + prune
+- [ ] `ItemSorter.cs` — FFD + LIFO sıralama
+- [ ] `PackingEngine.cs` — tam ana döngü
+
+---
+
+## Faz 3 — Mock Data ve Girdi Doğrulama
+
+> **Amaç:** DB bağımlılığı olmadan algoritmayı test edecek kapsamlı mock veri ve istek doğrulama.
+
+### 3.1 Mock Data Sağlayıcı
+
+**`CargoPilot.Infrastructure/Packing/MockPackingDataProvider.cs`**
+
+```csharp
+public static class MockPackingDataProvider
+{
+    public static ContainerSpec GetContainer()     // 20-ft konteyner benzeri
+    public static IReadOnlyList<ItemSpec> GetItems() // 15 farklı ürün
+    public static PackingParameters GetParameters()
+}
+```
+
+**Mock ürün seti — kapsam:**
+- Hacimce büyük palettler (stackable=true, max_stack yüksek)
+- Orta boy kutular (çeşitli boyut oranları)
+- Küçük paketler (LIFO index'li — 1,2,3)
+- Kırılgan ürün (stackable=false)
+- Konteynere sığmayan aşırı büyük ürün (yerleşmeyen listesi testi)
+- Farklı ağırlıklarda ürünler (CG dengesini zorlayan)
+
+### 3.2 JSON Mock Data Dosyası
+
+**`CargoPilot.WebAPI/MockData/bin_packing_mock.json`**
+
+Dışarıdan `POST /api/packing/optimize` çağrısını test etmek için kullanılabilir hazır JSON body.
+
+### 3.3 Girdi Doğrulama
+
+**`CargoPilot.Application/Features/Packing/OptimizePacking/OptimizePackingCommandValidator.cs`**
+
+- Tüm boyutlar > 0
+- `MaxWeightCapacity` > 0
+- LIFO index'leri unique (çakışma → validation error)
+- LIFO açık ama hiç `lifoIndex` yok → warning üret, devam et
+
+**Teslimatlar:**
+- [ ] `MockPackingDataProvider.cs` — en az 15 ürün, tüm kısıt senaryoları kapsanmış
+- [ ] `bin_packing_mock.json` — doğrudan Swagger'dan test edilebilir
+- [ ] `OptimizePackingCommandValidator.cs` — 4 kural
+
+---
+
+## Faz 4 — Application Katmanı — Command/Query
+
+> **Amaç:** MediatR command, handler ve DTO'larını projenin mevcut CQRS pattern'ine uygun yaz.
+
+Klasör: **`CargoPilot.Application/Features/Packing/`**
+
+### 4.1 Command ve DTO'lar
+
+**`OptimizePackingCommand.cs`**
+
+```csharp
+public sealed record OptimizePackingCommand(
+    ContainerSpecDto Container,
+    IReadOnlyList<ItemSpecDto> Items,
+    PackingParametersDto Parameters
+) : IRequest<Result<PackingResultDto>>;
+```
+
+**DTO Dosyaları:**
+- `ContainerSpecDto.cs` — uzunluk, genislik, yukseklik, maxYuk, aracTipi
+- `ItemSpecDto.cs` — id, uzunluk, genislik, yukseklik, agirlik, istiflenebilir, maxIstif, lifoIndex
+- `PackingParametersDto.cs` — lifoAktif, cgEsik
+- `PackingResultDto.cs` — yerleşimler, cgFinal, toplamAgirlik, dolulukOrani, uyarilar, yerlesmeyen
+
+### 4.2 Mock Command
+
+**`OptimizePackingWithMockDataCommand.cs`**
+
+```csharp
+public sealed record OptimizePackingWithMockDataCommand : IRequest<Result<PackingResultDto>>;
+```
+
+Handler: `MockPackingDataProvider`'dan veri alır → `IPackingEngine` çalıştırır → sonucu maplar.
+
+### 4.3 Real Command Handler
+
+**`OptimizePackingCommandHandler.cs`**
+
+- Validator çağırır
+- DTO → Domain model map
+- `IPackingEngine.Optimize(...)` çağırır
+- Domain sonuç → DTO map
+- `Result<PackingResultDto>.Success(...)` döner
+
+**Teslimatlar:**
+- [ ] `OptimizePackingCommand.cs` + tüm DTO'lar
+- [ ] `OptimizePackingWithMockDataCommand.cs` + handler
+- [ ] `OptimizePackingCommandHandler.cs`
+- [ ] `OptimizePackingCommandValidator.cs`
+
+---
+
+## Faz 5 — WebAPI Katmanı — Controller ve Kayıt
+
+> **Amaç:** HTTP endpoint'leri aç, DI kayıtlarını tamamla.
+
+### 5.1 Controller
+
+**`CargoPilot.WebAPI/Controllers/PackingController.cs`**
+
+```
+POST /api/packing/optimize
+    Body: OptimizePackingCommand
+    → PackingResultDto
+
+POST /api/packing/optimize/mock
+    Body: (yok)
+    → PackingResultDto   ← algoritma doğrulaması için hızlı test endpoint'i
+```
+
+- `[Authorize]` attribute (mevcut JWT akışı)
+- `HandleResult<PackingResultDto>(result)` ile standart yanıt
+- Swagger XML comment'leri
+
+### 5.2 DI Kayıtları
+
+**`CargoPilot.Infrastructure/DependencyInjection.cs`** içine:
+
+```csharp
+services.AddSingleton<IPackingEngine, PackingEngine>();
+```
+
+**`CargoPilot.Application/DependencyInjection.cs`** — MediatR zaten tüm assembly'yi tarar; ekstra kayıt gerekmez.
+
+### 5.3 Performans
+
+- `PackingEngine` → `Singleton` (durumsuz, thread-safe)
+- `Stopwatch` ile süre ölçümü → response header veya log
+
+**Teslimatlar:**
+- [ ] `PackingController.cs` — 2 endpoint
+- [ ] DI kayıtları güncellendi
+- [ ] Swagger'dan her iki endpoint test edilebilir
+
+---
+
+## Faz 6 — Test Senaryoları ve Doğrulama
+
+> **Amaç:** Dokümanın §10.3 test senaryolarını karşıla; edge case'leri kapat.
+
+### 6.1 Unit Test Senaryoları
+
+**Dosya:** `CargoPilot.Tests/Packing/PackingEngineTests.cs`
+
+| No | Senaryo | Beklenen |
+|---|---|---|
+| T1 | Tek ürün — konteynere tam sığan | x=0, y=0, z=0 |
+| T2 | İki ürün yan yana | Çakışma yok |
+| T3 | stackable=false ürün | Üstüne ürün konulmamalı |
+| T4 | CG fallback | Uyarı üretilmeli |
+| T5 | LIFO sırası | lifo_index=1 → en düşük x |
+| T6 | Konteynere sığmayan ürün | yerlesmeyen listesinde |
+| T7 | Doluluk oranı | 10 birim / 100 birim = %10 |
+| T8 | LIFO + CG çakışması | CG öncelikli, uyarı üretilir |
+| T9 | Dominance filtresi | EP listesi 30'u aşmamalı |
+| T10 | Zemin desteği | %80 altı → yerleştirilmemeli |
+
+### 6.2 Integration Test
+
+`POST /api/packing/optimize/mock` → HTTP 200, `placements` boş değil, `fillRatePercent > 0`
+
+### 6.3 Performans Doğrulaması
+
+- n=50 → < 500ms
+- n=100 → < 2s
+- `Stopwatch` log çıktısı
+
+**Teslimatlar:**
+- [ ] `PackingEngineTests.cs` — 10 unit test
+- [ ] Integration smoke test
+- [ ] Performans log kaydı
+
+---
+
+## Özet Tablo
+
+| Faz | Katman | Ana Çıktı | Bağımlılık |
+|---|---|---|---|
+| 1 | Domain | Value object'ler, `IPackingEngine` kontratı | Yok |
+| 2 | Infrastructure | EP motoru — tam algoritma | Faz 1 |
+| 3 | Infrastructure + WebAPI | Mock data, JSON dosyası, validator | Faz 1-2 |
+| 4 | Application | MediatR command/handler, DTO'lar | Faz 1-3 |
+| 5 | WebAPI | Controller, DI kaydı | Faz 1-4 |
+| 6 | Tests | Unit + integration + performans | Faz 1-5 |
+
+---
+
+## Dosya Ağacı — Geliştirme Sonrası Hedef Yapı
+
+```
+CargoPilot.Domain/
+└── Packing/
+    ├── ContainerSpec.cs
+    ├── ItemSpec.cs
+    ├── PackingParameters.cs
+    ├── ExtremePoint.cs
+    ├── Rotation.cs
+    ├── PlacedItem.cs
+    ├── PackingCandidate.cs
+    ├── PackingPlacement.cs
+    ├── PackingWarning.cs
+    ├── UnplacedItemResult.cs
+    ├── PackingResult.cs
+    └── IPackingEngine.cs
+
+CargoPilot.Infrastructure/
+└── Packing/
+    ├── PackingEngine.cs
+    ├── ItemSorter.cs
+    ├── GeometryHelper.cs
+    ├── CgCalculator.cs
+    ├── CostFunction.cs
+    ├── ExtremePointManager.cs
+    └── MockPackingDataProvider.cs
+
+CargoPilot.Application/
+└── Features/Packing/
+    ├── OptimizePacking/
+    │   ├── OptimizePackingCommand.cs
+    │   ├── OptimizePackingCommandHandler.cs
+    │   ├── OptimizePackingCommandValidator.cs
+    │   └── OptimizePackingWithMockDataCommand.cs
+    └── DTOs/
+        ├── ContainerSpecDto.cs
+        ├── ItemSpecDto.cs
+        ├── PackingParametersDto.cs
+        ├── PlacementDto.cs
+        ├── CgFinalDto.cs
+        ├── PackingWarningDto.cs
+        ├── UnplacedItemDto.cs
+        └── PackingResultDto.cs
+
+CargoPilot.WebAPI/
+├── Controllers/
+│   └── PackingController.cs
+└── MockData/
+    └── bin_packing_mock.json
+```
+
+---
+
+## Geliştirme Notları
+
+**Koordinat sistemi:** Doküman metreyle çalışır. `Item` entity'si mevcut durumda milimetre saklar. Mock data ve DTO'lar **metre** cinsinden olacak; gerekirse `InternalLength / 1000` dönüşümü API katmanında yapılır.
+
+**`PackingEngine` durumsuz:** Her `Optimize` çağrısı kendi lokal state'ini taşır; Singleton güvenli.
+
+**Epsilon:** Tüm geometrik karşılaştırmalarda `const double Epsilon = 1e-6` kullanılır.
+
+**Fallback uyarı kodu:** `"PACKING_CG_FALLBACK"`

--- a/apps/backend/docs/matematiksel_model.md
+++ b/apps/backend/docs/matematiksel_model.md
@@ -1,0 +1,443 @@
+# 3D Bin Packing — Matematiksel Model
+
+> **Durum: Tasarım arşivi — güncel implementasyonun birebir dokümantasyonu değildir.**
+>
+> Bu doküman `feature/3D_Packing_Algorithm` branch'inde (2026-05-05) üretildi. Branch, `test`'teki
+> `CargoPilot.Infrastructure/Services/OptimizationEngine.cs` implementasyonu tarafından geride
+> bırakıldığı için kapatılmaktadır; tasarım içeriği kaybolmasın diye doküman buraya taşınmıştır.
+>
+> Güncel kodla bilinen farklar:
+> - Koordinat ekseni adlandırması burada farklıdır. Güncel sözleşme: **X = genişlik, Y = yükseklik,
+>   Z = derinlik**, origin kutunun **sol-alt-arka** köşesi (`apps/frontend/.claude/CLAUDE.md`,
+>   `lib/config/scene-config.ts`).
+> - MediatR'a yapılan atıflar geçerli değildir; backend service-based yaklaşım kullanır
+>   (`apps/backend/docs/architecture.md`).
+> - `Packing/` klasörü ve `PackingEngine` sınıfı `test` branch'inde bulunmamaktadır.
+>
+> Algoritma çalışması yapılırken kavramsal referans olarak kullanılabilir; kod kaynağı olarak değil.
+
+---
+
+## 1. Küme ve Parametre Tanımları
+
+### 1.1 Konteyner
+
+```
+C = (L_c, W_c, H_c, W_max)
+```
+
+| Sembol | Açıklama | Birim |
+|---|---|---|
+| L_c | Konteyner uzunluğu (x ekseni, kapıdan içeriye) | metre |
+| W_c | Konteyner genişliği (y ekseni, sol→sağ) | metre |
+| H_c | Konteyner yüksekliği (z ekseni, alttan üste) | metre |
+| W_max | Maksimum yük kapasitesi | kg |
+
+**Koordinat sistemi:** Orijin (0,0,0) konteynırın kapı-sol-alt köşesidir. x ekseni kapıdan içeriye (0 = kapı, L_c = arka duvar), y ekseni soldan sağa, z ekseni alttan yukarıya artar.
+
+### 1.2 Ürün Kümesi
+
+```
+P = {P_1, P_2, ..., P_n}
+
+P_i = (l_i, w_i, h_i, mass_i, stackable_i, max_stack_i, lifo_i)
+```
+
+| Sembol | Açıklama | Tip |
+|---|---|---|
+| l_i | Uzunluk (x yönü, temel rotasyonda) | metre |
+| w_i | Genişlik (y yönü) | metre |
+| h_i | Yükseklik (z yönü) | metre |
+| mass_i | Ağırlık | kg |
+| stackable_i | Üstüne ürün konulabilir mi | boolean |
+| max_stack_i | Üstünde taşıyabileceği maksimum ağırlık | kg (∞ = sınırsız) |
+| lifo_i | LIFO sırası (1 = ilk çıkacak, n = son çıkacak) | tam sayı ∣ null |
+
+### 1.3 Sistem Parametreleri
+
+```
+θ = (eşik_CG, lifo_aktif, EP_max)
+```
+
+| Sembol | Açıklama | Varsayılan |
+|---|---|---|
+| eşik_CG | İzin verilen maksimum CG sapması (%) | 15 |
+| lifo_aktif | LIFO modunun aktif olup olmadığı | false |
+| EP_max | Boşluk kalitesi normalizasyonu için referans EP sayısı | 20 |
+
+---
+
+## 2. Rotasyon Modeli
+
+Her ürün P_i için 6 olası rotasyon tanımlanır. Her rotasyon (l_r, w_r, h_r) üçlüsüdür:
+
+```
+R_i = {
+  r1: (l_i,  w_i,  h_i),
+  r2: (l_i,  h_i,  w_i),
+  r3: (w_i,  l_i,  h_i),
+  r4: (w_i,  h_i,  l_i),
+  r5: (h_i,  l_i,  w_i),
+  r6: (h_i,  w_i,  l_i)
+}
+```
+
+Yerleştirmede kullanılan efektif boyutlar (l_r, w_r, h_r) seçili rotasyona göre belirlenir.
+
+---
+
+## 3. Sıralama Katmanı
+
+Sıralama, EP motoruna ürünlerin hangi sırayla verileceğini belirler. Hacim her zaman temel sıralama kriteridir. LIFO aktifse sıralama değişir.
+
+### 3.1 LIFO Kapalı
+
+```
+sıra = sort(P, key = V_i, order = DESC)
+
+V_i = l_i × w_i × h_i
+```
+
+Hacim büyükten küçüğe sıralama (First Fit Decreasing — sektör standardı).
+
+### 3.2 LIFO Aktif
+
+```
+sıra = sort(P, key = lifo_i, order = DESC)
+```
+
+Yüksek LIFO indeksi = konteynıra önce girer = konteynırın gerisine yerleşir = en son çıkar.
+Düşük LIFO indeksi = konteynıra sonra girer = kapıya yakın yerleşir = ilk çıkar.
+
+**Not:** lifo_i = null olan ürünler LIFO kuyruğunun sonuna eklenir ve kendi aralarında hacme göre sıralanır.
+
+---
+
+## 4. Extreme Point (EP) Modeli
+
+### 4.1 EP Tanımı
+
+Extreme Point, mevcut yerleştirmeler sonucu oluşan ve yeni bir ürünün potansiyel olarak konulabileceği köşe koordinatıdır.
+
+**Başlangıç durumu:**
+```
+EP_0 = {(0, 0, 0)}
+```
+
+### 4.2 EP Üretimi
+
+P_i ürünü (x_a, y_a, z_a) konumuna (l_r, w_r, h_r) rotasyonuyla yerleştirildikten sonra üç yeni EP üretilir:
+
+```
+EP_yeni = {
+  (x_a + l_r,  y_a,         z_a),    ← sağ köşe
+  (x_a,        y_a + w_r,   z_a),    ← ön köşe
+  (x_a,        y_a,         z_a + h_r)  ← üst köşe
+}
+```
+
+### 4.3 Dominance Filtresi
+
+EP listesinin büyümesini önlemek için dominance filtresi uygulanır. EP_p, EP_q'ya dominedir ve EP_q listeden çıkarılır:
+
+```
+dominant(EP_p, EP_q) ←→ x_p ≥ x_q  AND  y_p ≥ y_q  AND  z_p ≥ z_q  AND  EP_p ≠ EP_q
+```
+
+Dominant EP'ler erişilemez konumlardır — başka bir ürün zaten önlerini kapatmıştır.
+
+---
+
+## 5. Fiziksel Geçerlilik Kontrolleri
+
+Bir (EP, rotasyon) adayı üç fiziksel kontrolü sırasıyla geçmelidir.
+
+### 5.1 Konteyner Sınırı
+
+```
+x_a + l_r ≤ L_c
+y_a + w_r ≤ W_c
+z_a + h_r ≤ H_c
+```
+
+### 5.2 Çakışma Kontrolü (AABB)
+
+Yerleşik her P_j ürünüyle eksen hizalı sınır kutusu (Axis-Aligned Bounding Box) kesişim testi:
+
+```
+çakışmaz(a, j) ←→
+  x_a + l_r ≤ x_j  OR  x_j + l_j ≤ x_a  OR
+  y_a + w_r ≤ y_j  OR  y_j + w_j ≤ y_a  OR
+  z_a + h_r ≤ z_j  OR  z_j + h_j ≤ z_a
+
+geçer ←→ ∀ P_j ∈ yerleşik: çakışmaz(a, j)
+```
+
+### 5.3 Zemin Desteği
+
+Ürünün alt yüzeyinin en az %80'i desteklenmiş olmalıdır (zemin veya altındaki ürünün üst yüzeyi):
+
+```
+destek_alanı = alan(alt_yüzey ∩ (zemin ∪ ⋃ üst_yüzey(P_j)))
+
+destek_oranı = destek_alanı / (l_r × w_r)
+
+geçer ←→ destek_oranı ≥ 0.80
+```
+
+### 5.4 İstif Kontrolü
+
+```
+altındaki_ürün = {P_j | P_j.z + P_j.h_j = z_a  AND  alanlar_kesişiyor(a, j)}
+
+geçer ←→ ∀ P_j ∈ altındaki_ürün:
+  P_j.stackable = true  AND
+  mevcut_yük(P_j) + mass_i ≤ P_j.max_stack
+```
+
+---
+
+## 6. Hard Constraint — Ağırlık Dengesi
+
+### 6.1 Ağırlık Merkezi (İnkremental Güncelleme)
+
+n. ürün yerleştirildikten sonra ağırlık merkezi:
+
+```
+M(n) = M(n-1) + mass_n
+
+CG_x(n) = (CG_x(n-1) × M(n-1) + cx_n × mass_n) / M(n)
+CG_y(n) = (CG_y(n-1) × M(n-1) + cy_n × mass_n) / M(n)
+CG_z(n) = (CG_z(n-1) × M(n-1) + cz_n × mass_n) / M(n)
+```
+
+Burada cx_n, cy_n, cz_n ürünün geometrik merkezi:
+
+```
+cx_n = x_a + l_r / 2
+cy_n = y_a + w_r / 2
+cz_n = z_a + h_r / 2
+```
+
+**Başlangıç:** CG_x(0) = L_c/2, CG_y(0) = W_c/2, CG_z(0) = 0, M(0) = 0
+
+### 6.2 Sapma Hesabı
+
+Bu adayı yerleştirirsem oluşacak geçici CG:
+
+```
+M_temp = M(n-1) + mass_i
+
+CG_x_temp = (CG_x(n-1) × M(n-1) + cx_aday × mass_i) / M_temp
+CG_y_temp = (CG_y(n-1) × M(n-1) + cy_aday × mass_i) / M_temp
+
+δ_x = |CG_x_temp − L_c/2| / (L_c/2) × 100   (yüzde)
+δ_y = |CG_y_temp − W_c/2| / (W_c/2) × 100   (yüzde)
+```
+
+### 6.3 Hard Constraint Karar Kuralı
+
+```
+hard_constraint_geçer(aday) ←→
+  δ_x ≤ eşik_CG  AND  δ_y ≤ eşik_CG
+```
+
+Bu koşulu sağlamayan aday, maliyet fonksiyonuna girmeden elenir.
+
+---
+
+## 7. Maliyet Fonksiyonu
+
+Yalnızca hard constraint filtresini geçmiş adaylara uygulanır.
+
+### 7.1 Terimler
+
+**Zemin yakınlığı:**
+```
+f_zemin(a) = 1 − (z_a / H_c)
+```
+z=0 → f_zemin=1.0 (en iyi), z=H_c → f_zemin=0.
+
+**Boşluk kalitesi:**
+```
+f_boşluk(a) = 1 − (|EP_listesi_sonrası(a)| / EP_max)
+```
+Bu adayı yerleştirirsem EP listesi kaç elemana çıkar? Az EP = az parçalanmış boşluk = yüksek kalite. EP_max = 20 (normalleştirme sabiti).
+
+**LIFO uyumu** (yalnızca lifo_aktif = true ve P_i.lifo_i ≠ null ise):
+```
+x_ideal_i = (1 − lifo_i / lifo_max) × L_c
+
+f_lifo(a) = 1 − |x_a − x_ideal_i| / L_c
+```
+lifo_i = 1 (ilk çıkacak) → x_ideal = 0 (kapıya yakın)
+lifo_i = lifo_max (son çıkacak) → x_ideal = L_c (konteynır gerisi)
+
+### 7.2 Ağırlık Vektörü
+
+```
+w_zemin  = 0.15   (her zaman sabit)
+
+lifo_aktif = false:
+  w_boşluk = 0.85
+  w_lifo   = 0.00
+
+lifo_aktif = true:
+  w_boşluk = 0.425
+  w_lifo   = 0.425
+```
+
+### 7.3 Toplam Skor
+
+```
+Maliyet(a) = w_zemin  × f_zemin(a)
+           + w_boşluk × f_boşluk(a)
+           + w_lifo   × f_lifo(a)
+```
+
+---
+
+## 8. Aday Seçim Kuralı
+
+### 8.1 Normal Durum
+
+```
+G = {a ∈ A_tüm | hard_constraint_geçer(a) = true}
+
+G ≠ ∅  →  a* = argmax_{a ∈ G} Maliyet(a)
+```
+
+### 8.2 Fallback Durumu
+
+```
+G = ∅  →  a* = argmin_{a ∈ A_tüm} (δ_x(a) + δ_y(a))
+
+uyarı_ekle(P_i, δ_x(a*), δ_y(a*),
+           "hard constraint sağlanamadı, en az ihlal eden seçildi")
+```
+
+---
+
+## 9. Ana Döngü — Pseudocode
+
+```
+INPUT:  C, P, θ
+OUTPUT: Sonuç
+
+sıralı_liste ← sırala(P, θ.lifo_aktif)
+EP_listesi   ← {(0, 0, 0)}
+yerleşimler  ← []
+uyarılar     ← []
+yerleşmeyen  ← []
+CG           ← (L_c/2, W_c/2, 0)
+M_toplam     ← 0
+
+FOR P_i IN sıralı_liste:
+
+  A_geçerli ← []
+  A_tüm     ← []
+
+  FOR ep IN EP_listesi:
+    FOR r IN R_i:   // 6 rotasyon
+      a ← (ep, r)
+
+      // Fiziksel kontroller
+      IF NOT konteyner_sınırı(a, C):   CONTINUE
+      IF NOT çakışma_yok(a, yerleşimler): CONTINUE
+      IF NOT zemin_desteği(a, yerleşimler): CONTINUE
+      IF NOT istif_geçerli(a, yerleşimler, P_i): CONTINUE
+
+      // CG geçici hesap
+      δ_x, δ_y ← hesapla_sapma(a, CG, M_toplam, P_i, C)
+      a.δ_x ← δ_x
+      a.δ_y ← δ_y
+
+      A_tüm.ekle(a)
+
+      IF δ_x ≤ θ.eşik_CG AND δ_y ≤ θ.eşik_CG:
+        A_geçerli.ekle(a)
+
+  IF A_geçerli boş değil:
+    a* ← argmax_{a ∈ A_geçerli} Maliyet(a)
+
+  ELSE IF A_tüm boş değil:
+    a* ← argmin_{a ∈ A_tüm} (a.δ_x + a.δ_y)
+    uyarılar.ekle(P_i, a*.δ_x, a*.δ_y)
+
+  ELSE:
+    // Hiçbir EP'ye sığmıyor — boyut veya fiziksel kısıt
+    yerleşmeyen.ekle(P_i)
+    CONTINUE
+
+  // Yerleştir
+  yerleşimler.ekle((P_i, a*.ep, a*.r))
+  CG, M_toplam ← güncelle_CG(CG, M_toplam, a*, P_i)
+  EP_listesi ← güncelle_EP(EP_listesi, a*, P_i)
+  EP_listesi ← dominance_filtresi(EP_listesi)
+
+RETURN Sonuç(yerleşimler, CG, M_toplam, uyarılar, yerleşmeyen)
+```
+
+---
+
+## 10. Çıktı Yapısı
+
+```
+Sonuç = {
+  yerleşimler: [
+    {
+      urun_id:   string,
+      x:         float,   // konteynır koordinatı
+      y:         float,
+      z:         float,
+      rotasyon:  (l_r, w_r, h_r)
+    },
+    ...
+  ],
+
+  CG_final: {
+    x: float,   // metre
+    y: float,
+    z: float,
+    δ_x: float, // yüzde — ön/arka sapma
+    δ_y: float  // yüzde — sol/sağ sapma
+  },
+
+  toplam_agirlik: float,   // kg
+  doluluk_orani:  float,   // yüzde (yerleşen ürünler hacmi / C hacmi)
+
+  uyarilar: [
+    {
+      urun_id: string,
+      δ_x:     float,
+      δ_y:     float,
+      mesaj:   string
+    },
+    ...
+  ],
+
+  yerlesmeyen: [
+    {
+      urun_id: string,
+      sebep:   string  // "boyut aşımı" | "fiziksel kısıt" | "istif ihlali"
+    },
+    ...
+  ]
+}
+```
+
+---
+
+## 11. Karmaşıklık Analizi
+
+| Adım | Karmaşıklık | Açıklama |
+|---|---|---|
+| Sıralama | O(n log n) | Tek kriter, standart sort |
+| EP başına aday üretimi | O(\|EP\| × 6) | 6 rotasyon × EP sayısı |
+| Çakışma kontrolü | O(k) | k = yerleşik ürün sayısı |
+| Hard constraint | O(1) | Sabit hesap |
+| Maliyet fonksiyonu | O(1) | Sabit hesap |
+| Dominance filtresi | O(\|EP\|²) | Her EP çifti karşılaştırması |
+| **Toplam (n ürün)** | **O(n² × \|EP\|²)** | Pratik: EP listesi küçük kalır |
+
+Pratik performans: EP listesi dominance filtresi sayesinde genellikle 10–30 eleman arasında kalır. n = 100 ürün için tipik çalışma süresi < 1 saniye.

--- a/apps/backend/docs/sistem_mimarisi.md
+++ b/apps/backend/docs/sistem_mimarisi.md
@@ -1,0 +1,348 @@
+# 3D Bin Packing — Sistem Mimarisi ve Gereksinim Dokümantasyonu
+
+> **Durum: Tasarım arşivi — güncel implementasyonun birebir dokümantasyonu değildir.**
+>
+> Bu doküman `feature/3D_Packing_Algorithm` branch'inde (2026-05-05) üretildi. Branch, `test`'teki
+> `CargoPilot.Infrastructure/Services/OptimizationEngine.cs` implementasyonu tarafından geride
+> bırakıldığı için kapatılmaktadır; tasarım içeriği kaybolmasın diye doküman buraya taşınmıştır.
+>
+> Güncel kodla bilinen farklar:
+> - Koordinat ekseni adlandırması burada farklıdır. Güncel sözleşme: **X = genişlik, Y = yükseklik,
+>   Z = derinlik**, origin kutunun **sol-alt-arka** köşesi (`apps/frontend/.claude/CLAUDE.md`,
+>   `lib/config/scene-config.ts`).
+> - MediatR'a yapılan atıflar geçerli değildir; backend service-based yaklaşım kullanır
+>   (`apps/backend/docs/architecture.md`).
+> - `Packing/` klasörü ve `PackingEngine` sınıfı `test` branch'inde bulunmamaktadır.
+>
+> Algoritma çalışması yapılırken kavramsal referans olarak kullanılabilir; kod kaynağı olarak değil.
+
+---
+
+## 1. Problem Tanımı
+
+Boyutları ve ağırlıkları bilinen ürünlerin, boyutları ve kapasitesi tanımlanmış bir konteyner veya araca optimum şekilde yerleştirilmesi gerekiyor. Sistem, yerleştirme sırasında fiziksel kısıtları (çakışma, boyut sınırı, zemin desteği, istif kuralları) zorunlu olarak sağlamalı; ağırlık dengesini her durumda aktif bir kısıt olarak izlemeli ve LIFO erişim sıralaması opsiyonel olarak desteklemelidir.
+
+Bu problem NP-Hard sınıfında Constrained 3D Bin Packing Problem (3D-BPP) olarak tanımlanır. Tek bir konteyner (sabit bin) ve değişken ürün kümesi söz konusudur.
+
+---
+
+## 2. Seçilen Algoritma Yaklaşımı
+
+**Hibrit Extreme Point (EP) tabanlı yerleştirici.**
+
+İki bağımsız katmandan oluşur:
+
+**Katman A — Sıralama motoru:** EP motoruna ürünlerin hangi sırayla verileceğini belirler. Strateji: hacim büyükten küçüğe (First Fit Decreasing). LIFO aktifse sıralama LIFO indeksine göre değişir.
+
+**Katman B — EP motoru:** Her ürün için geçerli yerleştirme konumlarını (Extreme Point + rotasyon kombinasyonları) üretir, fiziksel kontrolleri uygular, CG hard constraint filtresinden geçirir ve maliyet fonksiyonu ile en iyi konumu seçer.
+
+### Neden bu yaklaşım?
+
+| Alternatif | Neden seçilmedi |
+|---|---|
+| Genetik algoritma | 10–60 sn yakınsama, gerçek zamanlı kullanıma uygun değil |
+| Deep Reinforcement Learning | Eğitim altyapısı gerektirir, kararlar açıklanamaz |
+| Layer-by-layer | Hacim verimliliği düşük |
+| Sadece zone-based denge | Bölge içi CG kaymasını görmez, dinamik değil |
+
+EP yaklaşımı gerçek zamanlı çalışır, tüm kısıtları tek döngüye entegre eder ve sektörde CargoWiz, Cube-IQ, LoadXpert gibi ticari yazılımların çekirdeğinde kullanılır.
+
+---
+
+## 3. Sistem Girdileri
+
+### 3.1 Konteyner / Araç Tanımı
+
+```
+{
+  uzunluk:          float,   // metre — x ekseni (kapı → arka)
+  genislik:         float,   // metre — y ekseni (sol → sağ)
+  yukseklik:        float,   // metre — z ekseni (alt → üst)
+  max_yuk:          float,   // kg — toplam ağırlık kapasitesi
+  arac_tipi:        enum     // "konteyner" | "tir" | "platform"
+}
+```
+
+**Koordinat sistemi:** Orijin (0,0,0) konteynırın kapı-sol-alt köşesidir. x=0 kapı, x=uzunluk arka duvardır.
+
+### 3.2 Ürün Listesi
+
+Her ürün için:
+
+```
+{
+  id:           string,
+  uzunluk:      float,    // metre
+  genislik:     float,    // metre
+  yukseklik:    float,    // metre
+  agirlik:      float,    // kg
+  istiflenebilir: boolean,  // üstüne ürün konulabilir mi
+  max_istif:    float,    // kg — üstünde taşıyabileceği max ağırlık (null = sınırsız)
+  lifo_index:   int       // null = LIFO dışı ürün
+}
+```
+
+### 3.3 Kullanıcı Parametreleri
+
+```
+{
+  lifo_aktif:   boolean,  // LIFO modunu etkinleştir
+  cg_esik:      float     // ağırlık dengesi toleransı (%, default: 15)
+}
+```
+
+**Önemli:** Hacim optimizasyonu bir kullanıcı seçeneği değildir — her zaman aktiftir ve algoritmanın doğasında bulunur. Kullanıcı yalnızca LIFO'yu açıp kapayabilir ve CG eşiğini ayarlayabilir.
+
+---
+
+## 4. Sistem Mimarisi — Katmanlar ve Sorumluluklar
+
+### 4.1 Girdi Doğrulama Katmanı
+
+Algoritma çalışmadan önce zorunlu kontroller:
+
+- Tüm boyutlar pozitif sayı mı?
+- Toplam ürün ağırlığı konteyner kapasitesini aşıyor mu? (aşıyorsa uyarı, devam et)
+- LIFO indeksleri unique mi? (çakışma varsa hata döndür)
+- lifo_aktif = true ama hiçbir ürünün lifo_index'i yok mu? (uyarı ver)
+
+### 4.2 Sıralama Katmanı (Katman A)
+
+**LIFO kapalıyken:**
+Ürünler hacim büyükten küçüğe sıralanır. Bu First Fit Decreasing (FFD) standardıdır ve EP motoruna en büyük ürünü önce vererek konteynırın ana blok yapısını erken oluşturur — sonraki küçük ürünler boşluklara dolar.
+
+**LIFO açıkken:**
+Ürünler LIFO indeksine göre büyükten küçüğe sıralanır (yüksek index = konteynıra önce girer = konteynır gerisine yerleşir = en son çıkar). lifo_index = null olan ürünler kuyruğun sonuna eklenir ve kendi aralarında hacme göre sıralanır.
+
+**Kritik:** Ağırlık hiçbir zaman sıralama kriteri değildir. Ağırlık dengesi EP motorunun CG hard constraint mekanizması tarafından yönetilir.
+
+### 4.3 EP Motoru — Aday Üretimi (Katman B)
+
+Her ürün için şu adımlar sırayla çalışır:
+
+**Adım 1 — Aday üretimi:**
+Mevcut EP listesindeki her nokta için 6 rotasyon denenir. Her (EP, rotasyon) çifti bir aday oluşturur.
+
+**Adım 2 — Fiziksel kontroller (sırasıyla):**
+1. Konteyner sınırı: ürün konteynır dışına taşıyor mu?
+2. Çakışma kontrolü: yerleşik ürünlerle AABB kesişimi var mı?
+3. Zemin desteği: alt yüzeyin en az %80'i destekleniyor mu?
+4. İstif kontrolü: altındaki ürün istiflenebilir mi, max yük aşılıyor mu?
+
+Bu dört kontrolden birini geçemeyen aday doğrudan elenir.
+
+**Adım 3 — Hard constraint filtresi (CG kontrolü):**
+Fiziksel kontrolü geçen her aday için "bu adayı yerleştirirsem ağırlık merkezi nereye gider?" hesaplanır. CG sapması (hem ön-arka hem sol-sağ ekseninde) kullanıcının belirlediği eşiği aşıyorsa aday elenir.
+
+**Adım 4 — Maliyet fonksiyonu:**
+Hard constraint'i geçen adaylar maliyet skoru ile değerlendirilir. En yüksek skorlu aday seçilir.
+
+**Adım 5 — Fallback:**
+Hiçbir aday hard constraint'i geçemediyse — tüm adaylar CG eşiğini aşıyorsa — en az ihlal eden seçilir ve uyarı üretilir.
+
+**Adım 6 — Hiçbir EP'ye sığmıyorsa:**
+Ürün fiziksel olarak konteyner içine sığmıyorsa "yerleştirilemeyen" listesine alınır, algoritma bir sonraki ürüne geçer.
+
+### 4.4 Maliyet Fonksiyonu
+
+```
+Maliyet(aday) = 0.15 × zemin_yakınlığı(aday)
+              + w_boşluk × boşluk_kalitesi(aday)
+              + w_lifo   × lifo_uyumu(aday)
+```
+
+**Ağırlıklar:**
+
+| LIFO durumu | w_boşluk | w_lifo |
+|---|---|---|
+| LIFO kapalı | 0.85 | 0.00 |
+| LIFO açık | 0.425 | 0.425 |
+
+**Zemin yakınlığı:** `1 − (z / H_c)` — ürün ne kadar altta olursa skor o kadar yüksek.
+
+**Boşluk kalitesi:** `1 − (EP_sonrası / 20)` — bu adayı koyarsam EP listesi kaç elemana çıkar? Az EP = boşluk az parçalandı = iyi.
+
+**LIFO uyumu:** Ürünün LIFO indeksine göre hesaplanan ideal x pozisyonuna ne kadar yakın? `1 − |x_aday − x_ideal| / L_c`
+
+**Önemli:** Ağırlık dengesi maliyet fonksiyonunda değildir. CG hard constraint adım 3'te aday eleme yapar; maliyet fonksiyonu yalnızca hayatta kalan adayları sıralar.
+
+### 4.5 CG Monitör
+
+Her ürün yerleştirildikten sonra ağırlık merkezi inkremental olarak güncellenir. Bu güncelleme hem bir sonraki adımın CG hesabı için gereklidir hem de nihai çıktı raporuna dahil edilir.
+
+---
+
+## 5. Kısıtlar ve Öncelik Sırası
+
+Tüm kısıtlar iki kategoriye ayrılır:
+
+### 5.1 Hard Constraints — Asla İhlal Edilemez
+
+1. Konteyner sınırı aşılamaz
+2. Ürünler birbirine geçemez (çakışma)
+3. Zemin desteği %80 altına düşemez
+4. `stackable = false` olan ürünün üstüne ürün konulamaz
+5. `max_stack` değeri aşılamaz
+6. CG sapması eşik değerini aşan konuma yerleştirme yapılamaz (fallback hariç)
+
+### 5.2 Soft Objectives — Optimize Edilir
+
+1. Hacim verimliliği (boşluk kalitesi terimi)
+2. LIFO erişim sırası uyumu
+3. Zemin yakınlığı
+
+### 5.3 Çakışan Kısıt Senaryoları
+
+**LIFO + CG çakışması:**
+LIFO indeksi 1 olan ürün kapıya yakın olmak zorundadır ama ağır bir ürünse CG bunu engelliyor olabilir. Bu durumda CG hard constraint uygulanır — LIFO ideal pozisyon sağlanamıyorsa fallback devreye girer ve uyarı üretilir. LIFO sırası bozulmaz ama pozisyon idealsizleşebilir.
+
+**İstif kuralı + hacim verimliliği çakışması:**
+`stackable = false` olan büyük bir ürün her zaman üst katmana yerleşir, üstüne hiçbir şey konulamaz. Bu hacim verimliliğini düşürür. Kabul edilir bir durumdur, raporda doluluk oranı düşük olarak gösterilir.
+
+**Hiçbir konum CG'yi sağlamıyorsa:**
+Fallback mekanizması devreye girer. Bu durum yükün yapısal olarak dengelenememesi anlamına gelir; uyarı üretilir ve operatöre bildirilir.
+
+---
+
+## 6. Araç Tipi Davranış Farkları
+
+| Araç tipi | CG kontrolü | Aks hesabı | Notlar |
+|---|---|---|---|
+| Konteyner (statik) | Opsiyonel | Yok | Hareket yok, CG zorunlu değil |
+| Tır / dorse | Zorunlu | Ön/arka aks | VDI 2700 uyumu gerekir |
+| Platform araç | Zorunlu | Tüm akslar | Aks pozisyonları tanımlanmalı |
+
+**Taşımacılık senaryolarında** (tır, platform) CG hard constraint kapatılamaz — yalnızca eşik değeri ayarlanabilir.
+
+**Statik depo senaryosunda** CG kontrolü opsiyoneldir.
+
+---
+
+## 7. Sistem Çıktıları
+
+### 7.1 Başarılı Yerleşim
+
+```
+{
+  yerlesimler: [
+    {
+      urun_id:   string,
+      x:         float,   // konteynır koordinatı (köşe noktası)
+      y:         float,
+      z:         float,
+      rotasyon:  {l: float, w: float, h: float}
+    }
+  ],
+  cg_final: {
+    x:    float,   // metre
+    y:    float,
+    z:    float,
+    d_x:  float,   // ön-arka sapma yüzdesi
+    d_y:  float    // sol-sağ sapma yüzdesi
+  },
+  toplam_agirlik: float,
+  doluluk_orani:  float    // yüzde
+}
+```
+
+### 7.2 Uyarılar
+
+Her fallback tetiklendiğinde:
+
+```
+{
+  urun_id:   string,
+  d_x:       float,
+  d_y:       float,
+  mesaj:     "CG eşiği sağlanamadı — en az ihlal eden konum seçildi"
+}
+```
+
+CG sapması eşiği geçtiğinde (genel):
+
+```
+{
+  mesaj:   "Yük dengesi eşik aşıldı",
+  d_x:     float,
+  d_y:     float,
+  yön:     "arka ağır" | "ön ağır" | "sağ ağır" | "sol ağır"
+}
+```
+
+### 7.3 Yerleştirilemeyen Ürünler
+
+```
+{
+  urun_id:  string,
+  sebep:    "boyut aşımı" | "fiziksel kısıt" | "istif ihlali" | "kapasite aşımı"
+}
+```
+
+---
+
+## 8. Performans Gereksinimleri
+
+- n ≤ 50 ürün: < 500ms
+- n ≤ 100 ürün: < 2 saniye
+- n ≤ 200 ürün: < 10 saniye
+- EP listesi dominance filtresi ile 10–30 eleman arasında tutulmalı
+- Çakışma kontrolü AABB testi ile O(k) — k yerleşik ürün sayısı
+
+---
+
+## 9. Sınırlamalar ve Bilinen Kısıtlar
+
+**Lokal optimum riski:**
+EP algoritması ileriye bakmaz (greedy). Sıralama yanlışsa veya erken yerleştirmeler kötü EP'ler üretirse sonuç lokal optimumda takılabilir. Küresel optimum garantisi yoktur — bu sektördeki tüm gerçek zamanlı yerleştirici algoritmalar için geçerlidir.
+
+**Rotasyon kısıtı yok:**
+Şu anki modelde 6 rotasyonun tümü denenir. Belirli ürünlerin belirli rotasyonlarda taşınması gerekiyorsa (örneğin "bu ürün yatırılamaz") ürün tanımına `izinli_rotasyonlar` parametresi eklenmeli ve rotasyon döngüsü buna göre filtrelenmelidir.
+
+**Aks hesabı:**
+Aks dengesi (ön aks / arka aks yük dağılımı) bu modelde CG_x üzerinden dolaylı olarak yönetilir. Aks pozisyonları ve maksimum aks kapasitesi tanımlanmışsa ek bir aks kontrolü hard constraint katmanına eklenmelidir.
+
+**Çok konteyner desteği:**
+Bu model tek konteyner (single bin) için tasarlanmıştır. Birden fazla konteynıra dağıtım (multi-bin packing) ayrı bir dış döngü gerektirir.
+
+---
+
+## 10. Implementasyon Direktifleri
+
+### 10.1 Veri Yapıları
+
+```
+EP listesi:     min-heap (z'ye göre, düşük z önce)
+Yerleşik ürünler: spatial index (R-tree veya grid) — çakışma testi için
+Aday listesi:   max-heap (maliyet skoruna göre)
+```
+
+### 10.2 Kritik Implementasyon Notları
+
+**EP üretimi:** Her yerleştirmeden sonra 3 yeni EP üretilir. Dominance filtresi hemen uygulanır. EP listesi 30'u geçerse en düşük skorlu EP'ler temizlenir.
+
+**CG inkremental:** Her yerleştirmeden sonra CG güncellenir. Tüm liste baştan hesaplanmaz. Formül: `CG_yeni = (CG_eski × M_eski + cx_yeni × mass_yeni) / (M_eski + mass_yeni)`
+
+**Floating point:** Tüm geometrik karşılaştırmalarda epsilon toleransı kullanılmalı (ε = 1e-6). İki yüzeyin tam üst üste olup olmadığı testi `|z1 - z2| < ε` şeklinde yapılmalı.
+
+**Zemin desteği:** Alt yüzey kesişim alanı hesabı dikdörtgen kesişimi ile yapılır. Her iki boyutta min/max karşılaştırması yeterlidir.
+
+### 10.3 Test Senaryoları
+
+Implementasyon doğruluğu için minimum test kümesi:
+
+1. **Tek ürün:** Konteyner boyutuna tam sığan bir ürün → x=0, y=0, z=0'a yerleşmeli
+2. **İki ürün yan yana:** İkisi birlikte konteyner genişliğini dolduruyor → çakışma olmamalı
+3. **İstif:** stackable=false ürünün üstüne ürün konulmamalı
+4. **CG ihlali fallback:** Tüm adaylar CG'yi bozuyorsa uyarı üretilmeli
+5. **LIFO sırası:** lifo_index=1 olan ürün en düşük x koordinatına sahip olmalı
+6. **Sığmayan ürün:** Konteynırdan büyük ürün yerleştirilemeyen listesine girmeli
+7. **Doluluk oranı:** 10 birim küp ürün, 100 birim küp konteyner → %10 doluluk
+
+---
+
+## 11. Referans Standartlar
+
+- **VDI 2700:** Kara taşımacılığında yük emniyeti — CG toleransı referansı
+- **EUMOS 40509:** Yük testi ve denge standartları
+- **First Fit Decreasing (FFD):** Bin packing sıralama standardı
+- **AABB collision detection:** Gerçek zamanlı çakışma testi standardı


### PR DESCRIPTION
`dev`'e #888 ile merge edildi, aynı branch'ten `test`'e açılıyor (branching kuralı).

## Özet

Silinen `feature/3D_Packing_Algorithm` branch'indeki **1.160 satırlık algoritma tasarım dokümanı** korunuyor:

- `apps/backend/docs/matematiksel_model.md` (425) — 3D-BPP matematiksel modeli
- `apps/backend/docs/sistem_mimarisi.md` (330) — hibrit Extreme Point yaklaşımı, kısıt katmanları
- `apps/backend/docs/bin_packing_implementation_plan.md` (405) — faz bazlı geliştirme planı

Sadece doküman; kod değişikliği yok.

Her dosyanın başında "tasarım arşivi" durum notu var: koordinat ekseni güncel sözleşmeden farklı, MediatR atıfları geçersiz, `PackingEngine` `test`'te yok. Kavramsal referans olarak kullanılır, kod kaynağı olarak değil.

## Değişiklik Tipi

- [x] 📄 Dokümantasyon

## Test Edildi mi?

- [x] Doküman değişikliği — kod etkisi yok

## Kontrol Listesi

- [x] Commit mesajları commit kurallarına uygun
- [x] Self-review yapıldı