### PR TITLE
chore: trunk branch modeline geçiş

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,21 @@
 name: CI — Kod Kalite ve Build Kontrolü
 
-# Tüm feature/bugfix push'larında ve dev/test PR'larında çalışır.
-# Amaç: hataları main/test branch'e ulaşmadan yakalamak.
+# Tüm iş branch'i push'larında ve main PR'larında çalışır.
+# Amaç: hataları main'e ulaşmadan yakalamak.
 on:
   push:
     branches:
+      - feat/**
+      - fix/**
+      - hotfix/**
+      - chore/**
+      - infra/**
+      # Eski isimlendirme — geçiş dönemi için korunuyor
       - feature/**
       - bugfix/**
   pull_request:
     branches:
-      - dev
-      - test
+      - main
 
 jobs:
   # ─── Frontend CI ─────────────────────────────────────────────────────────────
@@ -86,7 +91,7 @@ jobs:
             dotnet test cargo-pilot.sln --no-build --configuration Release --verbosity normal
           fi
 
-  # ─── Docker Image Build (sadece test'e giden PR ve test push) ────────────────
+  # ─── Docker Image Build (main'e giden PR ve iş branch'i push'ları) ───────────
   docker-build:
     name: Docker Image Build
     runs-on: ubuntu-latest
@@ -95,9 +100,8 @@ jobs:
       contents: read
       packages: read
     if: |
-      (github.event_name == 'pull_request' && github.base_ref == 'test') ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/feature/')) ||
-      (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/bugfix/'))
+      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
+      (github.event_name == 'push' && github.ref != 'refs/heads/main')
 
     steps:
       - name: Kodu al

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,127 +1,36 @@
 name: Test Ortamı CI/CD
 
+# Trunk modeli: tek uzun ömürlü branch = main. "test" bir ORTAM adıdır, branch değil.
+#
 # Tetikleyiciler:
-#   push (feature/*, bugfix/*)  → sadece deploy (inline build + healthcheck)
-#   pull_request → dev           → sadece deploy
-#   pull_request → test          → build + deploy
-#                                  + PR base kontrolü:
-#                                     - head 'dev' OLAMAZ (dev→test yasak)
-#                                     - head branch'in PR commit'i origin/dev'de bulunmalı
-#                                       (önce dev'e merge edilmeli, aynı branch'ten test'e PR)
-#   push (test)                  → build + deploy
+#   push (iş branch'leri)  → sadece deploy (inline build + healthcheck)
+#   pull_request → main    → build + deploy (doğrulama)
+#   push (main)            → build + GHCR push + test sunucusuna deploy
 on:
   push:
     branches:
-      - test
+      - main
+      - feat/**
+      - fix/**
+      - hotfix/**
+      - chore/**
+      - infra/**
+      # Eski isimlendirme — geçiş dönemi için korunuyor
       - feature/**
       - bugfix/**
   pull_request:
     branches:
-      - test
-      - dev
+      - main
 
 jobs:
-  # ─── Kural kontrolü: test PR, dev'e merge edilmiş feature/bugfix branch'ten gelmeli
-  # sync/* branch'leri bu kontrolü atlar (dev birikimi senkronizasyon PR'ları için)
-  enforce-test-base:
-    name: Test PR Dev Kontrolü
-    runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'pull_request' &&
-      github.base_ref == 'test' &&
-      !startsWith(github.head_ref, 'sync/')
-
-    steps:
-      - name: Kodu al
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Head 'dev' olmamalı ve PR commit'i dev'de bulunmalı
-        run: |
-          HEAD="${{ github.head_ref }}"
-          PR_SHA="${{ github.event.pull_request.head.sha }}"
-          echo "PR: ${HEAD} (${PR_SHA}) → test"
-
-          if [ "${HEAD}" = "dev" ]; then
-            echo "::error::test branch'ine PR doğrudan 'dev' branch'inden açılamaz. Önce dev'e merge edilmiş feature/bugfix branch'ten PR açın."
-            exit 1
-          fi
-
-          git fetch --no-tags origin dev test
-
-          # Feature branch'e özgü commit'leri bul (test'ten gelmeyen).
-          FEATURE_COMMITS=$(git log --pretty=format:"%H" "${PR_SHA}" --not origin/test)
-
-          if [ -z "$FEATURE_COMMITS" ]; then
-            echo "::error::Feature branch'te test'e özgü olmayan commit bulunamadı. Branch test'ten mi açıldı?"
-            exit 1
-          fi
-
-          # Her commit dev'de olmalı.
-          # İstisna: test'i feature'a merge eden conflict resolution commit'leri atlanır
-          # (bu commit'lerin bir parent'ı origin/test'te bulunur).
-          for commit in $FEATURE_COMMITS; do
-            PARENTS=$(git log --pretty=format:"%P" -1 "${commit}")
-            IS_TEST_MERGE=false
-            for parent in $PARENTS; do
-              if git merge-base --is-ancestor "${parent}" origin/test 2>/dev/null; then
-                IS_TEST_MERGE=true
-                break
-              fi
-            done
-
-            if [ "$IS_TEST_MERGE" = "true" ]; then
-              echo "Conflict resolution merge commit atlanıyor: ${commit}"
-              continue
-            fi
-
-            if ! git merge-base --is-ancestor "${commit}" origin/dev; then
-              echo "::error::Commit ${commit} origin/dev'de bulunamadı. test'e PR atmadan önce tüm commit'leri dev'e merge edin."
-              exit 1
-            fi
-          done
-
-          echo "OK: Tüm feature commit'leri origin/dev'de mevcut."
-
-      - name: Bu branch'ten dev'e merge edilmiş PR zorunlu
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          HEAD="${{ github.head_ref }}"
-
-          # GitHub API: bu branch'ten dev'e merge edilmiş PR var mı?
-          MERGED_PR=$(gh pr list \
-            --repo "${{ github.repository }}" \
-            --base dev \
-            --head "${HEAD}" \
-            --state merged \
-            --json number,mergedAt \
-            --jq '.[0].number // empty')
-
-          if [ -z "$MERGED_PR" ]; then
-            echo "::error::Branch '${HEAD}' için dev'e merge edilmiş bir PR bulunamadı."
-            echo "::error::Kural: test'e PR açmadan önce aynı branch'ten dev'e PR açılmalı ve merge edilmelidir."
-            echo "::error::Adım 1: gh pr create --base dev --head ${HEAD}"
-            echo "::error::Adım 2: PR onaylanıp merge edildikten sonra test'e PR açın."
-            exit 1
-          fi
-
-          echo "OK: Branch '${HEAD}' için dev'e merge edilmiş PR #${MERGED_PR} bulundu."
-
   # ─── Migration kontrolü: model değişmiş ama migration oluşturulmamışsa fail ──
-  # Sadece test'e giden PR'larda veya test'e push'ta çalışır (feature push'larda gereksiz)
+  # Sadece main'e giden PR'larda veya main'e push'ta çalışır (iş branch'i push'larında gereksiz)
   migration-check:
     name: Pending Migration Kontrolü
     runs-on: ubuntu-latest
-    needs: [enforce-test-base]
     if: |
-      always() &&
-      (needs.enforce-test-base.result == 'success' || needs.enforce-test-base.result == 'skipped') &&
-      (
-        (github.event_name == 'pull_request' && github.base_ref == 'test') ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/test')
-      )
+      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     steps:
       - name: Kodu al
@@ -153,21 +62,17 @@ jobs:
             --configuration Release
           echo "Migration kontrolü geçti: bekleyen model değişikliği yok."
 
-  # ─── Build job: sadece test'e giden PR'da veya test'e push'ta çalışır ────────
-  # US-D27-I: test branch push'ta image'lar GHCR'a push edilir.
+  # ─── Build job: sadece main'e giden PR'da veya main'e push'ta çalışır ────────
+  # US-D27-I: main push'ta image'lar GHCR'a push edilir.
   # Her push'ta hem :test (mutable, latest) hem :test-{sha} (immutable) tag'i push edilir.
+  # NOT: :test tag'i ORTAM adıdır (test sunucusu), branch adı değil.
   # deploy-test-server job'u immutable tag'i kullanır; rollback için geçmişe erişim sağlar.
   build:
     name: Image Build
     runs-on: ubuntu-latest
-    needs: [enforce-test-base]
     if: |
-      always() &&
-      (needs.enforce-test-base.result == 'success' || needs.enforce-test-base.result == 'skipped') &&
-      (
-        (github.event_name == 'pull_request' && github.base_ref == 'test') ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/test')
-      )
+      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     # packages: write — GHCR'a push edebilmek için gerekli
     permissions:
@@ -203,7 +108,7 @@ jobs:
         with:
           context: ./apps/backend
           file: ./apps/backend/Dockerfile
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/test' }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: |
             ghcr.io/divizyon/cargo-pilot-backend:test
             ghcr.io/divizyon/cargo-pilot-backend:${{ steps.sha.outputs.tag }}
@@ -218,7 +123,7 @@ jobs:
         with:
           context: ./apps/frontend
           file: ./apps/frontend/Dockerfile
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/test' }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: |
             ghcr.io/divizyon/cargo-pilot-frontend:test
             ghcr.io/divizyon/cargo-pilot-frontend:${{ steps.sha.outputs.tag }}
@@ -235,16 +140,15 @@ jobs:
   deploy:
     name: Deploy (Test)
     runs-on: ubuntu-latest
-    needs: [enforce-test-base, migration-check]
+    needs: [migration-check]
     permissions:
       contents: read
       packages: read
     if: |
       always() &&
-      (needs.enforce-test-base.result == 'success' || needs.enforce-test-base.result == 'skipped') &&
       (needs.migration-check.result == 'success' || needs.migration-check.result == 'skipped') &&
       (
-        (github.event_name == 'pull_request' && github.base_ref == 'test') ||
+        (github.event_name == 'pull_request' && github.base_ref == 'main') ||
         (github.event_name == 'push')
       )
 
@@ -383,18 +287,17 @@ jobs:
         run: |
           docker compose -f infra/compose/docker-compose.test.yml down -v
 
-  # ─── Test sunucusuna deploy: sadece test branch'e push'ta çalışır ─────────────
+  # ─── Test sunucusuna deploy: sadece main'e push'ta çalışır ───────────────────
   deploy-test-server:
     name: Deploy (Test Server)
     runs-on: ubuntu-latest
-    needs: [enforce-test-base, migration-check, build]
+    needs: [migration-check, build]
     if: |
       always() &&
-      (needs.enforce-test-base.result == 'success' || needs.enforce-test-base.result == 'skipped') &&
       (needs.migration-check.result == 'success') &&
       (needs.build.result == 'success') &&
       github.event_name == 'push' &&
-      github.ref == 'refs/heads/test'
+      github.ref == 'refs/heads/main'
 
     steps:
       # US-D27-I: Sunucu artık build yapmıyor; GHCR'dan pull edilen image'ı kullanıyor.
@@ -412,11 +315,11 @@ jobs:
             set -e
             cd /opt/cargo-pilot
 
-            echo "==> Test branch güncelleniyor..."
+            echo "==> main branch güncelleniyor..."
             git remote prune origin
             git fetch --prune origin
-            git checkout test
-            git reset --hard origin/test
+            git checkout main
+            git reset --hard origin/main
 
             echo "==> Image'lar GHCR'dan çekiliyor (tag: ${IMAGE_TAG})..."
             IMAGE_TAG="${IMAGE_TAG}" docker compose \

--- a/docs/context/branch-audit.md
+++ b/docs/context/branch-audit.md
@@ -1,7 +1,8 @@
 # Branch & PR Denetimi
 
-**Tarih:** 2026-08-03 · **Referans:** `origin/test` @ `3c42f65a`
-**Durum:** 🔍 Analiz — **hiçbir branch silinmedi, hiçbir PR kapatılmadı.** Bu doküman karar önerisidir.
+**Tarih:** 2026-08-03 · **Referans:** `origin/test` @ `3c42f65a` (denetim anı)
+**Durum:** ✅ **Tamamlandı ve uygulandı.** Sonuç: **29 branch → 3** (`main`, `test`, `dev`),
+26 `archive/*` tag'i, açık PR yok. Ardından trunk geçişi yapıldı — bkz. §8.
 
 ---
 
@@ -171,17 +172,71 @@ Her adım ayrı ve geri alınabilir tutulmalı.
 
 ### 6.1 Uygulama Kaydı — 2026-08-03
 
-**18 branch silindi** (§4.1'den 7, §4.2'den 11). Remote branch sayısı **29 → 13**.
+**Sonuç: 29 branch → 3.** Kalan: `main`, `test`, `dev`.
 
-Silinen her branch için `archive/<branch-adı>` tag'i oluşturulup push edildi (18 tag).
-Commit'ler kalıcı olarak erişilebilir; branch listesi kirlenmiyor. Geri alma:
+| Aşama | Ne yapıldı |
+|-------|-----------|
+| 1 | §4.1'den 7 + §4.2'den 11 = **18 branch** arşivlenip silindi |
+| 2 | Kullanıcı `bugfix/Responsive`, `US-XXX-coklu-arac`, `US-XXX-container-collision-rear-door`'u UI'dan sildi — objeler lokalde yakalanıp sonradan tag'lendi |
+| 3 | Kalan **5 branch** (§4.3'ün 4'ü + `lifo-kapi-zekasi-eklendi`) arşivlenip silindi |
+| 4 | PR #888/#889 → `dev`, #890/#891 → `test` merge edildi |
+| 5 | `delete_branch_on_merge` **açıldı** |
+
+**26 `archive/*` tag'i** push edildi. Hiçbir commit kaybolmadı. Geri alma:
 
 ```bash
-git checkout -b <branch-adı> archive/<branch-adı>
+git fetch --tags
+git checkout -b <yeni-branch-adi> archive/<eski-branch-adi>
 ```
 
-Kalan 13 branch: `main`, `test`, `dev`, iki doküman PR branch'i, §5'teki 4 kurtarma adayı,
-§4.3'teki 4 backlog adayı.
+{% hint style="warning" %}
+Kurtarma kararı verilmeden silinen, `test`'te karşılığı olmayan işler — ihtiyaç olursa tag'lerden alınır:
+
+- `archive/feature/lifo-kapi-zekasi-eklendi` — LIFO kapı zekası + `DebugStepPanel` (sadece 206 commit gerideydi)
+- `archive/feature/US-XXX-coklu-arac` — `LoadingPlanVehicle` entity + çoklu araç migration'ı
+- `archive/feature/US-XXX-container-collision-rear-door` — `/share` sayfası salt-okunur 3D viewer
+- `archive/feature/US-SUB-02-paytr-subscription-backend` — PayTR ödeme entegrasyonu
+- `archive/feature/US-VY-36-erp-vehicle-upsert-clean` — ERP araç upsert + `PendingVehicleMapping`
+- `archive/feature/US-VY-DAT-01-item-list-api` — ürün birim normalizasyonu + stok durumu
+- `archive/feature/US-AUTH-05-hesap-kitleme-mekanizması` — IP bazlı lockout
+{% endhint %}
+
+---
+
+## 8. Trunk Geçişi — 2026-08-03
+
+Temizlikten sonra [branching-proposal.md](branching-proposal.md) uygulandı.
+
+| Adım | Durum |
+|------|-------|
+| `main`'i `test` seviyesine hizala (PR #892) | ✅ |
+| `dev`'i `test` seviyesine hizala (PR #893) | ✅ |
+| Üç branch içerik olarak birebir aynı | ✅ Doğrulandı |
+| Workflow tetikleyicileri `test`/`dev` → `main` | ✅ |
+| `enforce-test-base` job'u kaldırıldı | ✅ |
+| Sunucu deploy script'i `git checkout main` | ✅ |
+| `BRANCHING.md` trunk modeliyle yeniden yazıldı | ✅ |
+| Default branch → `main` | ✅ |
+| `main-protection`'a required status check eklendi | ✅ |
+| Production pipeline (`v*` tag) | ⛔ Yapılmadı — gerekçe aşağıda |
+
+### Production pipeline neden yapılmadı
+
+`branching-proposal.md` §5 adım 5'te yer alıyor ama şu an inşa edilemez:
+
+1. `PROD_SSH_HOST` / `PROD_SSH_PRIVATE_KEY` secret'ları tanımlı değil.
+2. Production stack sunucuda **hiç kurulmadı** — `.env.prod` yok (`known-issues.md` #2).
+3. `docker-compose.prod.yml` eksik: backend healthcheck yok, OAuth/CORS/Resend env yok,
+   `SA_PASSWORD` ↔ `MSSQL_SA_PASSWORD` uyumsuz (`known-issues.md` #5).
+
+Bu üçü çözülmeden yazılacak pipeline ilk çalıştırmada patlar. Sıra:
+`devops-backlog.md` 1.2–1.4 → 2.1 → 2.2/2.3.
+
+### `dev` ve `test` branch'leri
+
+Silinmediler — kullanıcı üçünün de eşitlenmesini istedi. Artık `main` ile aynı içeriği taşıyan,
+CI tetiklemeyen **dondurulmuş kopyalar**. Ekip onayıyla silinebilirler;
+`archive/main-2026-08-03` ve `archive/dev-2026-08-03` tag'leri geçiş öncesi durumu tutuyor.
 
 > Silmeden önce güvenlik ağı: `git tag archive/<branch-adı> origin/<branch-adı> && git push origin --tags`.
 > Tag'ler commit'leri kalıcı tutar, branch listesini kirletmez, gerektiğinde geri alınır.

--- a/docs/context/branching-proposal.md
+++ b/docs/context/branching-proposal.md
@@ -1,9 +1,11 @@
 # Branch Stratejisi Önerisi — 5 Kişilik Ekip
 
-**Tarih:** 2026-08-03 · **Durum:** 📋 Öneri, karar bekliyor
+**Tarih:** 2026-08-03 · **Durum:** ✅ **Kabul edildi ve uygulandı** (production pipeline hariç)
 **Ekip:** DevOps · Backend · Algoritma · Frontend (4 rol / 5 kişi)
 
-Karar verildiğinde `docs/conventions/BRANCHING.md` bu içerikle güncellenir.
+Yürürlükteki kurallar artık [`docs/conventions/BRANCHING.md`](../conventions/BRANCHING.md)'de.
+Bu doküman **gerekçe ve ölçüm kaydı** olarak duruyor.
+Uygulama detayı: [branch-audit.md](branch-audit.md) §8.
 
 ---
 

--- a/docs/context/project-snapshot.md
+++ b/docs/context/project-snapshot.md
@@ -36,10 +36,10 @@ Monorepo: `apps/frontend` (React) + `apps/backend` (.NET 8) + `infra` (Docker/CI
 
 ## 3. Ortamlar
 
-| Ortam | Branch | URL | Durum |
+| Ortam | Kaynak | URL | Durum |
 |-------|--------|-----|-------|
-| Test | `test` | http://cargopilot.divizyon.org · 104.247.163.42 | ✅ Aktif (demo da buradan yapılıyor) |
-| Production | `main` | 104.247.163.42:80 | ❌ **Hiç deploy edilmedi** |
+| Test | `main` push | http://cargopilot.divizyon.org · 104.247.163.42 | ✅ Aktif (demo da buradan yapılıyor) |
+| Production | `v*` tag (pipeline yok) | 104.247.163.42:80 | ❌ **Hiç deploy edilmedi** |
 
 **Sunucu:** tek makine, Ubuntu 24.04, 8 vCPU / 16 GB / 147 GB SSD. Prod ve test aynı host'ta.
 
@@ -61,13 +61,12 @@ Workflow'lar: `ci.yml`, `test-deploy.yml`, `cache-cleanup.yml`, `sync-base-image
 
 | Tetikleyici | Sonuç |
 |-------------|-------|
-| push `feature/**`, `bugfix/**` | CI + Deploy (Test) — inline build |
-| PR → `dev` | CI + Deploy (Test) |
-| PR → `test` | `enforce-test-base` + Image Build + Deploy (Test) |
-| push `test` | Image Build → GHCR → Deploy (Test) |
-| push `main` | **hiçbir şey — production pipeline yok** |
+| push `feat/**`, `fix/**`, `hotfix/**`, `chore/**`, `infra/**` (+ eski `feature/**`, `bugfix/**`) | CI + Deploy (Test) — inline build |
+| PR → `main` | CI + Pending Migration Kontrolü + Image Build + Deploy (Test) |
+| push `main` | Image Build → GHCR → test sunucusuna deploy |
+| `v*` tag | **hiçbir şey — production pipeline yok** (devops-backlog 2.2) |
 
-- `enforce-test-base`: head `dev` olamaz + PR commit'i `origin/dev`'de bulunmalı. `sync/*` muaf.
+- `enforce-test-base` job'u **kaldırıldı** (2026-08-03 trunk geçişi) — iki dallı model bittiği için gereksizdi.
 - GHCR image'ları **public**; geliştirici login'i gerekmiyor. Immutable tag: `test-{sha}`.
 - Koruma **repository ruleset** ile yapılıyor (klasik branch protection API'si 404 döner — yanıltıcıdır):
   `main-protection`, `test-protection`, `dev-protection` aktif; `freeze` kapalı.
@@ -103,14 +102,18 @@ branch silme ve force-push kapalı. `main`'de ayrıca `update` kuralı → doğr
 
 ---
 
-## 6. Süreç Gözlemi
+## 6. Branch Modeli — Trunk (2026-08-03'ten itibaren)
 
-- Mevcut model: `test`'ten branch aç → PR `dev` → **aynı branch'ten** PR `test` → PR `test→main`.
-- Bu model her iş için **2 PR** üretiyor. PR numaraları 887'yi geçmiş; son 40 PR'da 13 branch
-  birden fazla PR açmış, son 30 PR'ın 10'u merge edilmeden kapatılmış.
-- Bilinen yan etki (known-issues #6): `dev` ile `test` ayrışabiliyor. **Şu an ayrışma yok** —
-  iki branch'in ağacı birebir aynı (bkz. [branch-audit.md](branch-audit.md) §3.1).
-- Öneri ve gerekçe: [branching-proposal.md](branching-proposal.md).
+```
+main ──► feat|fix|chore|infra/* ──► PR → main ──► test ortamına otomatik deploy
+```
+
+- Tek uzun ömürlü branch: **`main`** (default). İş branch'leri kısa ömürlü, merge sonrası otomatik silinir.
+- İş başına **1 PR**. Eski `feature → dev → test → main` modeli kaldırıldı.
+- `dev` ve `test` branch'leri `main` ile aynı içeriği taşıyan **dondurulmuş kopyalar**; CI tetiklemezler,
+  ekip onayıyla silinecekler.
+- Silinen tüm eski branch'ler `archive/<branch-adı>` tag'i olarak korunuyor (26 tag).
+- Kurallar: [BRANCHING.md](../conventions/BRANCHING.md) · Gerekçe ve ölçümler: [branching-proposal.md](branching-proposal.md)
 
 ---
 

--- a/docs/conventions/BRANCHING.md
+++ b/docs/conventions/BRANCHING.md
@@ -2,83 +2,85 @@
 
 Bu doküman, Cargo Pilot projesinde branch yapısını, geliştirme akışını ve PR kurallarını tanımlar.
 
+**Model:** Trunk-based — tek uzun ömürlü branch (`main`), kısa ömürlü iş branch'leri.
+**Geçerlilik:** 2026-08-03'ten itibaren. Önceki `feature → dev → test → main` modeli kaldırılmıştır.
+
 ---
 
 ## Branch Modeli
 
 ```
-test ──► feature/* ──► PR → dev ──► PR: aynı feature → test ──► PR: test → main
+main ──► feat/US-142-login-form ──► PR → main ──► test ortamına otomatik deploy
+                                          │
+                                          └──► v1.4.0 tag'i → production (onaylı)
 ```
 
 {% hint style="info" %}
-**İki kritik kural:**
+**Üç kritik kural:**
 
-1. Feature branch'ler **`test` branch'inden** açılır (`dev`'den değil).
-2. `test`'e PR, feature branch'in **önce `dev`'e merge edildiği aynı branch'ten** açılır. `dev`'den `test`'e doğrudan PR açılamaz.
+1. Tüm iş branch'leri **`main`'den** açılır.
+2. Tek PR açılır: iş branch'i → `main`. İkinci bir doğrulama dalı yoktur.
+3. `main`'e her merge, **test ortamına** otomatik deploy olur.
 {% endhint %}
 
-Neden `test`'ten açılır? `dev` birden fazla geliştiricinin işlerini barındırır. `dev`'den açılan branch zaman içinde başka commit'leri taşır. `test`'ten açılan branch yalnızca o işin kopyasıdır — temiz ve izole.
+**`test` bir ORTAM adıdır, branch değil.** Docker image tag'leri (`:test`, `:test-{sha}`),
+compose dosyaları (`docker-compose.test.yml`) ve env dosyaları (`.env.test`) ortamı ifade eder.
 
 ---
 
 ## Branch Türleri
 
-| Branch | Rol | Açılış Noktası |
-|--------|-----|----------------|
-| `main` | Production | — (doğrudan push yok) |
-| `test` | Test ortamı + feature başlangıç noktası | — |
-| `dev` | Teknik doğrulama kapısı | — |
-| `feature/*` | Yeni geliştirme | `test`'ten |
-| `bugfix/*` | Hata düzeltme | `test`'ten |
-
-### `main`
+| Branch | Rol | Açılış Noktası | Ömür |
+|--------|-----|----------------|------|
+| `main` | Trunk — tek gerçek kaynak, test ortamının kaynağı | — (doğrudan push yok) | Kalıcı |
+| `feat/*` | Yeni özellik | `main`'den | ≤ 3 gün |
+| `fix/*` | Hata düzeltme | `main`'den | ≤ 3 gün |
+| `hotfix/*` | Production acil düzeltme | Production tag'inden | Saatler |
+| `chore/*` | Doküman, bağımlılık, temizlik | `main`'den | ≤ 3 gün |
+| `infra/*` | CI/CD, compose, monitoring (DevOps) | `main`'den | ≤ 3 gün |
 
 {% hint style="danger" %}
-Doğrudan push yapılmaz. Yalnızca onaylı, production'a hazır içerik alınır.
+`main`'e doğrudan push yapılmaz. Ruleset engeller.
 {% endhint %}
 
-### `test`
+### Kısa ömür neden önemli
 
-- Test ortamının referans branch'i.
-- Feature branch'lerin başlangıç noktası.
-- CI/CD pipeline buradan tetiklenir.
-- `dev` branch'inden doğrudan PR açılamaz; `enforce-test-base` CI job'u bunu denetler.
-
-### `dev`
-
-- Kalıcı entegrasyon alanı değil — teknik doğrulama kapısı.
-- Feature branch `dev`'e merge edildikten sonra kod review ve temel doğrulama yapılır.
-- `test`'e çıkış için ön koşul: commit `origin/dev`'de bulunmak zorunda (CI kontrol eder).
+Eski modelde 1000+ commit geride kalan branch'ler birikmişti; hiçbiri rebase edilemedi ve
+hepsi silinmek zorunda kaldı. **3 günden uzun yaşayan branch bir uyarı işaretidir** — işi böl.
 
 ---
 
 ## Branch İsimlendirme
 
 ```
-feature/<iş-kodu>-<kısa-açıklama>
-bugfix/<iş-kodu>-<kısa-açıklama>
+<tür>/<iş-kodu>-<kısa-açıklama>
 ```
 
 **Doğru örnekler:**
 
 ```
-feature/US-142-login-form
-feature/US-211-customer-search
-bugfix/US-188-null-check
-bugfix/INC-002-minio-config-fix
+feat/US-142-login-form
+feat/US-211-customer-search
+fix/US-188-null-check
+fix/INC-002-minio-config-fix
+chore/branch-temizligi
+infra/prod-deploy-pipeline
+hotfix/v1.3.1-share-token-401
 ```
 
 {% hint style="danger" %}
 **Yanlış örnekler:**
 
 ```
-feature/yeni-yapi              # iş kodu yok
-Feature/US-142-Login           # büyük harf
-bugfix/docker compose fix      # boşluk var
-feature/çalışan-yapı           # Türkçe karakter
-feature/us-142-login-form      # iş kodu küçük harf
+feat/yeni-yapi                 # iş kodu yok
+Feat/US-142-Login              # büyük harf
+fix/docker compose fix         # boşluk var
+feat/çalışan-yapı              # Türkçe karakter
+feat/us-142-login-form         # iş kodu küçük harf
 ```
 {% endhint %}
+
+`chore/` ve `infra/` için iş kodu zorunlu değildir.
 
 ---
 
@@ -88,7 +90,7 @@ feature/us-142-login-form      # iş kodu küçük harf
 
 ```bash
 git fetch origin
-git checkout -b feature/US-142-login-form origin/test
+git checkout -b feat/US-142-login-form origin/main
 ```
 
 **Adım 2 — Geliştir ve commit at:**
@@ -96,82 +98,103 @@ git checkout -b feature/US-142-login-form origin/test
 ```bash
 git add <dosyalar>
 git commit -m "login form eklendi"
-git push origin feature/US-142-login-form
+git push origin feat/US-142-login-form
 ```
 
-**Adım 3 — `dev`'e PR aç (teknik doğrulama):**
+Push anında CI çalışır (lint, format, TypeScript, test, backend build, image build).
+
+**Adım 3 — `main`'e PR aç:**
 
 ```bash
-gh pr create --base dev --head feature/US-142-login-form
+gh pr create --base main --head feat/US-142-login-form
 ```
 
-**Adım 4 — dev'de doğrula:**
+**Adım 4 — Review ve merge:**
 
-- Kod review tamamlandı mı?
-- Build hatası var mı?
-- Kritik yan etki oluşturuyor mu?
+- En az 1 approving review
+- Tüm required check'ler yeşil
+- Merge sonrası branch **otomatik silinir**
 
-**Adım 5 — Aynı branch'ten `test`'e PR aç:**
-
-```bash
-gh pr create --base test --head feature/US-142-login-form
-```
-
-{% hint style="warning" %}
-`test`'e PR yalnızca dev'e merge edilmiş branch'ten açılabilir. CI'daki `enforce-test-base` job'u şunları kontrol eder:
-
-- Head branch `dev` olamaz
-- PR commit'i `origin/dev`'de bulunmalı
-{% endhint %}
-
-**Adım 6 — Merge sonrası branch'i sil.**
+**Adım 5 — Doğrula:** Merge test ortamına otomatik deploy olur —
+[cargopilot.divizyon.org](http://cargopilot.divizyon.org)
 
 ---
 
 ## PR Kuralları
 
-### Feature → Dev
-
 | Kural | Detay |
 |-------|-------|
 | Açıklama | İş kodu + ne yapıldığı |
 | Onay | En az 1 approving review |
-| Merge eden | Herhangi bir geliştirici |
-
-### Feature → Test
-
-| Kural | Detay |
-|-------|-------|
-| Ön koşul | Dev'e merge edilmiş olmalı (CI kontrol eder) |
-| Onay | En az 1 approving review |
-| Merge eden | Yalnızca Chapter Lead / DevOps |
-| Required checks | `Test PR Base Kontrolü`, `Image Build`, `Deploy (Test)` |
-
-### Test → Main
-
-| Kural | Detay |
-|-------|-------|
-| Ön koşul | QA onayı |
-| Merge eden | Yalnızca Chapter Lead / DevOps |
+| Required checks | `Frontend CI`, `Backend CI`, `Pending Migration Kontrolü`, `Image Build`, `Deploy (Test)` |
+| Push sonrası | Eski onaylar düşer, yeniden review gerekir |
+| Review thread | Tümü çözülmüş olmalı |
+| UI değişikliği | Ekran görüntüsü zorunlu |
+| 3D / algoritma değişikliği | Öncesi–sonrası plan karşılaştırması zorunlu |
 
 ---
 
 ## Branch — Ortam İlişkisi
 
-| Branch | Ortam | Çalışan Pipeline |
-|--------|-------|-----------------|
-| `feature/*`, `bugfix/*` | — | Sadece `Deploy (Test)` (inline build) |
-| `dev` | Dev | Sadece `Deploy (Test)` (PR'da) |
-| `test` | Test | `Image Build` + `Deploy (Test)` |
-| `main` | Production | _(Production pipeline henüz yok)_ |
+| Tetikleyici | Ortam | Çalışan Pipeline |
+|-------------|-------|------------------|
+| `feat/*`, `fix/*`, `chore/*`, `infra/*` push | — | `CI` (lint + build + test + image build) |
+| PR → `main` | — | `CI` + `Pending Migration Kontrolü` + `Image Build` + `Deploy (Test)` doğrulaması |
+| push `main` | **Test** | `Image Build` → GHCR push → test sunucusuna deploy |
+| `v*` tag | **Production** | _(Production pipeline henüz yok — bkz. devops-backlog 2.2)_ |
+
+---
+
+## Production'a Çıkış
+
+Production pipeline'ı henüz kurulmamıştır (`docs/devops/devops-backlog.md` madde 2.2, 2.3).
+Kurulduğunda akış:
+
+```bash
+# main üzerinde, test ortamında doğrulanmış commit'te
+git tag v1.4.0
+git push origin v1.4.0
+```
+
+Tag, `production` GitHub Environment'ını tetikler; zorunlu onaylayıcı deploy'u başlatır.
+Rollback tag tabanlıdır (`.github/workflows/rollback.yml`).
+
+### Hotfix
+
+```bash
+git checkout -b hotfix/v1.3.1-aciklama v1.3.0
+# düzelt
+gh pr create --base main --head hotfix/v1.3.1-aciklama
+# merge sonrası
+git tag v1.3.1 && git push origin v1.3.1
+```
 
 ---
 
 ## Merge Stratejisi
 
-**Tercih edilen: Merge Commit**
+**Tercih edilen: Merge Commit.** Branch commit geçmişi korunur, `git bisect` çalışır.
 
-GitHub'da "Create a merge commit" seçeneği kullanılır. Branch commit geçmişi korunur, `git bisect` ile hata tespiti yapılabilir.
+{% hint style="info" %}
+PR açmadan önce anlamsız commit'leri temizleyin (bkz. [Commit Kuralları](COMMITS.md)).
+Tek mantıksal değişiklik için 10 ayrı "prettier düzeltmesi" commit'i bırakmayın.
+{% endhint %}
+
+---
+
+## Eski Modelden Geçiş
+
+`dev` ve `test` branch'leri artık **kullanılmıyor**. `main` ile aynı içeriği taşıyan
+dondurulmuş kopyalardır ve CI tetiklemezler; ekip onayıyla silineceklerdir.
+
+Eskiden silinen tüm branch'ler `archive/<branch-adı>` tag'i olarak korunmaktadır:
+
+```bash
+git fetch --tags
+git checkout -b feat/US-XXX-devam archive/feature/eski-branch-adi
+```
+
+Geçiş gerekçesi ve ölçümler: `docs/context/branching-proposal.md`.
 
 ---
 


### PR DESCRIPTION
## Özet

`feature → dev → test → main` zinciri kaldırıldı, tek uzun ömürlü branch (`main`) modeline geçildi.

## Değişiklikler

**Workflow'lar**
- `ci.yml` + `test-deploy.yml` tetikleyicileri: `test`/`dev` → `main`
- `enforce-test-base` job'u **kaldırıldı** — iki dallı model bittiği için gereksiz (87 satır, `sync/*` muafiyeti ve copilot muafiyet denemeleri dahil)
- Yeni branch önekleri: `feat/`, `fix/`, `hotfix/`, `chore/`, `infra/` — eski `feature/`, `bugfix/` geçiş için korundu
- Sunucu deploy script'i artık `git checkout main` yapıyor

**Doküman**
- `BRANCHING.md` trunk modeliyle yeniden yazıldı
- `docs/context/*` güncel duruma getirildi

## Değişiklik Tipi

- [x] 🔧 Chore / altyapı

## Neden

5 kişilik ekipte (DevOps/Backend/Algoritma/Frontend) iki entegrasyon dalı tutmanın maliyeti faydasını aşıyordu. Ölçüm: son 40 PR'da **13 branch birden fazla PR** açmış, son 30 PR'ın **10'u merge edilmeden kapatılmış**. Gerekçe: `docs/context/branching-proposal.md`.

## Test Edildi mi?

- [x] Bu PR'ın kendi CI koşusu yeni tetikleyicilerin doğrulaması — `Frontend CI`, `Backend CI`, `Pending Migration Kontrolü`, `Image Build`, `Deploy (Test)` job'larının hepsi `base_ref == 'main'` koşuluyla çalışmalı
- [x] Kalan `refs/heads/test` / `base_ref == 'test'` referansı yok (grep ile doğrulandı)

## Kontrol Listesi

- [x] Commit mesajları commit kurallarına uygun
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi

## Ek Notlar

⛔ **Production pipeline (`v*` tag) bu PR'da YOK.** Sebep: `PROD_SSH_*` secret'ları tanımsız, prod stack sunucuda hiç kurulmadı, `docker-compose.prod.yml`'de healthcheck/env eksikleri var. Önce `devops-backlog.md` 1.2–1.4 ve 2.1 çözülmeli.

Geri alma noktaları: `archive/main-2026-08-03`, `archive/dev-2026-08-03`.