### PR TITLE
fix(INC-003): deploy öncesi bayat GHCR kimlik bilgisi temizleniyor

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -321,6 +321,12 @@ jobs:
             git checkout main
             git reset --hard origin/main
 
+            # GHCR paketleri public; login GEREKMEZ. Sunucuda kalmış eski/süresi dolmuş
+            # bir ghcr.io kimlik bilgisi varsa docker anonim pull'a düşmez ve
+            # "error from registry: denied" alır. Kalıntı kimlik bilgisini temizle.
+            echo "==> Bayat GHCR kimlik bilgisi temizleniyor..."
+            docker logout ghcr.io >/dev/null 2>&1 || true
+
             echo "==> Image'lar GHCR'dan çekiliyor (tag: ${IMAGE_TAG})..."
             IMAGE_TAG="${IMAGE_TAG}" docker compose \
               -f infra/compose/docker-compose.test.yml \

--- a/docs/devops/known-issues.md
+++ b/docs/devops/known-issues.md
@@ -8,6 +8,31 @@
 
 ## Açık Sorunlar
 
+### 0 — Sunucuda Bayat GHCR Kimlik Bilgisi (INC-003)
+
+{% hint style="warning" %}
+**Durum:** 🔧 Düzeltme uygulandı — doğrulama bekliyor
+{% endhint %}
+
+2026-08-03'te test sunucusuna deploy `error from registry: denied` ile kırıldı. Son başarılı
+deploy 2026-05-20'ydi.
+
+**Kök neden:** GHCR paketleri 2026-05-10'da public yapıldı ve `TEST_GHCR_PAT` login'i
+`test-deploy.yml`'den kaldırıldı (#483). Ancak sunucudaki `~/.docker/config.json` içinde eski
+PAT kimlik bilgisi kaldı. PAT'in süresi dolunca docker anonim pull'a **düşmedi**; geçersiz
+kimlik bilgisiyle deneyip `denied` aldı.
+
+**Etkisi:** Test ortamı 2026-05-20'den beri yeni image almıyordu.
+
+**Not:** Bu sorun trunk branch geçişinden **önce** de mevcuttu — aynı hata `test` branch'inde de
+alınmıştı (run 30809546247). Geçişten kaynaklanmadı.
+
+**Uygulanan çözüm:** Deploy script'ine pull öncesi `docker logout ghcr.io || true` eklendi.
+
+**Manuel alternatif:** Sunucuda bir kez `docker logout ghcr.io`.
+
+---
+
 ### 1 — Resend Domain Doğrulaması Tamamlanmadı
 
 {% hint style="warning" %}


### PR DESCRIPTION
## Özet

Test sunucusuna deploy `error from registry: denied` ile kırılıyordu. **Son başarılı deploy 2026-05-20.**

## Kök neden

GHCR paketleri 2026-05-10'da public yapıldı ve `TEST_GHCR_PAT` login'i workflow'dan kaldırıldı (#483). Ancak sunucudaki `~/.docker/config.json` içinde eski PAT kimlik bilgisi kaldı. PAT'in süresi dolunca docker **anonim pull'a düşmedi** — geçersiz kimlik bilgisiyle deneyip `denied` aldı.

Doğrulama: aynı tag'ler anonim olarak sorunsuz çekilebiliyor.

```
cargo-pilot-backend   test-d56bca2   HTTP 200
cargo-pilot-frontend  test-d56bca2   HTTP 200
```

## Çözüm

Deploy script'inde pull öncesi `docker logout ghcr.io || true`. Paketler public olduğu için login zaten gereksiz; bu satır kalıntı kimlik bilgisini temizleyip anonim pull'u garantiler.

## Değişiklik Tipi

- [x] 🐛 Bug düzeltme

## Bu trunk geçişinden mi kaynaklandı?

**Hayır.** Aynı hata trunk geçişinden önce, `test` branch'inde de alınmıştı (run `30809546247`, 11:30). Geçiş sadece sorunu görünür kıldı.

## Test Edildi mi?

- [x] Kök neden GHCR registry'ye doğrudan sorgu ile doğrulandı
- [ ] Merge sonrası `main` push'unda `Deploy (Test Server)` job'unun geçmesiyle doğrulanacak

## Kontrol Listesi

- [x] Commit mesajları commit kurallarına uygun
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (`known-issues.md` madde 0)