### PR TITLE
docs: proje bağlam kütüphanesi (docs/context)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,6 +12,14 @@
 * [Branching Strategy](docs/conventions/BRANCHING.md)
 * [Commit Kuralları](docs/conventions/COMMITS.md)
 
+## 🧭 Proje Bağlamı
+
+* [Bağlam Kütüphanesi](docs/context/README.md)
+* [Proje Anlık Görüntüsü](docs/context/project-snapshot.md)
+* [Doküman Haritası](docs/context/doc-map.md)
+* [Branch & PR Denetimi](docs/context/branch-audit.md)
+* [Branch Stratejisi Önerisi](docs/context/branching-proposal.md)
+
 ## 🛠️ DevOps
 
 * [Sunucu Gereksinimleri](docs/devops/server-requirements.md)

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1,0 +1,32 @@
+# Proje Bağlam Kütüphanesi (context)
+
+Bu klasör, repodaki tüm dokümanların **özetlenmiş halini** tutar. Amaç: bir soruya cevap
+vermek için 25 ayrı `.md` dosyasını baştan okumak zorunda kalmamak.
+
+## Kullanım Kuralı
+
+1. Önce `project-snapshot.md` okunur — teknik gerçekler, ortamlar, portlar, açık riskler.
+2. Detay gerekiyorsa `doc-map.md`'den **hangi dosyanın** okunacağı bulunur, sadece o dosya açılır.
+3. Branch / PR durumu için `branch-audit.md`.
+4. Branch stratejisi tartışması için `branching-proposal.md`.
+
+## İçindekiler
+
+| Dosya | İçerik | Ne zaman okunur |
+|-------|--------|-----------------|
+| [project-snapshot.md](project-snapshot.md) | Stack, ortamlar, portlar, CI/CD, açık riskler — tek sayfa | Her oturum başında |
+| [doc-map.md](doc-map.md) | Repodaki 25 `.md` dosyasının haritası + özeti | "Bu bilgi nerede yazıyor?" sorusunda |
+| [branch-audit.md](branch-audit.md) | 30 remote branch + açık PR analizi, temizlik kararları | Branch/PR temizliği yaparken |
+| [branching-proposal.md](branching-proposal.md) | 5 kişilik ekip için önerilen branch stratejisi | Strateji kararı alınırken |
+
+## Güncelleme Sorumluluğu
+
+| Tetikleyici | Güncellenecek dosya |
+|-------------|---------------------|
+| Yeni `.md` eklendi / silindi | `doc-map.md` |
+| Ortam, port, servis, CI değişti | `project-snapshot.md` |
+| Branch temizliği yapıldı | `branch-audit.md` (karar sütunu → uygulandı) |
+| Branch stratejisi değişti | `branching-proposal.md` + `docs/conventions/BRANCHING.md` |
+
+> Bu klasör kaynak değil, **indeks**tir. Çelişki durumunda orijinal doküman geçerlidir;
+> çelişki bulunursa bu klasör düzeltilir.

--- a/docs/context/branch-audit.md
+++ b/docs/context/branch-audit.md
@@ -1,0 +1,178 @@
+# Branch & PR Denetimi
+
+**Tarih:** 2026-08-03 · **Referans:** `origin/test` @ `3c42f65a`
+**Durum:** 🔍 Analiz — **hiçbir branch silinmedi, hiçbir PR kapatılmadı.** Bu doküman karar önerisidir.
+
+---
+
+## 1. Özet
+
+| Ölçüt | Değer |
+|-------|------:|
+| Remote branch | 29 |
+| Uzun ömürlü branch | 3 (`main`, `test`, `dev`) |
+| İş branch'i | 26 |
+| Açık PR | 2 (ikisi de aynı branch'ten, ikisi de CONFLICTING) |
+| En eski açık branch | 2026-04-28 (97 gün) |
+| Doğrudan silinebilir (içeriği `test`'te) | 7 |
+| Eskimiş / yerini almış, silinebilir | 11 |
+| Silinebilir ama işi backlog'a taşınmalı | 4 |
+| **Kurtarılması gereken gerçek iş** | **4** |
+
+**Kritik bulgu:** `dev` branch'inde `test`'te olmayan bir refresh-token güvenlik düzeltmesi var (§3).
+
+---
+
+## 2. Açık PR'lar
+
+| PR | Branch | Hedef | Durum | Öneri |
+|----|--------|-------|-------|-------|
+| #835 | `feature/US-XXX-coklu-arac` | `test` | CONFLICTING · 49 dosya · +4184/−671 | **Kapat** |
+| #834 | `feature/US-XXX-coklu-arac` | `dev` | CONFLICTING · aynı diff | **Kapat** |
+
+**Gerekçe:** Branch `test`'in 161 commit gerisinde, iki PR da conflict veriyor ve branch'in son commit'i
+`Revert "branch içerigi test ile hizalandi ve ci derleme hatalari giderildi"` — yani hizalama denemesi
+geri alınmış durumda. Bu haliyle merge edilemez.
+**Ama içerik gerçek:** `LoadingPlanVehicle` entity'si, çoklu araç migration'ı ve ilgili frontend
+`test`'te **yok**. Öneri: PR'ları kapat, işi `test`'ten açılan taze bir branch'e yeniden uygula (§5).
+
+> Bu iki PR, mevcut "her iş için 2 PR" modelinin maliyetinin somut örneği: aynı diff iki kez
+> review kuyruğunda bekliyor.
+
+---
+
+## 3. Uzun Ömürlü Branch'ler
+
+| Branch | test'e göre | Durum |
+|--------|-------------|-------|
+| `test` | — | Default branch. Korumalı (1 review + 3 required check). Aktif, güncel. |
+| `dev` | 3 geride / **9 önde** | Aşağıya bak. Korumasız. |
+| `main` | 2051 geride / 0 önde | 2026-04-11'den beri dokunulmamış. **Korumasız.** Production hiç deploy edilmedi. |
+
+### 3.1 `dev`'de kalan, `test`'e hiç geçmemiş iş 🔴
+
+İçerik farkı sadece 2 dosya (36 satır) ama işlevsel olarak önemli:
+
+```
+CargoPilot.Application/Common/Errors/AuthErrors.cs   +10
+CargoPilot.Infrastructure/Auth/AuthService.cs        +29/−3
+```
+
+İki commit — `MusabDINC`, 2026-05-19, PR #878 ile `dev`'e girmiş:
+
+1. `fix: refresh token 401 - spesifik hata kodları eklendi (REFRESH_TOKEN_EXPIRED, REFRESH_TOKEN_REVOKED)`
+2. `fix: refresh token race condition - atomik revoke ile es zamanli istek korumasi`
+
+İkincisi `session.Revoke()` yerine `ExecuteUpdateAsync` ile **atomik revoke** yapıyor; eş zamanlı iki
+refresh isteğinde kullanıcının tüm oturumlarının hatalı şekilde kapanmasını engelliyor.
+Aynı branch'in `test` PR'ı (#879) bu iki commit'ten **önceki** halden merge edilmiş.
+
+**Aksiyon:** `dev` kapatılmadan önce bu iki commit `test`'e taşınmalı. Aksi hâlde kullanıcılar
+sekme/istek yarışında oturum kaybetmeye devam eder. `known-issues.md` #6'da tarif edilen
+"dev–test ayrışması" riskinin gerçekleşmiş hâli.
+
+### 3.2 `main`
+
+`main`, `test`'in tam atası — yani `git push origin test:main` **fast-forward** olarak çalışır,
+çakışma riski yok. Şu an korumasız ve boş bir kabuk. Karar: ya trunk yapılacak (§6 önerisi)
+ya da en azından branch protection eklenecek.
+
+---
+
+## 4. Silinebilir Branch'ler
+
+### 4.1 İçeriği zaten `test`'te — risk yok (7)
+
+| Branch | Kanıt |
+|--------|-------|
+| `copilot/investigate-server-http-500` | 0 benzersiz commit |
+| `feature/US-3D-01-3d-sahne-arac-onizleme` | 0 benzersiz commit |
+| `feature/US-USR-01-user-management-profile` | 0 benzersiz commit |
+| `feature/US-VY-29-3d-arac-silüet-onizleme` | 0 benzersiz commit · PR #404/#405 merged |
+| `feature/US-VY-99-arac-kapi-yonu` | 0 benzersiz commit |
+| `feature/BE-3D-03-3-optimization-integration` | Patch `test`'te mevcut (`git cherry` −) |
+| `feature/erp-kaynak-badge-ve-paylasim-duzeltmeleri` | Patch `test`'te mevcut · PR #778/#780 merged |
+
+### 4.2 Yerini alan iş `test`'e girmiş — eskimiş (11)
+
+| Branch | Yaş / geride | Neden eskimiş |
+|--------|-------------|---------------|
+| `bugfix/US-AUTH-03-US-AUTH-04-endpoint-fix` | 1515 | Google OAuth `test`'te kurulu (`GoogleOAuthService`), `useAuth.ts` mevcut |
+| `feature/US-VY-27-final2` | 1315 | `GetVehicleByIdQuery` `test`'te var |
+| `feature/US-VY-27-get-vehicle-by-id` | 1314 | Aynı işin ikinci kopyası — aynı story için 2 branch |
+| `feature/US-VY-INF-15-urun-havuzu-listeleme` | 1624 | `SearchItems` akışı yerini aldı · PR #227/#228 CLOSED |
+| `feature/BE-NTF-01-4-5-rbac-policy-hangfire-setup` | 1100 | `NotificationVisibilityPolicy` ve Hangfire `test`'te mevcut |
+| `feature/US-3D-XX-door-panel-mesh-visual` | 1076 | `ContainerMesh`/`ContainerBody` `test`'te defalarca değişti, rebase maliyeti > değeri |
+| `feat/3D-container-steel-texture-floor-grid` | 1129 | `SceneFloor` `test`'te var. Ayrıca **8 MB binary texture** taşıyor — bu dosyalar repoya değil LFS/CDN'e ait |
+| `feature/3D_Packing_Algorithm` | 1327 | `test`'teki `OptimizationEngine` extreme-point + CoG + grup zone'lu tam implementasyon; branch'teki `PackingEngine` iskeleti geride kaldı. ⚠️ **Önce dokümanları kurtar** (aşağı bak) |
+| `copilot/investigate-door-direction-issue` | 50 | Kapı yönü düzeltmesi `test`'e #874 ile ayrıca geldi. PR #861 ve #867 CLOSED. ⚠️ Branch 3 migration dosyasını siliyor (−2873 satır) — merge edilmesi tehlikeli |
+| `copilot/fix-ci-cd-errors-another-one` | 44 | PR hiç açılmamış. İçinde `test-deploy.yml`'e *copilot branch muafiyeti* var — kalıcı olmamalı |
+| `copilot/resolve-conflicts-with-test-branch` | 161 | PR hiç açılmamış. Commit mesajı `Changes before error encountered` — yarım kalmış otomatik conflict çözümü, 72 dosya |
+
+> ⚠️ **Silmeden önce kurtarılacak:** `feature/3D_Packing_Algorithm` branch'i şu üç dosyayı
+> içeriyor ve bunlar `test`'te yok:
+> `apps/backend/docs/matematiksel_model.md` (425 satır),
+> `apps/backend/docs/sistem_mimarisi.md` (330),
+> `apps/backend/docs/bin_packing_implementation_plan.md` (405).
+> Toplam 1.160 satır algoritma tasarım dokümanı. Algoritma geliştiricisi için değerli olabilir —
+> silmeden önce ayrı bir doküman PR'ı ile `test`'e alınmalı.
+
+### 4.3 Branch silinsin, iş backlog'a taşınsın (4)
+
+Bu dörtte iş **gerçekten `test`'te yok** ama branch'ler o kadar geride ki rebase maliyeti
+sıfırdan yazmaktan yüksek. Branch'i saklamak kimseyi kurtarmıyor; story'yi saklamak kurtarıyor.
+
+| Branch | Geride | `test`'te eksik olan | Backlog kaydı |
+|--------|-------:|----------------------|---------------|
+| `feature/US-AUTH-05-hesap-kitleme-mekanizması` | 1666 | IP bazlı lockout (`IpLoginAttempt`). Kullanıcı bazlı lockout (5 deneme / 15 dk) `test`'te **var** | "IP bazlı brute-force koruması" — kalan iş küçük |
+| `feature/US-VY-DAT-01-item-list-api` | 1659 | `DimensionUnit` / `WeightUnit` / `StockStatus` alanları ve cm/kg normalizasyonu | "Ürün birim normalizasyonu + stok durumu" |
+| `feature/US-VY-36-erp-vehicle-upsert-clean` | 970 | `PendingVehicleMapping` entity'si, ERP araç upsert + approve endpoint'i | "ERP araç senkronizasyonu" — `docs/erp-integration/` ile birlikte planlanmalı |
+| `feature/US-SUB-02-paytr-subscription-backend` | 656 | PayTR ödeme entegrasyonunun tamamı (`test`'te "PayTR" kelimesi hiç geçmiyor) | "Abonelik/ödeme" — önce ürün kararı: bu sürümde var mı? |
+
+---
+
+## 5. Kurtarılması Gereken İş (4)
+
+Bunlar silinmeden önce sahipleriyle konuşulmalı.
+
+| Branch | Sahip | Ne var | Öneri |
+|--------|-------|--------|-------|
+| `feature/lifo-kapi-zekasi-eklendi` | İbrahim Nuryağınlı | LIFO algoritmasının kapı yönüne göre zone + skor hesabı, `SideBoth` kapı tipinin kaldırılması, `DebugStepPanel` (yerleştirme adım debug paneli). 12 commit, sadece 206 geride — **en taze iş** | `test`'ten yeni branch, 12 commit'i **tek commit'e squash** (10'u prettier/TS düzeltmesi), PR aç |
+| `feature/US-XXX-coklu-arac` | Çağrı Tekin / İbrahim N. | Çoklu araç desteği: `LoadingPlanVehicle` entity + migration + plan UI. Açık PR #834/#835 | PR'ları kapat, işi `test` üzerine yeniden uygula, tek PR aç |
+| `feature/US-XXX-container-collision-rear-door` | şeyma | PR #522/#523 merge edildikten **sonra** eklenen 5 commit: `/share` sayfasına salt-okunur 3D viewer (`test`'teki `SharePage.tsx`'te Canvas yok), kamera preset sadeleştirmesi | 3D viewer parçası değerli — ayrı branch'e taşınıp PR açılmalı |
+| `bugfix/Responsive` | akgunege1 | PR #698/#701 merge edildikten sonra 1 commit: `LandingPage` `CraneAnimation` z-index düzeltmesi (2 satır) | 2 satır — yeni bugfix branch'ine taşı, sonra sil |
+
+---
+
+## 6. Önerilen Uygulama Sırası
+
+Her adım ayrı ve geri alınabilir tutulmalı.
+
+| # | Adım | Risk |
+|---|------|------|
+| 1 | `dev`'deki 2 refresh-token commit'ini `test`'e taşı (§3.1) | Düşük — 36 satır |
+| 2 | `feature/3D_Packing_Algorithm`'daki 3 algoritma dokümanını `test`'e al | Yok — sadece doküman |
+| 3 | §5'teki 4 branch için sahipleriyle 15 dk'lık karar toplantısı | Yok |
+| 4 | Açık PR #834/#835'i gerekçeli kapat | Düşük |
+| 5 | §4.1'deki 7 branch'i sil | Yok |
+| 6 | §4.2'deki 11 branch'i sil (2. adımdan sonra) | Düşük |
+| 7 | §4.3'teki 4 story'yi backlog'a yaz, sonra branch'leri sil | Düşük |
+| 8 | `delete_branch_on_merge` ayarını **açık** hale getir | Yok — birikmeyi kökten keser |
+| 9 | Branch stratejisi kararı → [branching-proposal.md](branching-proposal.md) | — |
+
+> Silmeden önce güvenlik ağı: `git tag archive/<branch-adı> origin/<branch-adı> && git push origin --tags`.
+> Tag'ler commit'leri kalıcı tutar, branch listesini kirletmez, gerektiğinde geri alınır.
+
+---
+
+## 7. Kök Neden
+
+Bu tablonun 26 iş branch'iyle oluşmasının üç nedeni var; hiçbiri kişi kaynaklı değil:
+
+1. **`delete_branch_on_merge` kapalı** → merge edilmiş 7 branch hâlâ listede duruyor.
+2. **Her iş için 2 PR** (`dev` + `test`) → biri merge edilip diğeri unutulduğunda iş yarım kalıyor;
+   `dev`'deki refresh-token fix'i tam olarak bu şekilde kayboldu.
+3. **Uzun ömürlü branch'ler** → 1000+ commit geride kalan branch rebase edilemiyor, kimse silmeye de
+   cesaret edemiyor, süresiz duruyor.
+
+Üçünün de yapısal karşılığı [branching-proposal.md](branching-proposal.md)'de.

--- a/docs/context/branch-audit.md
+++ b/docs/context/branch-audit.md
@@ -112,8 +112,9 @@ ya da en azından branch protection eklenecek.
 > `apps/backend/docs/matematiksel_model.md` (425 satır),
 > `apps/backend/docs/sistem_mimarisi.md` (330),
 > `apps/backend/docs/bin_packing_implementation_plan.md` (405).
-> Toplam 1.160 satır algoritma tasarım dokümanı. Algoritma geliştiricisi için değerli olabilir —
-> silmeden önce ayrı bir doküman PR'ı ile `test`'e alınmalı.
+> Toplam 1.160 satır algoritma tasarım dokümanı.
+> ✅ **Kurtarıldı:** PR #888 (`chore/algoritma-tasarim-dokumanlari`). Merge edildikten sonra
+> `feature/3D_Packing_Algorithm` güvenle silinebilir.
 
 ### 4.3 Branch silinsin, iş backlog'a taşınsın (4)
 

--- a/docs/context/branch-audit.md
+++ b/docs/context/branch-audit.md
@@ -19,7 +19,7 @@
 | Silinebilir ama işi backlog'a taşınmalı | 4 |
 | **Kurtarılması gereken gerçek iş** | **4** |
 
-**Kritik bulgu:** `dev` branch'inde `test`'te olmayan bir refresh-token güvenlik düzeltmesi var (§3).
+**Ana bulgu:** `dev` ile `test` **içerik olarak birebir aynı** — `dev` risksiz kapatılabilir (§3.1).
 
 ---
 
@@ -46,30 +46,28 @@ geri alınmış durumda. Bu haliyle merge edilemez.
 | Branch | test'e göre | Durum |
 |--------|-------------|-------|
 | `test` | — | Default branch. Korumalı (1 review + 3 required check). Aktif, güncel. |
-| `dev` | 3 geride / **9 önde** | Aşağıya bak. Korumasız. |
+| `dev` | 3 geride / 9 önde (hepsi merge commit) | **İçerik `test` ile birebir aynı.** Korumasız. |
 | `main` | 2051 geride / 0 önde | 2026-04-11'den beri dokunulmamış. **Korumasız.** Production hiç deploy edilmedi. |
 
-### 3.1 `dev`'de kalan, `test`'e hiç geçmemiş iş 🔴
-
-İçerik farkı sadece 2 dosya (36 satır) ama işlevsel olarak önemli:
+### 3.1 `dev` — `test` ile içerik farkı yok ✅
 
 ```
-CargoPilot.Application/Common/Errors/AuthErrors.cs   +10
-CargoPilot.Infrastructure/Auth/AuthService.cs        +29/−3
+$ git diff origin/test origin/dev --stat
+(çıktı boş)
 ```
 
-İki commit — `MusabDINC`, 2026-05-19, PR #878 ile `dev`'e girmiş:
+İki branch'in **çalışma ağaçları birebir aynı**. `dev`'de görünen 9 fazla commit'in tamamı merge
+commit'i veya içeriği `test`'e başka bir branch üzerinden ulaşmış commit
+(ör. `loadingType` düzeltmeleri `test`'e #874 ile girdi).
 
-1. `fix: refresh token 401 - spesifik hata kodları eklendi (REFRESH_TOKEN_EXPIRED, REFRESH_TOKEN_REVOKED)`
-2. `fix: refresh token race condition - atomik revoke ile es zamanli istek korumasi`
+**Aksiyon:** `dev`'de kurtarılacak iş yok. Branch kapatıldığında kod kaybı olmaz.
 
-İkincisi `session.Revoke()` yerine `ExecuteUpdateAsync` ile **atomik revoke** yapıyor; eş zamanlı iki
-refresh isteğinde kullanıcının tüm oturumlarının hatalı şekilde kapanmasını engelliyor.
-Aynı branch'in `test` PR'ı (#879) bu iki commit'ten **önceki** halden merge edilmiş.
-
-**Aksiyon:** `dev` kapatılmadan önce bu iki commit `test`'e taşınmalı. Aksi hâlde kullanıcılar
-sekme/istek yarışında oturum kaybetmeye devam eder. `known-issues.md` #6'da tarif edilen
-"dev–test ayrışması" riskinin gerçekleşmiş hâli.
+> ⚠️ **Metodoloji notu — ilk analizde yapılan hata.** `test` ile `dev` arasında **iki merge-base**
+> var. Bu durumda `git diff A...B` (üç nokta) merge-base'lerden birini keyfî seçer ve gerçekte var
+> olmayan bir fark üretir. İlk taramada bu yolla "dev'de kalan refresh-token düzeltmesi" tespit
+> edilmişti; `git diff A B` (iki nokta) ile doğrulandığında farkın olmadığı görüldü.
+> **Kural: branch karşılaştırmasında iki nokta kullan, ya da dosya varlığını `git cat-file -e` ile doğrula.**
+> Bu dokümandaki diğer "test'te var/yok" tespitleri `cat-file` ile yapıldığından bu hatadan etkilenmez.
 
 ### 3.2 `main`
 
@@ -140,7 +138,7 @@ Bunlar silinmeden önce sahipleriyle konuşulmalı.
 | `feature/lifo-kapi-zekasi-eklendi` | İbrahim Nuryağınlı | LIFO algoritmasının kapı yönüne göre zone + skor hesabı, `SideBoth` kapı tipinin kaldırılması, `DebugStepPanel` (yerleştirme adım debug paneli). 12 commit, sadece 206 geride — **en taze iş** | `test`'ten yeni branch, 12 commit'i **tek commit'e squash** (10'u prettier/TS düzeltmesi), PR aç |
 | `feature/US-XXX-coklu-arac` | Çağrı Tekin / İbrahim N. | Çoklu araç desteği: `LoadingPlanVehicle` entity + migration + plan UI. Açık PR #834/#835 | PR'ları kapat, işi `test` üzerine yeniden uygula, tek PR aç |
 | `feature/US-XXX-container-collision-rear-door` | şeyma | PR #522/#523 merge edildikten **sonra** eklenen 5 commit: `/share` sayfasına salt-okunur 3D viewer (`test`'teki `SharePage.tsx`'te Canvas yok), kamera preset sadeleştirmesi | 3D viewer parçası değerli — ayrı branch'e taşınıp PR açılmalı |
-| `bugfix/Responsive` | akgunege1 | PR #698/#701 merge edildikten sonra 1 commit: `LandingPage` `CraneAnimation` z-index düzeltmesi (2 satır) | 2 satır — yeni bugfix branch'ine taşı, sonra sil |
+| `bugfix/Responsive` | akgunege1 | PR #698/#701 merge edildikten sonra 1 commit: `LandingPage`'de `CraneAnimation` sarmalayıcılarına `z-10` (2 satır) | ⚠️ Mekanik cherry-pick değil: `test`'te bu blok yeniden yazılmış (konum `top-1/2`→`top-0`, boyut `288×480`→`500×780`). Frontend geliştirici güncel `test`'te hatanın hâlâ olup olmadığına bakmalı; varsa tek satırlık yeni fix |
 
 ---
 
@@ -148,17 +146,18 @@ Bunlar silinmeden önce sahipleriyle konuşulmalı.
 
 Her adım ayrı ve geri alınabilir tutulmalı.
 
-| # | Adım | Risk |
-|---|------|------|
-| 1 | `dev`'deki 2 refresh-token commit'ini `test`'e taşı (§3.1) | Düşük — 36 satır |
-| 2 | `feature/3D_Packing_Algorithm`'daki 3 algoritma dokümanını `test`'e al | Yok — sadece doküman |
-| 3 | §5'teki 4 branch için sahipleriyle 15 dk'lık karar toplantısı | Yok |
-| 4 | Açık PR #834/#835'i gerekçeli kapat | Düşük |
-| 5 | §4.1'deki 7 branch'i sil | Yok |
-| 6 | §4.2'deki 11 branch'i sil (2. adımdan sonra) | Düşük |
-| 7 | §4.3'teki 4 story'yi backlog'a yaz, sonra branch'leri sil | Düşük |
-| 8 | `delete_branch_on_merge` ayarını **açık** hale getir | Yok — birikmeyi kökten keser |
-| 9 | Branch stratejisi kararı → [branching-proposal.md](branching-proposal.md) | — |
+| # | Adım | Risk | Durum |
+|---|------|------|-------|
+| 1 | `feature/3D_Packing_Algorithm`'daki 3 algoritma dokümanını `test`'e al | Yok — sadece doküman | ✅ PR açıldı |
+| 2 | §5'teki 4 branch için sahipleriyle 15 dk'lık karar toplantısı | Yok | ⏳ Ekipte |
+| 3 | Açık PR #834/#835'i gerekçeli kapat | Düşük | ⏳ |
+| 4 | §4.1'deki 7 branch'i sil | Yok | ⏳ |
+| 5 | §4.2'deki 11 branch'i sil (1. adımdan sonra) | Düşük | ⏳ |
+| 6 | §4.3'teki 4 story'yi backlog'a yaz, sonra branch'leri sil | Düşük | ⏳ |
+| 7 | `delete_branch_on_merge` ayarını **açık** hale getir | Yok — birikmeyi kökten keser | ⏳ |
+| 8 | Branch stratejisi kararı → [branching-proposal.md](branching-proposal.md) | — | ⏳ |
+
+> `dev`'de kurtarılacak iş bulunmadığı için (§3.1) ayrı bir taşıma adımı gerekmiyor.
 
 > Silmeden önce güvenlik ağı: `git tag archive/<branch-adı> origin/<branch-adı> && git push origin --tags`.
 > Tag'ler commit'leri kalıcı tutar, branch listesini kirletmez, gerektiğinde geri alınır.
@@ -170,8 +169,11 @@ Her adım ayrı ve geri alınabilir tutulmalı.
 Bu tablonun 26 iş branch'iyle oluşmasının üç nedeni var; hiçbiri kişi kaynaklı değil:
 
 1. **`delete_branch_on_merge` kapalı** → merge edilmiş 7 branch hâlâ listede duruyor.
-2. **Her iş için 2 PR** (`dev` + `test`) → biri merge edilip diğeri unutulduğunda iş yarım kalıyor;
-   `dev`'deki refresh-token fix'i tam olarak bu şekilde kayboldu.
+2. **Her iş için 2 PR** (`dev` + `test`) → PR sayısı ve gürültü ikiye katlanıyor. Son 40 PR ölçüldüğünde:
+   **13 branch birden fazla PR açmış**, son 30 PR'ın **10'u merge edilmeden kapatılmış**.
+   Uç örnekler: `bugfix/refresh-yeni` → #876/#877 kapatıldı, #878/#879 merge edildi (4 PR, tek iş);
+   `feature/US-XXX-planning-3d-ui-revize-coklu-arac` → 5 PR.
+   Review kapasitesinin önemli bir kısmı aynı diff'i ikinci kez okumaya gidiyor.
 3. **Uzun ömürlü branch'ler** → 1000+ commit geride kalan branch rebase edilemiyor, kimse silmeye de
    cesaret edemiyor, süresiz duruyor.
 

--- a/docs/context/branch-audit.md
+++ b/docs/context/branch-audit.md
@@ -25,10 +25,12 @@
 
 ## 2. Açık PR'lar
 
-| PR | Branch | Hedef | Durum | Öneri |
+| PR | Branch | Hedef | Durum | Sonuç |
 |----|--------|-------|-------|-------|
-| #835 | `feature/US-XXX-coklu-arac` | `test` | CONFLICTING · 49 dosya · +4184/−671 | **Kapat** |
-| #834 | `feature/US-XXX-coklu-arac` | `dev` | CONFLICTING · aynı diff | **Kapat** |
+| #835 | `feature/US-XXX-coklu-arac` | `test` | CONFLICTING · 49 dosya · +4184/−671 | ✅ Yazarı kapattı (2026-08-03) |
+| #834 | `feature/US-XXX-coklu-arac` | `dev` | CONFLICTING · aynı diff | ✅ Yazarı kapattı (2026-08-03) |
+
+Branch **silinmedi** — içeriği kurtarılacak (§5).
 
 **Gerekçe:** Branch `test`'in 161 commit gerisinde, iki PR da conflict veriyor ve branch'in son commit'i
 `Revert "branch içerigi test ile hizalandi ve ci derleme hatalari giderildi"` — yani hizalama denemesi
@@ -45,9 +47,14 @@ geri alınmış durumda. Bu haliyle merge edilemez.
 
 | Branch | test'e göre | Durum |
 |--------|-------------|-------|
-| `test` | — | Default branch. Korumalı (1 review + 3 required check). Aktif, güncel. |
-| `dev` | 3 geride / 9 önde (hepsi merge commit) | **İçerik `test` ile birebir aynı.** Korumasız. |
-| `main` | 2051 geride / 0 önde | 2026-04-11'den beri dokunulmamış. **Korumasız.** Production hiç deploy edilmedi. |
+| `test` | — | Default branch. `test-protection` ruleset'i (1 review + 3 required check). Aktif, güncel. |
+| `dev` | 3 geride / 9 önde (hepsi merge commit) | **İçerik `test` ile birebir aynı.** `dev-protection` ruleset'i (1 review + 1 check). |
+| `main` | 2051 geride / 0 önde | 2026-04-11'den beri dokunulmamış. `main-protection` ruleset'i var ama **required status check yok**. Production hiç deploy edilmedi. |
+
+> ⚠️ İlk taramada `main` ve `dev` "korumasız" diye kaydedilmişti. Yanlıştı: koruma klasik branch
+> protection ile değil **repository ruleset** ile tanımlı ve
+> `GET /repos/.../branches/<b>/protection` bu durumda 404 döner. Doğru sorgu:
+> `GET /repos/.../rules/branches/<b>`.
 
 ### 3.1 `dev` — `test` ile içerik farkı yok ✅
 
@@ -71,9 +78,11 @@ commit'i veya içeriği `test`'e başka bir branch üzerinden ulaşmış commit
 
 ### 3.2 `main`
 
-`main`, `test`'in tam atası — yani `git push origin test:main` **fast-forward** olarak çalışır,
-çakışma riski yok. Şu an korumasız ve boş bir kabuk. Karar: ya trunk yapılacak (§6 önerisi)
-ya da en azından branch protection eklenecek.
+`main`, `test`'in tam atası — yani içerik olarak `git push origin test:main` **fast-forward**'dır,
+birleştirme çakışması yok. Ancak `main-protection` ruleset'indeki `update` kuralı doğrudan push'u
+engeller; güncelleme ya PR ile ya da bypass yetkisiyle yapılmalı.
+
+Eksik: `main`'de required status check tanımlı değil — CI geçmeden merge edilebilir durumda.
 
 ---
 
@@ -149,16 +158,30 @@ Her adım ayrı ve geri alınabilir tutulmalı.
 
 | # | Adım | Risk | Durum |
 |---|------|------|-------|
-| 1 | `feature/3D_Packing_Algorithm`'daki 3 algoritma dokümanını `test`'e al | Yok — sadece doküman | ✅ PR açıldı |
-| 2 | §5'teki 4 branch için sahipleriyle 15 dk'lık karar toplantısı | Yok | ⏳ Ekipte |
-| 3 | Açık PR #834/#835'i gerekçeli kapat | Düşük | ⏳ |
-| 4 | §4.1'deki 7 branch'i sil | Yok | ⏳ |
-| 5 | §4.2'deki 11 branch'i sil (1. adımdan sonra) | Düşük | ⏳ |
+| 1 | `feature/3D_Packing_Algorithm`'daki 3 algoritma dokümanını `test`'e al | Yok — sadece doküman | ✅ PR #888 açıldı, CI yeşil, review bekliyor |
+| 2 | §4.1'deki 7 branch'i sil | Yok | ✅ Silindi (2026-08-03) |
+| 3 | §4.2'deki 11 branch'i sil | Düşük | ✅ Silindi (2026-08-03) |
+| 4 | Açık PR #834/#835'i kapat | Düşük | ✅ Yazarı (cagr1tekin) kapattı |
+| 5 | §5'teki 4 branch için sahipleriyle karar | Yok | ⏳ Ekipte |
 | 6 | §4.3'teki 4 story'yi backlog'a yaz, sonra branch'leri sil | Düşük | ⏳ |
 | 7 | `delete_branch_on_merge` ayarını **açık** hale getir | Yok — birikmeyi kökten keser | ⏳ |
 | 8 | Branch stratejisi kararı → [branching-proposal.md](branching-proposal.md) | — | ⏳ |
 
 > `dev`'de kurtarılacak iş bulunmadığı için (§3.1) ayrı bir taşıma adımı gerekmiyor.
+
+### 6.1 Uygulama Kaydı — 2026-08-03
+
+**18 branch silindi** (§4.1'den 7, §4.2'den 11). Remote branch sayısı **29 → 13**.
+
+Silinen her branch için `archive/<branch-adı>` tag'i oluşturulup push edildi (18 tag).
+Commit'ler kalıcı olarak erişilebilir; branch listesi kirlenmiyor. Geri alma:
+
+```bash
+git checkout -b <branch-adı> archive/<branch-adı>
+```
+
+Kalan 13 branch: `main`, `test`, `dev`, iki doküman PR branch'i, §5'teki 4 kurtarma adayı,
+§4.3'teki 4 backlog adayı.
 
 > Silmeden önce güvenlik ağı: `git tag archive/<branch-adı> origin/<branch-adı> && git push origin --tags`.
 > Tag'ler commit'leri kalıcı tutar, branch listesini kirletmez, gerektiğinde geri alınır.

--- a/docs/context/branching-proposal.md
+++ b/docs/context/branching-proposal.md
@@ -16,9 +16,9 @@ Bu modelin 5 kişide taşıdığı maliyet, ölçülebilir hâliyle:
 
 | Sorun | Kanıt |
 |-------|-------|
-| Her iş **2 PR** üretiyor | PR numarası 887'ye ulaşmış; #834/#835, #878/#879, #886/#887 aynı işin çiftleri |
-| Çift PR'ın biri unutulunca iş yarım kalıyor | `dev`'de kalan refresh-token race-condition düzeltmesi `test`'e hiç geçmedi |
-| İki dal ayrışıyor | `known-issues.md` #6 bu riski zaten kayıt altına almış, `sync/test-to-dev` diye bir yama akışı doğmuş |
+| Her iş **2 PR** üretiyor | Son 40 PR'da **13 branch birden fazla PR** açmış; #834/#835, #878/#879, #886/#887 aynı işin çiftleri |
+| Çift PR akışı gürültü üretiyor | Son 30 PR'ın **10'u merge edilmeden kapatıldı**. `bugfix/refresh-yeni` tek iş için 4 PR (#876/#877 kapatıldı, #878/#879 merge), `US-XXX-planning-3d-ui-revize-coklu-arac` 5 PR |
+| İki dal ayrışma riski taşıyor | `known-issues.md` #6 bu riski kayıt altına almış, `sync/test-to-dev` diye bir yama akışı doğmuş. (Bugün fiilî ayrışma yok — ama riski taşımanın karşılığı yukarıdaki PR maliyeti) |
 | `enforce-test-base` CI job'u ek karmaşıklık | "head `dev` olamaz + commit `origin/dev`'de bulunmalı" kuralı, `sync/*` muafiyeti, `copilot/*` muafiyet denemesi |
 | `main` ölü | 2026-04-11'den beri dokunulmamış, korumasız, production pipeline'ı yok |
 | Branch'ler birikiyor | `delete_branch_on_merge` kapalı → 29 branch, 7'si zaten merge edilmiş |
@@ -114,19 +114,21 @@ Böylece PR açıldığında doğru kişi otomatik reviewer olur — kimin bakac
 
 | # | Adım | Komut / yer |
 |---|------|-------------|
-| 1 | `dev`'de kalan 2 refresh-token commit'ini `test`'e taşı | `branch-audit.md` §3.1 |
-| 2 | `main`'i `test`'e fast-forward'la | `git push origin origin/test:main` |
-| 3 | Default branch'i `main` yap | GitHub → Settings → Branches |
-| 4 | `main`'e branch protection uygula (§4) | GitHub API / UI |
-| 5 | Workflow tetikleyicilerini güncelle | `ci.yml`, `test-deploy.yml`: `test`/`dev` → `main`; `enforce-test-base` job'unu **sil** |
-| 6 | Production pipeline'ı ekle | `v*` tag → prod image build + `production` environment ile deploy |
-| 7 | Branch temizliğini uygula | `branch-audit.md` §6 |
-| 8 | `test` ve `dev` branch'lerini arşivle | `git tag archive/test origin/test`, sonra branch'leri sil |
-| 9 | `BRANCHING.md`'yi yeni modelle yeniden yaz | `docs/conventions/BRANCHING.md` |
-| 10 | Ekibe 15 dk'lık aktarım | — |
+| 1 | `main`'i `test`'e fast-forward'la | `git push origin origin/test:main` |
+| 2 | Default branch'i `main` yap | GitHub → Settings → Branches |
+| 3 | `main`'e branch protection uygula (§4) | GitHub API / UI |
+| 4 | Workflow tetikleyicilerini güncelle | `ci.yml`, `test-deploy.yml`: `test`/`dev` → `main`; `enforce-test-base` job'unu **sil** |
+| 5 | Production pipeline'ı ekle | `v*` tag → prod image build + `production` environment ile deploy |
+| 6 | Branch temizliğini uygula | `branch-audit.md` §6 |
+| 7 | `test` ve `dev` branch'lerini arşivle | `git tag archive/test origin/test`, sonra branch'leri sil |
+| 8 | `BRANCHING.md`'yi yeni modelle yeniden yaz | `docs/conventions/BRANCHING.md` |
+| 9 | Ekibe 15 dk'lık aktarım | — |
 
-**Sıra önemli:** 5. adım (workflow'lar) 3. adımdan (default branch) önce yapılırsa deploy kırılır.
-6. adım tamamlanana kadar production deploy'u zaten manuel; yeni model bunu kötüleştirmiyor.
+**Sıra önemli:** 4. adım (workflow'lar) 2. adımdan (default branch) önce yapılırsa deploy kırılır.
+5. adım tamamlanana kadar production deploy'u zaten manuel; yeni model bunu kötüleştirmiyor.
+
+`dev`'in kapatılması kod kaybı doğurmaz: `dev` ile `test` ağaçları bugün birebir aynı
+(`branch-audit.md` §3.1).
 
 ---
 

--- a/docs/context/branching-proposal.md
+++ b/docs/context/branching-proposal.md
@@ -92,15 +92,19 @@ Böylece PR açıldığında doğru kişi otomatik reviewer olur — kimin bakac
 
 ## 4. Koruma ve Otomasyon Ayarları
 
+Koruma zaten **repository ruleset** ile yapılıyor (`main-protection`, `test-protection`,
+`dev-protection`). Değişmesi gerekenler:
+
 | Ayar | Şu an | Olması gereken |
 |------|-------|----------------|
 | Default branch | `test` | `main` |
-| `main` protection | ❌ yok | ✅ 1 approving review + required checks + force-push kapalı |
-| `enforce_admins` | ❌ kapalı | ✅ açık (kural herkese işlesin) |
-| Required checks | `test`'te 3 adet | `Frontend CI`, `Backend CI`, `Image Build`, `Deploy (Test)` |
+| `main` required checks | ❌ **hiç yok** | ✅ `Frontend CI`, `Backend CI`, `Image Build`, `Deploy (Test)` |
+| `dev-protection` ruleset | Aktif | Sil (`dev` kalkıyor) |
+| `test-protection` ruleset | Aktif | Sil, kuralları `main-protection`'a taşı |
+| Bypass aktörleri | `dev`/`test`'te Team → **her zaman** bypass | `always` yerine `pull_request` (kural fiilen işlesin) |
 | `delete_branch_on_merge` | ❌ kapalı | ✅ açık |
-| Merge yöntemi | 3'ü de açık | **Squash** varsayılan (merge commit sadece release için) |
-| Stale review dismissal | — | ✅ açık — yeni push onayı düşürsün |
+| Merge yöntemi | Ruleset sadece merge commit'e izin veriyor | **Squash**'a izin ver ve varsayılan yap |
+| Stale review dismissal | ✅ zaten açık | Değişiklik yok |
 
 **Squash neden:** `feature/lifo-kapi-zekasi-eklendi` branch'inde 12 commit'in 10'u prettier/TS düzeltmesi.
 `COMMITS.md`'nin "atomic commit + PR öncesi temizlik" hedefini squash otomatik olarak sağlıyor.
@@ -114,7 +118,7 @@ Böylece PR açıldığında doğru kişi otomatik reviewer olur — kimin bakac
 
 | # | Adım | Komut / yer |
 |---|------|-------------|
-| 1 | `main`'i `test`'e fast-forward'la | `git push origin origin/test:main` |
+| 1 | `main`'i `test` seviyesine getir | `main-protection`'daki `update` kuralı doğrudan push'u engeller → `test` → `main` PR'ı aç (fast-forward, çakışma yok) veya kuralı geçici kaldır |
 | 2 | Default branch'i `main` yap | GitHub → Settings → Branches |
 | 3 | `main`'e branch protection uygula (§4) | GitHub API / UI |
 | 4 | Workflow tetikleyicilerini güncelle | `ci.yml`, `test-deploy.yml`: `test`/`dev` → `main`; `enforce-test-base` job'unu **sil** |

--- a/docs/context/branching-proposal.md
+++ b/docs/context/branching-proposal.md
@@ -1,0 +1,155 @@
+# Branch Stratejisi Önerisi — 5 Kişilik Ekip
+
+**Tarih:** 2026-08-03 · **Durum:** 📋 Öneri, karar bekliyor
+**Ekip:** DevOps · Backend · Algoritma · Frontend (4 rol / 5 kişi)
+
+Karar verildiğinde `docs/conventions/BRANCHING.md` bu içerikle güncellenir.
+
+---
+
+## 1. Neden Değişsin
+
+Mevcut model kalabalık ekip için tasarlandı: `test` → `feature/*` → PR `dev` → **aynı branch'ten**
+PR `test` → PR `main`. `dev` bir "teknik doğrulama kapısı", `test` ise hem ortam hem başlangıç noktası.
+
+Bu modelin 5 kişide taşıdığı maliyet, ölçülebilir hâliyle:
+
+| Sorun | Kanıt |
+|-------|-------|
+| Her iş **2 PR** üretiyor | PR numarası 887'ye ulaşmış; #834/#835, #878/#879, #886/#887 aynı işin çiftleri |
+| Çift PR'ın biri unutulunca iş yarım kalıyor | `dev`'de kalan refresh-token race-condition düzeltmesi `test`'e hiç geçmedi |
+| İki dal ayrışıyor | `known-issues.md` #6 bu riski zaten kayıt altına almış, `sync/test-to-dev` diye bir yama akışı doğmuş |
+| `enforce-test-base` CI job'u ek karmaşıklık | "head `dev` olamaz + commit `origin/dev`'de bulunmalı" kuralı, `sync/*` muafiyeti, `copilot/*` muafiyet denemesi |
+| `main` ölü | 2026-04-11'den beri dokunulmamış, korumasız, production pipeline'ı yok |
+| Branch'ler birikiyor | `delete_branch_on_merge` kapalı → 29 branch, 7'si zaten merge edilmiş |
+
+`dev` kapısının varlık nedeni review'ı ölçeklemekti. 5 kişilik ekipte review zaten tek adımda yapılabilir —
+kapı, faydasından çok gecikme üretiyor.
+
+---
+
+## 2. Önerilen Model — Tek Trunk
+
+```
+main (trunk, korumalı, default)
+ ├── feat/<kod>-<açıklama>      ─┐
+ ├── fix/<kod>-<açıklama>        │  kısa ömürlü (hedef ≤ 3 gün)
+ ├── chore/<açıklama>            │  main'den açılır → PR → main (squash)
+ └── infra/<açıklama>           ─┘
+        │
+        ├─ merge → test ortamına OTOMATİK deploy
+        └─ v1.4.0 tag'i → production'a ONAYLI deploy
+```
+
+**Tek uzun ömürlü branch: `main`.** `dev` ve `test` branch olarak kalkar; "test" bir **ortam** olur,
+branch değil. Ortamlar branch'lerle değil, deploy hedefleriyle ayrılır.
+
+### Branch türleri
+
+| Önek | Kullanım | Örnek |
+|------|----------|-------|
+| `feat/` | Yeni özellik | `feat/US-142-coklu-arac-plani` |
+| `fix/` | Hata düzeltme | `fix/INC-001-refresh-token-race` |
+| `hotfix/` | Production acil düzeltme | `hotfix/v1.3.1-share-token-401` |
+| `chore/` | Doküman, bağımlılık, temizlik | `chore/branch-temizligi` |
+| `infra/` | CI/CD, compose, monitoring (DevOps) | `infra/prod-deploy-pipeline` |
+
+İsimlendirme kuralları `BRANCHING.md`'den aynen korunur: küçük harf, Türkçe karakter yok, boşluk yok,
+iş kodu büyük harf.
+
+### Sürüm
+
+- `main`'e her merge → `test` ortamına otomatik deploy (bugünkü `test` branch davranışı).
+- Production'a çıkış: `main` üzerinde `v<major>.<minor>.<patch>` tag'i → GitHub Environment
+  `production` (zorunlu onaylayıcı) → prod deploy. Rollback zaten tag tabanlı (`rollback.yml`).
+- Hotfix: prod tag'inden `hotfix/*` aç → düzelt → `main`'e PR → yeni patch tag'i.
+
+---
+
+## 3. Rol Bazlı Kurallar
+
+Branch'i role göre bölmek yerine **sahipliği CODEOWNERS ile** tanımla. Yeni `.github/CODEOWNERS`:
+
+```
+apps/frontend/                @frontend-gelistirici
+apps/backend/                 @backend-gelistirici
+apps/backend/**/Packing/      @algoritma-gelistirici
+apps/backend/**/Services/OptimizationEngine.cs  @algoritma-gelistirici
+infra/  .github/  database/   @devops
+docs/                         @takim-lideri
+```
+
+Böylece PR açıldığında doğru kişi otomatik reviewer olur — kimin bakacağı tartışılmaz.
+
+| Rol | Tipik branch | Notu |
+|-----|--------------|------|
+| DevOps | `infra/` | Prod pipeline, secret rotation, image CVE'leri (bkz. `project-snapshot.md` §5) |
+| Backend | `feat/`, `fix/` | Clean Architecture kuralları `apps/backend/docs/architecture.md` |
+| Algoritma | `feat/` | Optimizasyon değişikliği + öncesi/sonrası plan karşılaştırması PR'da zorunlu |
+| Frontend | `feat/`, `fix/` | UI değişikliğinde ekran görüntüsü PR'da zorunlu |
+
+---
+
+## 4. Koruma ve Otomasyon Ayarları
+
+| Ayar | Şu an | Olması gereken |
+|------|-------|----------------|
+| Default branch | `test` | `main` |
+| `main` protection | ❌ yok | ✅ 1 approving review + required checks + force-push kapalı |
+| `enforce_admins` | ❌ kapalı | ✅ açık (kural herkese işlesin) |
+| Required checks | `test`'te 3 adet | `Frontend CI`, `Backend CI`, `Image Build`, `Deploy (Test)` |
+| `delete_branch_on_merge` | ❌ kapalı | ✅ açık |
+| Merge yöntemi | 3'ü de açık | **Squash** varsayılan (merge commit sadece release için) |
+| Stale review dismissal | — | ✅ açık — yeni push onayı düşürsün |
+
+**Squash neden:** `feature/lifo-kapi-zekasi-eklendi` branch'inde 12 commit'in 10'u prettier/TS düzeltmesi.
+`COMMITS.md`'nin "atomic commit + PR öncesi temizlik" hedefini squash otomatik olarak sağlıyor.
+`main` geçmişi PR başına tek, okunabilir commit olur ve `git bisect` daha da iyi çalışır.
+
+---
+
+## 5. Geçiş Planı
+
+`main`, `test`'in tam atası — fast-forward mümkün, çakışma riski yok (doğrulandı).
+
+| # | Adım | Komut / yer |
+|---|------|-------------|
+| 1 | `dev`'de kalan 2 refresh-token commit'ini `test`'e taşı | `branch-audit.md` §3.1 |
+| 2 | `main`'i `test`'e fast-forward'la | `git push origin origin/test:main` |
+| 3 | Default branch'i `main` yap | GitHub → Settings → Branches |
+| 4 | `main`'e branch protection uygula (§4) | GitHub API / UI |
+| 5 | Workflow tetikleyicilerini güncelle | `ci.yml`, `test-deploy.yml`: `test`/`dev` → `main`; `enforce-test-base` job'unu **sil** |
+| 6 | Production pipeline'ı ekle | `v*` tag → prod image build + `production` environment ile deploy |
+| 7 | Branch temizliğini uygula | `branch-audit.md` §6 |
+| 8 | `test` ve `dev` branch'lerini arşivle | `git tag archive/test origin/test`, sonra branch'leri sil |
+| 9 | `BRANCHING.md`'yi yeni modelle yeniden yaz | `docs/conventions/BRANCHING.md` |
+| 10 | Ekibe 15 dk'lık aktarım | — |
+
+**Sıra önemli:** 5. adım (workflow'lar) 3. adımdan (default branch) önce yapılırsa deploy kırılır.
+6. adım tamamlanana kadar production deploy'u zaten manuel; yeni model bunu kötüleştirmiyor.
+
+---
+
+## 6. Karşılaştırma
+
+| | Mevcut (feature→dev→test→main) | Önerilen (trunk) |
+|---|---|---|
+| İş başına PR | 2 | 1 |
+| Uzun ömürlü branch | 3 | 1 |
+| Ayrışma riski | Var (gerçekleşti) | Yapısal olarak yok |
+| CI özel kuralı | `enforce-test-base` + muafiyetler | Yok |
+| Prod'a çıkış | `test → main` PR (pipeline yok) | Tag + onaylı environment |
+| Rollback | Tag tabanlı | Aynı (değişmiyor) |
+| Review kalitesi | 2 kapı, ikisi de zayıf | 1 kapı + CODEOWNERS |
+| Ne zaman doğru | 15+ kişi, ayrı QA fazı | 5 kişi, sürekli teslim |
+
+---
+
+## 7. Bu Öneriyi Reddetmenin Makul Nedeni
+
+Ayrı bir QA ekibi gelir ve "test ortamında dondurulmuş bir sürüm üzerinde regresyon koşulacak"
+gereksinimi doğarsa, `release/*` branch'leri geri gelmeli — ama `dev` yine gerekmez.
+O senaryoda model: `main` (trunk) + `release/v1.4` (QA dondurma) + `hotfix/*`.
+
+Ayrıca §5 adım 6 (production pipeline) **her hâlükârda** yapılmalı; branch stratejisi kararından
+bağımsız olarak açık kritik risk (`devops-backlog.md` madde 2.2).

--- a/docs/context/doc-map.md
+++ b/docs/context/doc-map.md
@@ -1,0 +1,83 @@
+# Doküman Haritası
+
+Repodaki tüm `.md` dosyaları, ne içerdikleri ve hangi soruda açılacakları.
+**Toplam 25 dosya / ~4.600 satır.** Tarama: 2026-08-03.
+
+---
+
+## Kök
+
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `README.md` | 93 | Ürün tanıtımı, hızlı başlangıç (3 komut), stack tablosu, repo ağacı, ortam durumu | Projeye ilk bakış |
+| `SUMMARY.md` | 22 | GitBook içindekiler tablosu | Yeni doküman eklerken (buraya da satır eklenmeli) |
+| `PRODUCTION_DEPLOYMENT_INFO.md` | 159 | Test/prod servis adresleri, compose başlat-durdur komutları, sunucudaki env yolları, migration'ı SDK container'ı ile çalıştırma, CI/CD akış tablosu | Deploy / sunucu operasyonu |
+| `CLAUDE.md` | — | **Frontend** geliştirme kuralları (AI asistan talimatı). Kapsam, stack, sınırlar, veri kuralları, 3D invariant'ları, kalite kapıları | Frontend'e kod yazmadan önce |
+
+## docs/conventions
+
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `BRANCHING.md` | 182 | **Mevcut** branch modeli: `test`'ten feature aç → PR `dev` → aynı branch'ten PR `test` → PR `main`. Branch isimlendirme (iş kodu zorunlu, büyük harf/Türkçe karakter/boşluk yasak), PR onay kuralları, branch-ortam ilişkisi, merge commit tercihi | Branch/PR açarken. **Değişiklik önerisi:** `../context/branching-proposal.md` |
+| `COMMITS.md` | 105 | Sade + açıklayıcı mesaj, atomic commit (1 değişiklik = 1 commit), Türkçe tercih, "fix/update/son" gibi mesajlar yasak, PR öncesi geçmiş temizliği | Commit atmadan önce |
+
+## docs/setup
+
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `local-setup.md` | 273 | Ön koşullar, `.env.test` hazırlama, iki çalışma modu (tam Docker / Vite+Docker hibrit), migration & seed, default login, sık komutlar, 4 sık sorun çözümü | Yeni geliştirici onboarding |
+
+## docs/devops
+
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `server-requirements.md` | 97 | Sunucu donanımı (8 vCPU/16 GB/147 GB), bileşen bazlı CPU-RAM-disk gereksinimleri, ortam-port matrisi, aktif servis listesi | Kapasite planlama |
+| `server-access.md` | 239 | SSH erişimi ve yetkili key'ler, UFW port tablosu, fail2ban, nginx reverse proxy path'leri (`/api/`, `/media/`, `/`), ağ diyagramı, monitoring stack başlatma, DIVIZYON ERP DB restore, DB yedekleme cron'ları, GitHub Actions deploy key | Sunucuya bağlanma, ağ/proxy sorunu |
+| `secret-management.md` | 167 | "Repoya secret girmez" kuralı, env dosya tablosu, GHCR public durumu, backend local secret yöntemleri (User Secrets / Local JSON), GitHub Actions secret listesi, Google OAuth + Resend değişkenleri, ihlal prosedürü | Secret ekleme/döndürme |
+| `monitoring-setup.md` | 239 | Prometheus/Loki/Promtail/Grafana mimarisi, ilk kurulum, toplanan metrikler, 3 alert kuralı, sorun giderme (Loki log şişmesi dahil) | Alert/dashboard işleri |
+| `known-issues.md` | 160 | 8 açık sorun + çözülenler tablosu | **Her sprint başında.** Özeti: `project-snapshot.md` §5 |
+| `devops-backlog.md` | 237 | 11 maddelik öncelik matrisi + kategori bazlı detay (uyumsuzluklar, eksikler, güncellenecekler, GHCR, operasyonel) | DevOps planlaması |
+
+## infra
+
+| Dosya | Satır | Özet |
+|-------|------:|------|
+| `infra/env/README.md` | 144 | `.env.*.example` → `.env.*` kopyalama akışı, değişken referansı (genel/DB/MinIO/güvenlik/OAuth/monitoring), güvenlik kuralları, ortam farkları, sunucuda kurulum |
+
+## apps/backend/docs
+
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `architecture.md` | 188 | Clean Architecture 4 katman + referans yönü, katman içerikleri, **kararlar:** service-based (MediatR yok), aggregate-specific repository, FluentValidation, `Result<T>`, composition root, dev'de InMemory repo. Yeni use-case 8 adımı. Scope dışı: CQRS, domain event, Scrutor, generic repository | Backend'e yeni özellik eklemeden önce |
+| `developer-setup.md` | 74 | Visual Studio workload'ları, `global.json` ile SDK pinleme, doğrulama komutları, CI SDK sabitleme | Backend ortam kurulumu |
+| `environment-variables.md` | 163 | `Section__SubSection__Key` naming standardı ve neden `__`, yapılandırma öncelik sırası, ortam bazlı secret kaynakları, User Secrets kurulumu, prod bağlantı akışı, secret policy, zorunlu/opsiyonel değişken tablosu | Env var eklerken |
+| `database-migrations.md` | 235 | `dotnet-ef` kurulumu, connection string kaynakları, migration üretme/uygulama/geri alma, isimlendirme, ortam bazlı akış, SQL script üretme, 6 yaygın hata | Migration işleri |
+| `user-story-tracker.md` | 528 | 17 story'nin alt iş bazında durum takibi (✅/🟡/⬜) + kanıt dosya listesi. Açık kalanlar: Story 8 "validation hatalarını envelope'a bağla", Story 9 correlation id + exception testleri | Backend ilerleme durumu |
+| `erp-integration/data-model.md` | 53 | `Integration`, `SyncLog`, `ErpUserMapping` entity'leri + `Item`/`Vehicle`'a eklenecek alanlar | ERP entegrasyonu |
+| `erp-integration/erp-schema-divizyon.md` | 455 | Müşteri ERP şeması: `TBLSTSABIT` (stok, 134 kolon), `TBLSIPAMAS` (sipariş başlığı, 106), `TBLSIPATRA` (satırlar, 97), boyut birimi notu, sync ve delta-sync sorguları | ERP alan eşlemesi |
+
+## apps/frontend (AI asistan kuralları)
+
+| Dosya | Satır | Özet |
+|-------|------:|------|
+| `.claude/CLAUDE.md` | 588 | **Frontend standartlarının ana kaynağı.** Klasör yapısı, isimlendirme, TS kuralları (enum yerine `as const`), shadcn kuralları, tasarım token'ları, Zustand slice tablosu, TanStack Query kuralları, form + bağımlı alan tuzağı, 3D standartları (koordinat, `BoxWrapper`, Canvas, `InstancedMesh`, dispose, raycasting, katman), routing/RBAC/JWT, abonelik kilit modal pattern'i, PDF/Excel export, `/share/:token` kuralları |
+| `src/features/data-management/schemas/CLAUDE.md` | 49 | Squad 1 — form şeması, bağımlı alan (fragility ≥ 1 → Z rotasyon kilidi), Figma referansı |
+| `src/features/planning/components/CLAUDE.md` | 141 | Squad 2 — `scene-config.ts`, koordinat & `BoxWrapper`, Canvas, `InstancedMesh` + raycaster, animasyon state machine, `useFrame` kuralları, violation, memory & snapshot |
+
+## .github
+
+| Dosya | Özet |
+|-------|------|
+| `pull_request_template.md` | Özet / user story / değişiklik tipi / test edildi mi / 5 maddelik kontrol listesi. **Not:** ekran görüntüsü alanı yok, CLAUDE.md UI değişikliklerinde görsel istiyor — şablona eklenmesi öneri |
+
+---
+
+## Doküman Sağlığı — Tespit Edilen Boşluklar
+
+| Bulgu | Etki |
+|-------|------|
+| `SUMMARY.md` (GitBook ToC) backend ve ERP dokümanlarını hiç listelemiyor | Backend dokümanları GitBook'ta görünmüyor |
+| `main` ve production akışını anlatan doküman yok; `BRANCHING.md` "Production pipeline henüz yok" diyor | Prod release süreci yazılı değil |
+| `docs/conventions/BRANCHING.md` iki entegrasyon dalı tarif ediyor, `known-issues.md` #6 bu modelin ayrışma ürettiğini kayıt altına almış | Doküman kendi içinde çelişkiyi kabul ediyor, çözüm yazılı değil |
+| Algoritma tarafı (`matematiksel_model.md`, `sistem_mimarisi.md`, `bin_packing_implementation_plan.md`) sadece `feature/3D_Packing_Algorithm` branch'inde, `test`'te yok | Branch silinirse 1.160 satır tasarım dokümanı kaybolur — bkz. `branch-audit.md` |
+| PR şablonunda ekran görüntüsü alanı yok | UI PR'larında görsel kanıt atlanıyor |

--- a/docs/context/doc-map.md
+++ b/docs/context/doc-map.md
@@ -79,5 +79,5 @@ Repodaki tüm `.md` dosyaları, ne içerdikleri ve hangi soruda açılacakları.
 | `SUMMARY.md` (GitBook ToC) backend ve ERP dokümanlarını hiç listelemiyor | Backend dokümanları GitBook'ta görünmüyor |
 | `main` ve production akışını anlatan doküman yok; `BRANCHING.md` "Production pipeline henüz yok" diyor | Prod release süreci yazılı değil |
 | `docs/conventions/BRANCHING.md` iki entegrasyon dalı tarif ediyor, `known-issues.md` #6 bu modelin ayrışma ürettiğini kayıt altına almış | Doküman kendi içinde çelişkiyi kabul ediyor, çözüm yazılı değil |
-| Algoritma tarafı (`matematiksel_model.md`, `sistem_mimarisi.md`, `bin_packing_implementation_plan.md`) sadece `feature/3D_Packing_Algorithm` branch'inde, `test`'te yok | Branch silinirse 1.160 satır tasarım dokümanı kaybolur — bkz. `branch-audit.md` |
+| ~~Algoritma tasarım dokümanları sadece `feature/3D_Packing_Algorithm` branch'inde~~ | ✅ Çözüldü — 1.160 satır PR #888 ile `test`'e taşınıyor, her dosyaya "tasarım arşivi" durum notu eklendi |
 | PR şablonunda ekran görüntüsü alanı yok | UI PR'larında görsel kanıt atlanıyor |

--- a/docs/context/project-snapshot.md
+++ b/docs/context/project-snapshot.md
@@ -94,9 +94,10 @@ Workflow'lar: `ci.yml`, `test-deploy.yml`, `cache-cleanup.yml`, `sync-base-image
 ## 6. Süreç Gözlemi
 
 - Mevcut model: `test`'ten branch aç → PR `dev` → **aynı branch'ten** PR `test` → PR `test→main`.
-- Bu model her iş için **2 PR** üretiyor. PR numaraları 880'i geçmiş durumda.
-- Bilinen yan etki (known-issues #6): biri merge edilip diğeri unutulunca `dev` ile `test` ayrışıyor.
-  Bu ayrışma **şu an da mevcut** — bkz. [branch-audit.md](branch-audit.md) §3.
+- Bu model her iş için **2 PR** üretiyor. PR numaraları 887'yi geçmiş; son 40 PR'da 13 branch
+  birden fazla PR açmış, son 30 PR'ın 10'u merge edilmeden kapatılmış.
+- Bilinen yan etki (known-issues #6): `dev` ile `test` ayrışabiliyor. **Şu an ayrışma yok** —
+  iki branch'in ağacı birebir aynı (bkz. [branch-audit.md](branch-audit.md) §3.1).
 - Öneri ve gerekçe: [branching-proposal.md](branching-proposal.md).
 
 ---

--- a/docs/context/project-snapshot.md
+++ b/docs/context/project-snapshot.md
@@ -1,0 +1,111 @@
+# Proje Anlık Görüntüsü
+
+**Kaynak tarama:** 2026-08-03 · `test` @ `3c42f65a` · Repodaki 25 `.md` dosyası okundu.
+
+---
+
+## 1. Ürün
+
+Cargo Pilot — yük planlama süreçlerini dijitalleştiren ve 3D olarak görselleştiren web platformu.
+Monorepo: `apps/frontend` (React) + `apps/backend` (.NET 8) + `infra` (Docker/CI) + `database`.
+
+---
+
+## 2. Teknoloji
+
+| Katman | Teknoloji | Kritik kural |
+|--------|-----------|--------------|
+| Frontend | React 18 + Vite + TS strict | `any` yasak, barrel export yasak, default export yasak |
+| UI | Tailwind v3 + shadcn/ui + Radix | Sıfırdan UI bileşeni yazılmaz, `cn()` zorunlu, `@apply` yasak |
+| Form | react-hook-form + zod | Tip `z.infer`'den türetilir, manuel interface yazılmaz |
+| Server state | TanStack Query v5 | Tuple query key, API verisi Zustand'a **kopyalanmaz** |
+| Client state | Zustand v4 | Sadece UI state; access token yalnızca `useAuthStore` (localStorage yasak) |
+| 3D | Three.js + R3F + drei | cm birimi; X=genişlik, Y=yükseklik, Z=derinlik; origin **sol-alt-arka** |
+| Export | react-pdf, SheetJS | PDF `React.lazy`, Canvas `preserveDrawingBuffer: true` |
+| Backend | .NET 8, Clean Architecture | Domain ← Application ← Infrastructure/WebAPI; MediatR **yok**, service-based |
+| Backend hata | `Result<T>` + `Error` + `ErrorType` | Exception ile akış kontrolü yapılmaz |
+| Validation | FluentValidation (BE) / Zod (FE) | — |
+| DB | SQL Server 2022 + EF Core | Soft delete global query filter, `BaseEntity` audit alanları |
+| Storage | MinIO | Bucket policy public, nginx `/media/` proxy |
+| Paket | npm (pnpm/yarn yasak) | — |
+
+**3D pivot farkı:** Three.js pivot merkezde, backend pivot sol-alt-arka köşede.
+`BoxWrapper` / merkezi `lib/config/scene-config.ts` ile çözülür. 50+ kutuda `InstancedMesh` zorunlu.
+
+---
+
+## 3. Ortamlar
+
+| Ortam | Branch | URL | Durum |
+|-------|--------|-----|-------|
+| Test | `test` | http://cargopilot.divizyon.org · 104.247.163.42 | ✅ Aktif (demo da buradan yapılıyor) |
+| Production | `main` | 104.247.163.42:80 | ❌ **Hiç deploy edilmedi** |
+
+**Sunucu:** tek makine, Ubuntu 24.04, 8 vCPU / 16 GB / 147 GB SSD. Prod ve test aynı host'ta.
+
+| Servis | Test portu | Prod portu |
+|--------|-----------|-----------|
+| Frontend | 3001 | 80 |
+| Backend API | 8081 | 8080 |
+| MSSQL | 1434 (`CargoPilotTest`) | 1433 (`CargoPilot`) |
+| MinIO API / Console | 9002 / 9003 | 9000 / 9001 |
+| Grafana / Prometheus | 3002 / 9091 | 3000 / 9090 |
+
+Ek: `DIVIZYON` ERP veritabanı (müşteri `.bak` restore'u) test MSSQL container'ında — sadece geliştirme içindir.
+
+---
+
+## 4. CI/CD
+
+Workflow'lar: `ci.yml`, `test-deploy.yml`, `cache-cleanup.yml`, `sync-base-images.yml`, `rollback.yml`.
+
+| Tetikleyici | Sonuç |
+|-------------|-------|
+| push `feature/**`, `bugfix/**` | CI + Deploy (Test) — inline build |
+| PR → `dev` | CI + Deploy (Test) |
+| PR → `test` | `enforce-test-base` + Image Build + Deploy (Test) |
+| push `test` | Image Build → GHCR → Deploy (Test) |
+| push `main` | **hiçbir şey — production pipeline yok** |
+
+- `enforce-test-base`: head `dev` olamaz + PR commit'i `origin/dev`'de bulunmalı. `sync/*` muaf.
+- GHCR image'ları **public**; geliştirici login'i gerekmiyor. Immutable tag: `test-{sha}`.
+- Branch protection: sadece `test` korumalı (1 review, 3 required check, force-push kapalı, **enforce_admins kapalı**). `main` ve `dev` **korumasız**.
+- `delete_branch_on_merge` = **false** → merge sonrası branch'ler birikiyor.
+
+---
+
+## 5. Açık Riskler (docs/devops/known-issues.md + devops-backlog.md özeti)
+
+| # | Risk | Seviye |
+|---|------|--------|
+| 1 | Production stack hiç deploy edilmedi (`.env.prod` yok, compose çalışmadı) | 🔴 Kritik |
+| 2 | Production CI/CD ve prod GHCR image pipeline'ı yok | 🔴 Kritik |
+| 3 | `docker-compose.prod.yml` eksik: backend healthcheck yok, OAuth/CORS/Resend env yok, `SA_PASSWORD` vs `MSSQL_SA_PASSWORD` uyumsuz | 🔴 Kritik |
+| 4 | MSSQL SA parolası git geçmişinde — **rotate edilmedi** | 🔴 Güvenlik |
+| 5 | Docker image CVE: backend 4 CRITICAL/18 HIGH, frontend 6 CRITICAL/29 HIGH (Trivy, 2026-05-16) | 🟠 Yüksek |
+| 6 | Grafana alert var ama contact point yok → bildirim gitmiyor | 🟠 Yüksek |
+| 7 | Resend domain doğrulanmadı → prod'da şifre sıfırlama e-postası gönderilemez | 🟠 Yüksek |
+| 8 | SSL self-signed (Cloudflare Full, Strict değil) | 🟡 Orta |
+| 9 | Loki/cAdvisor log rotation yok (bir kez 960 MB'a çıkıp Grafana'yı düşürdü) | 🟡 Orta |
+| 10 | Node.js 20 deprecation (CI + Dockerfile) | 🟢 Düşük |
+
+---
+
+## 6. Süreç Gözlemi
+
+- Mevcut model: `test`'ten branch aç → PR `dev` → **aynı branch'ten** PR `test` → PR `test→main`.
+- Bu model her iş için **2 PR** üretiyor. PR numaraları 880'i geçmiş durumda.
+- Bilinen yan etki (known-issues #6): biri merge edilip diğeri unutulunca `dev` ile `test` ayrışıyor.
+  Bu ayrışma **şu an da mevcut** — bkz. [branch-audit.md](branch-audit.md) §3.
+- Öneri ve gerekçe: [branching-proposal.md](branching-proposal.md).
+
+---
+
+## 7. Squad / Sorumluluk Haritası (frontend)
+
+| Klasör | Sahip | Kapsam |
+|--------|-------|--------|
+| `features/data-management` | Squad 3 | Ürün, araç, kısıt, import, ERP ekranları |
+| `features/planning` | Squad 2 | Plan sihirbazı, optimizasyon, 3D viewer, manuel yerleştirme |
+| `features/platform` | Squad 1 | Auth, kullanıcı, billing, ayarlar, rapor, paylaşım |
+| `components/shared`, `lib/*` | Ortak | Paylaşılan UI + altyapı |

--- a/docs/context/project-snapshot.md
+++ b/docs/context/project-snapshot.md
@@ -69,7 +69,19 @@ Workflow'lar: `ci.yml`, `test-deploy.yml`, `cache-cleanup.yml`, `sync-base-image
 
 - `enforce-test-base`: head `dev` olamaz + PR commit'i `origin/dev`'de bulunmalı. `sync/*` muaf.
 - GHCR image'ları **public**; geliştirici login'i gerekmiyor. Immutable tag: `test-{sha}`.
-- Branch protection: sadece `test` korumalı (1 review, 3 required check, force-push kapalı, **enforce_admins kapalı**). `main` ve `dev` **korumasız**.
+- Koruma **repository ruleset** ile yapılıyor (klasik branch protection API'si 404 döner — yanıltıcıdır):
+  `main-protection`, `test-protection`, `dev-protection` aktif; `freeze` kapalı.
+
+| Ruleset | PR zorunlu | Onay | Required check | Bypass |
+|---------|-----------|------|----------------|--------|
+| `main-protection` | ✅ | 1 + son push onayı | **yok** | Team / sadece PR ile |
+| `test-protection` | ✅ | 1 + son push onayı | `Deploy (Test)`, `Image Build`, `Test PR Dev Kontrolü` (strict) | Team / **her zaman** |
+| `dev-protection` | ✅ | 1 + son push onayı | `Deploy (Test)` | Team / **her zaman** |
+
+Üçünde de: sadece merge commit, push'ta eski onaylar düşer, review thread'leri çözülmüş olmalı,
+branch silme ve force-push kapalı. `main`'de ayrıca `update` kuralı → doğrudan push engelli.
+
+- Boşluk: `main`'de hiç required status check yok — CI geçmeden merge edilebilir.
 - `delete_branch_on_merge` = **false** → merge sonrası branch'ler birikiyor.
 
 ---


### PR DESCRIPTION
`dev`'e #889 ile merge edildi, aynı branch'ten `test`'e açılıyor (branching kuralı).

## Özet

Repodaki 25 markdown dosyasının (~4.600 satır) özeti `docs/context/` altında toplandı.

| Dosya | İçerik |
|-------|--------|
| `README.md` | İndeks + güncelleme sorumluluğu |
| `project-snapshot.md` | Stack, ortamlar, portlar, CI/CD, ruleset'ler, 10 açık risk |
| `doc-map.md` | 25 dosyanın haritası + "şu soruda aç" sütunu |
| `branch-audit.md` | Branch/PR denetimi + uygulama kaydı |
| `branching-proposal.md` | 5 kişilik ekip için branch stratejisi önerisi |

`SUMMARY.md` güncellendi.

## Öne çıkan tespitler

- `dev` ile `test` ağaçları **birebir aynı** → `dev` risksiz kapatılabilir
- **`main`'de hiç required status check yok** → CI geçmeden merge edilebilir
- `dev`/`test` ruleset bypass aktörleri `always` modunda → kurallar fiilen zorlayıcı değil
- Son 40 PR'da 13 branch birden fazla PR açmış; son 30 PR'ın 10'u merge edilmeden kapatılmış
- Bu çalışmada 18 branch silindi (29 → 13), hepsi `archive/*` tag'i ile geri alınabilir

## Değişiklik Tipi

- [x] 📄 Dokümantasyon

## Test Edildi mi?

- [x] Doküman değişikliği — kod etkisi yok

## Kontrol Listesi

- [x] Commit mesajları commit kurallarına uygun
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi

## Ek Notlar

`branching-proposal.md` **karar bekleyen öneridir**, uygulanmadı.