### PR TITLE
infra: uc dalli terfi modeli (dev -> test -> main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI — Kod Kalite ve Build Kontrolü
 
-# Tüm iş branch'i push'larında ve main PR'larında çalışır.
-# Amaç: hataları main'e ulaşmadan yakalamak.
+# Tüm iş branch'i push'larında ve dev/test/main PR'larında çalışır.
+# Amaç: hataları bir sonraki dala terfi etmeden yakalamak.
 on:
   push:
     branches:
@@ -15,9 +15,44 @@ on:
       - bugfix/**
   pull_request:
     branches:
+      - dev
+      - test
       - main
 
 jobs:
+  # ─── Terfi zinciri denetimi ──────────────────────────────────────────────────
+  # Akış: feat/* → dev → test → main. Sıra atlanırsa dallar ayrışır.
+  # Bu repoda bir kez yaşandı (#482 dev'i atladı → sync/test-to-dev yaması gerekti).
+  enforce-promotion:
+    name: Terfi Zinciri Kontrolü
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      (github.base_ref == 'test' || github.base_ref == 'main')
+
+    steps:
+      - name: Kaynak branch'i doğrula
+        env:
+          BASE: ${{ github.base_ref }}
+          HEAD: ${{ github.head_ref }}
+        run: |
+          if [ "$BASE" = "test" ] && [ "$HEAD" != "dev" ]; then
+            echo "::error::'test' dalına yalnızca 'dev' üzerinden PR açılabilir. Gelen: '$HEAD'"
+            exit 1
+          fi
+
+          if [ "$BASE" = "main" ]; then
+            case "$HEAD" in
+              test|hotfix/*) ;;
+              *)
+                echo "::error::'main' dalına yalnızca 'test' veya 'hotfix/*' üzerinden PR açılabilir. Gelen: '$HEAD'"
+                exit 1
+                ;;
+            esac
+          fi
+
+          echo "Terfi zinciri geçerli: $HEAD → $BASE"
+
   # ─── Frontend CI ─────────────────────────────────────────────────────────────
   frontend-ci:
     name: Frontend CI
@@ -99,9 +134,11 @@ jobs:
     permissions:
       contents: read
       packages: read
+    # PR → test/main'de image build test-deploy.yml'deki "Image Build" job'u ile yapılır;
+    # burada yalnızca ilk kapıda (dev) ve iş branch'i push'larında koşar.
     if: |
-      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-      (github.event_name == 'push' && github.ref != 'refs/heads/main')
+      (github.event_name == 'pull_request' && github.base_ref == 'dev') ||
+      (github.event_name == 'push')
 
     steps:
       - name: Kodu al

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,49 @@
+name: Sürüm Etiketi
+
+# `test → main` terfisi bir sürüm noktasıdır. Prod sunucusu kurulana kadar main
+# deploy tetiklemez, ama etiket şimdiden atılır:
+#   - `infra/scripts/rollback.sh` tag tabanlı çalışır (TARGET_REF)
+#   - Prod açıldığı gün sürüm geçmişi ve geri dönüş noktaları hazır olur
+#
+# Sürüm şeması: v0.<minor>.0 — prod'a ilk çıkışta v1.0.0'a geçilir.
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  tag:
+    name: Sürüm Etiketi Oluştur
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Kodu al
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sıradaki sürümü belirle ve etiketle
+        run: |
+          set -e
+          git fetch --tags --force
+
+          LAST=$(git tag -l 'v0.*.0' | sort -V | tail -n 1)
+          if [ -z "$LAST" ]; then
+            NEXT_MINOR=1
+          else
+            NEXT_MINOR=$(( $(echo "$LAST" | cut -d. -f2) + 1 ))
+          fi
+          TAG="v0.${NEXT_MINOR}.0"
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Etiket zaten var, atlanıyor: ${TAG}"
+            exit 0
+          fi
+
+          git tag -a "$TAG" -m "Sürüm ${TAG} — $(git log -1 --pretty=%s)"
+          git push origin "$TAG"
+
+          echo "Etiket oluşturuldu: **${TAG}** (önceki: ${LAST:-yok})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,15 +1,18 @@
 name: Test Ortamı CI/CD
 
-# Trunk modeli: tek uzun ömürlü branch = main. "test" bir ORTAM adıdır, branch değil.
+# Üç dallı terfi modeli: feat/* → dev → test → main
+# Test SUNUCUSU'nun kaynağı `test` dalıdır; gösterilen ve QA'in denediği sürüm odur.
+# `main` production'a ayrılmıştır — prod sunucusu kurulana kadar deploy tetiklemez.
 #
 # Tetikleyiciler:
-#   push (iş branch'leri)  → sadece deploy (inline build + healthcheck)
-#   pull_request → main    → build + deploy (doğrulama)
-#   push (main)            → build + GHCR push + test sunucusuna deploy
+#   push (iş branch'leri)  → geçici stack ile doğrulama (inline build + healthcheck)
+#   pull_request → test    → migration + build + geçici stack doğrulaması
+#   pull_request → main    → yalnızca migration kontrolü (içerik test'te zaten koştu)
+#   push (test)            → build + GHCR push + test sunucusuna deploy
 on:
   push:
     branches:
-      - main
+      - test
       - feat/**
       - fix/**
       - hotfix/**
@@ -20,17 +23,18 @@ on:
       - bugfix/**
   pull_request:
     branches:
+      - test
       - main
 
 jobs:
   # ─── Migration kontrolü: model değişmiş ama migration oluşturulmamışsa fail ──
-  # Sadece main'e giden PR'larda veya main'e push'ta çalışır (iş branch'i push'larında gereksiz)
+  # test/main PR'larında ve test push'ta çalışır (iş branch'i push'larında gereksiz)
   migration-check:
     name: Pending Migration Kontrolü
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      (github.event_name == 'pull_request' && (github.base_ref == 'test' || github.base_ref == 'main')) ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/test')
 
     steps:
       - name: Kodu al
@@ -62,17 +66,16 @@ jobs:
             --configuration Release
           echo "Migration kontrolü geçti: bekleyen model değişikliği yok."
 
-  # ─── Build job: sadece main'e giden PR'da veya main'e push'ta çalışır ────────
-  # US-D27-I: main push'ta image'lar GHCR'a push edilir.
+  # ─── Build job: test'e giden PR'da veya test'e push'ta çalışır ──────────────
+  # US-D27-I: test push'ta image'lar GHCR'a push edilir.
   # Her push'ta hem :test (mutable, latest) hem :test-{sha} (immutable) tag'i push edilir.
-  # NOT: :test tag'i ORTAM adıdır (test sunucusu), branch adı değil.
   # deploy-test-server job'u immutable tag'i kullanır; rollback için geçmişe erişim sağlar.
   build:
     name: Image Build
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      (github.event_name == 'pull_request' && github.base_ref == 'test') ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/test')
 
     # packages: write — GHCR'a push edebilmek için gerekli
     permissions:
@@ -108,7 +111,7 @@ jobs:
         with:
           context: ./apps/backend
           file: ./apps/backend/Dockerfile
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/test' }}
           tags: |
             ghcr.io/divizyon/cargo-pilot-backend:test
             ghcr.io/divizyon/cargo-pilot-backend:${{ steps.sha.outputs.tag }}
@@ -123,7 +126,7 @@ jobs:
         with:
           context: ./apps/frontend
           file: ./apps/frontend/Dockerfile
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/test' }}
           tags: |
             ghcr.io/divizyon/cargo-pilot-frontend:test
             ghcr.io/divizyon/cargo-pilot-frontend:${{ steps.sha.outputs.tag }}
@@ -148,7 +151,7 @@ jobs:
       always() &&
       (needs.migration-check.result == 'success' || needs.migration-check.result == 'skipped') &&
       (
-        (github.event_name == 'pull_request' && github.base_ref == 'main') ||
+        (github.event_name == 'pull_request' && github.base_ref == 'test') ||
         (github.event_name == 'push')
       )
 
@@ -287,7 +290,7 @@ jobs:
         run: |
           docker compose -f infra/compose/docker-compose.test.yml down -v
 
-  # ─── Test sunucusuna deploy: sadece main'e push'ta çalışır ───────────────────
+  # ─── Test sunucusuna deploy: sadece test'e push'ta çalışır ──────────────────
   deploy-test-server:
     name: Deploy (Test Server)
     runs-on: ubuntu-latest
@@ -297,7 +300,7 @@ jobs:
       (needs.migration-check.result == 'success') &&
       (needs.build.result == 'success') &&
       github.event_name == 'push' &&
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/test'
 
     steps:
       # US-D27-I: Sunucu artık build yapmıyor; GHCR'dan pull edilen image'ı kullanıyor.
@@ -315,11 +318,11 @@ jobs:
             set -e
             cd /opt/cargo-pilot
 
-            echo "==> main branch güncelleniyor..."
+            echo "==> test branch güncelleniyor..."
             git remote prune origin
             git fetch --prune origin
-            git checkout main
-            git reset --hard origin/main
+            git checkout test
+            git reset --hard origin/test
 
             # GHCR paketleri public; login GEREKMEZ. Sunucuda kalmış eski/süresi dolmuş
             # bir ghcr.io kimlik bilgisi varsa docker anonim pull'a düşmez ve

--- a/docs/conventions/BRANCHING.md
+++ b/docs/conventions/BRANCHING.md
@@ -2,29 +2,39 @@
 
 Bu doküman, Cargo Pilot projesinde branch yapısını, geliştirme akışını ve PR kurallarını tanımlar.
 
-**Model:** Trunk-based — tek uzun ömürlü branch (`main`), kısa ömürlü iş branch'leri.
-**Geçerlilik:** 2026-08-03'ten itibaren. Önceki `feature → dev → test → main` modeli kaldırılmıştır.
+**Model:** Üç dallı terfi (promotion) modeli — `dev` → `test` → `main`.
+**Geçerlilik:** 2026-08-03'ten itibaren.
 
 ---
 
 ## Branch Modeli
 
 ```
-main ──► feat/US-142-login-form ──► PR → main ──► test ortamına otomatik deploy
-                                          │
-                                          └──► v1.4.0 tag'i → production (onaylı)
+feat/US-142-x ──PR (squash)──► dev ──PR (merge)──► test ──PR (merge)──► main
+                                │                   │                    │
+                               CI            TEST SUNUCUSU        ileride PRODUCTION
+                                          (gösterim + QA testi)   (şimdilik deploy yok)
 ```
 
-{% hint style="info" %}
-**Üç kritik kural:**
+| Dal | Rol | Deploy hedefi | Terfi ritmi |
+|-----|-----|---------------|-------------|
+| `dev` | Günlük entegrasyon | Yok, sadece CI | — |
+| `test` | QA / gösterim ortamı | **Test sunucusu** | İş onaylandıkça |
+| `main` | Production'a hazır sürüm | *(prod sunucusu kurulunca)* | Haftalık |
 
-1. Tüm iş branch'leri **`main`'den** açılır.
-2. Tek PR açılır: iş branch'i → `main`. İkinci bir doğrulama dalı yoktur.
-3. `main`'e her merge, **test ortamına** otomatik deploy olur.
+{% hint style="info" %}
+**Dört kritik kural:**
+
+1. Tüm iş branch'leri **`dev`'den** açılır.
+2. `test`'e **yalnızca `dev`'den** PR açılabilir. CI bunu zorunlu kılar.
+3. `main`'e **yalnızca `test`'ten** veya `hotfix/*`'ten PR açılabilir.
+4. `test`'e her merge, test sunucusuna otomatik deploy olur.
 {% endhint %}
 
-**`test` bir ORTAM adıdır, branch değil.** Docker image tag'leri (`:test`, `:test-{sha}`),
-compose dosyaları (`docker-compose.test.yml`) ve env dosyaları (`.env.test`) ortamı ifade eder.
+{% hint style="danger" %}
+`dev`, `test` ve `main`'e doğrudan push yapılmaz. Ruleset engeller.
+`test` ve `main` üzerinde **hiç commit üretilmez** — içerikleri yalnızca terfi ile değişir.
+{% endhint %}
 
 ---
 
@@ -32,21 +42,25 @@ compose dosyaları (`docker-compose.test.yml`) ve env dosyaları (`.env.test`) o
 
 | Branch | Rol | Açılış Noktası | Ömür |
 |--------|-----|----------------|------|
-| `main` | Trunk — tek gerçek kaynak, test ortamının kaynağı | — (doğrudan push yok) | Kalıcı |
-| `feat/*` | Yeni özellik | `main`'den | ≤ 3 gün |
-| `fix/*` | Hata düzeltme | `main`'den | ≤ 3 gün |
-| `hotfix/*` | Production acil düzeltme | Production tag'inden | Saatler |
-| `chore/*` | Doküman, bağımlılık, temizlik | `main`'den | ≤ 3 gün |
-| `infra/*` | CI/CD, compose, monitoring (DevOps) | `main`'den | ≤ 3 gün |
-
-{% hint style="danger" %}
-`main`'e doğrudan push yapılmaz. Ruleset engeller.
-{% endhint %}
+| `dev` | Entegrasyon dalı | — | Kalıcı |
+| `test` | QA ortamının kaynağı | — | Kalıcı |
+| `main` | Production'ın kaynağı | — | Kalıcı |
+| `feat/*` | Yeni özellik | `dev`'den | ≤ 3 gün |
+| `fix/*` | Hata düzeltme | `dev`'den | ≤ 3 gün |
+| `chore/*` | Doküman, bağımlılık, temizlik | `dev`'den | ≤ 3 gün |
+| `infra/*` | CI/CD, compose, monitoring (DevOps) | `dev`'den | ≤ 3 gün |
+| `hotfix/*` | Production acil düzeltme | Sürüm tag'inden | Saatler |
 
 ### Kısa ömür neden önemli
 
 Eski modelde 1000+ commit geride kalan branch'ler birikmişti; hiçbiri rebase edilemedi ve
-hepsi silinmek zorunda kaldı. **3 günden uzun yaşayan branch bir uyarı işaretidir** — işi böl.
+hepsi silinmek zorunda kaldı. **3 günden uzun yaşayan iş branch'i bir uyarı işaretidir** — işi böl.
+
+### `dev` her an çıkılabilir olmalı
+
+Sıra dışı bir terfi gerektiğinde (`dev → test` erken açılır) `dev`'deki **her şey** birlikte gider.
+Bu yüzden yarım kalan iş `dev`'e merge edilmez; `feat/*` dalında bekler. Uzun sürecek riskli
+değişiklikler için feature flag kullanın.
 
 ---
 
@@ -65,7 +79,7 @@ fix/US-188-null-check
 fix/INC-002-minio-config-fix
 chore/branch-temizligi
 infra/prod-deploy-pipeline
-hotfix/v1.3.1-share-token-401
+hotfix/v0.4.1-share-token-401
 ```
 
 {% hint style="danger" %}
@@ -86,11 +100,11 @@ feat/us-142-login-form         # iş kodu küçük harf
 
 ## Adım Adım Geliştirme Akışı
 
-**Adım 1 — Branch aç:**
+**Adım 1 — `dev`'den branch aç:**
 
 ```bash
 git fetch origin
-git checkout -b feat/US-142-login-form origin/main
+git checkout -b feat/US-142-login-form origin/dev
 ```
 
 **Adım 2 — Geliştir ve commit at:**
@@ -101,22 +115,85 @@ git commit -m "login form eklendi"
 git push origin feat/US-142-login-form
 ```
 
-Push anında CI çalışır (lint, format, TypeScript, test, backend build, image build).
+Push anında CI çalışır (lint, format, TypeScript, test, backend build).
 
-**Adım 3 — `main`'e PR aç:**
+**Adım 3 — `dev`'e PR aç:**
 
 ```bash
-gh pr create --base main --head feat/US-142-login-form
+gh pr create --base dev --head feat/US-142-login-form
 ```
 
-**Adım 4 — Review ve merge:**
+**Merge yöntemi: squash.** Branch'teki dağınık commit'ler tek, okunabilir commit'e iner.
 
-- En az 1 approving review
-- Tüm required check'ler yeşil
-- Merge sonrası branch **otomatik silinir**
+**Adım 4 — İş onaylandığında `test`'e terfi et:**
 
-**Adım 5 — Doğrula:** Merge test ortamına otomatik deploy olur —
-[cargopilot.divizyon.org](http://cargopilot.divizyon.org)
+```bash
+gh pr create --base test --head dev --title "Terfi: dev → test"
+```
+
+**Merge yöntemi: merge commit.** Squash yapılırsa `test`, `dev`'de olmayan yeni bir commit alır
+ve dallar kalıcı olarak ayrışır.
+
+Merge sonrası test sunucusuna otomatik deploy olur — geliştiriciler ve QA burada test eder.
+
+**Adım 5 — Haftalık görevler bitince `main`'e terfi et:**
+
+```bash
+gh pr create --base main --head test --title "Sürüm: test → main"
+```
+
+Merge sonrası CI otomatik `v0.<n>.0` sürüm etiketi atar.
+
+---
+
+## Bug Test Ortamında Bulunursa
+
+Test sunucusunda bulunan bir hata **`test` dalında düzeltilmez.**
+
+```bash
+git checkout -b fix/INC-004-aciklama origin/dev   # dev'den aç
+# düzelt, PR → dev, merge
+gh pr create --base test --head dev               # yeniden terfi et
+```
+
+Doğrudan `test`'e commit atmak veya `feat/*`'ten `test`'e PR açmak dalları ayrıştırır.
+Bu repoda bir kez yaşandı (#482 `dev`'i atladı → `sync/test-to-dev` yaması gerekti).
+CI artık bunu engelliyor.
+
+---
+
+## Hotfix
+
+Production'da acil bir hata için sıra beklenmez:
+
+```bash
+git checkout -b hotfix/v0.4.1-aciklama v0.4.0
+# düzelt
+gh pr create --base main --head hotfix/v0.4.1-aciklama
+```
+
+{% hint style="danger" %}
+**Merge sonrası geri-merge ZORUNLU.** Atlanırsa `test` ve `dev` düzeltmeyi kaçırır ve
+bir sonraki terfide düzeltme geri alınır:
+
+```bash
+gh pr create --base test --head main --title "Geri-merge: hotfix v0.4.1"
+gh pr create --base dev  --head test --title "Geri-merge: hotfix v0.4.1"
+```
+{% endhint %}
+
+---
+
+## Merge Stratejisi
+
+| PR | Yöntem | Neden |
+|----|--------|-------|
+| `feat/*` → `dev` | **Squash** | Temiz geçmiş; iş başına tek commit |
+| `dev` → `test` | **Merge commit** | Commit kimliği korunmalı |
+| `test` → `main` | **Merge commit** | Commit kimliği korunmalı |
+| `hotfix/*` → `main` | **Merge commit** | Geri-merge edilebilir kalmalı |
+
+Ruleset her dalda yalnızca doğru yöntemi açık bırakır; yanlış seçim yapılamaz.
 
 ---
 
@@ -126,11 +203,20 @@ gh pr create --base main --head feat/US-142-login-form
 |-------|-------|
 | Açıklama | İş kodu + ne yapıldığı |
 | Onay | En az 1 approving review |
-| Required checks | `Frontend CI`, `Backend CI`, `Pending Migration Kontrolü`, `Image Build`, `Deploy (Test)` |
 | Push sonrası | Eski onaylar düşer, yeniden review gerekir |
 | Review thread | Tümü çözülmüş olmalı |
 | UI değişikliği | Ekran görüntüsü zorunlu |
 | 3D / algoritma değişikliği | Öncesi–sonrası plan karşılaştırması zorunlu |
+
+### Required check'ler
+
+| Hedef dal | Zorunlu kontroller |
+|-----------|--------------------|
+| `dev` | `Frontend CI`, `Backend CI` |
+| `test` | `Frontend CI`, `Backend CI`, `Terfi Zinciri Kontrolü`, `Pending Migration Kontrolü`, `Image Build`, `Deploy (Test)` |
+| `main` | `Frontend CI`, `Backend CI`, `Terfi Zinciri Kontrolü`, `Pending Migration Kontrolü` |
+
+`main`'de image build ve deploy koşmaz — içerik `test`'te zaten build edilip çalıştırılmıştır.
 
 ---
 
@@ -138,63 +224,44 @@ gh pr create --base main --head feat/US-142-login-form
 
 | Tetikleyici | Ortam | Çalışan Pipeline |
 |-------------|-------|------------------|
-| `feat/*`, `fix/*`, `chore/*`, `infra/*` push | — | `CI` (lint + build + test + image build) |
-| PR → `main` | — | `CI` + `Pending Migration Kontrolü` + `Image Build` + `Deploy (Test)` doğrulaması |
-| push `main` | **Test** | `Image Build` → GHCR push → test sunucusuna deploy |
-| `v*` tag | **Production** | _(Production pipeline henüz yok — bkz. devops-backlog 2.2)_ |
+| `feat/*`, `fix/*`, `chore/*`, `infra/*` push | — | `CI` + geçici stack doğrulaması |
+| PR → `dev` | — | `CI` |
+| PR → `test` | — | `CI` + migration + `Image Build` + geçici stack |
+| push `test` | **Test sunucusu** | Build → GHCR push → deploy |
+| PR → `main` | — | `CI` + migration + terfi zinciri |
+| push `main` | — | `v0.<n>.0` sürüm etiketi |
+| Sürüm tag'i | **Production** | _(Pipeline henüz yok — bkz. devops-backlog 2.2)_ |
 
 ---
 
-## Production'a Çıkış
+## Production Durumu
 
-Production pipeline'ı henüz kurulmamıştır (`docs/devops/devops-backlog.md` madde 2.2, 2.3).
-Kurulduğunda akış:
+{% hint style="warning" %}
+Production ortamı **henüz kurulmamıştır.** `main`'e terfi bugün deploy tetiklemez;
+yalnızca sürüm etiketi üretir.
 
-```bash
-# main üzerinde, test ortamında doğrulanmış commit'te
-git tag v1.4.0
-git push origin v1.4.0
-```
+Eksikler: prod sunucusu, `PROD_SSH_HOST` / `PROD_SSH_PRIVATE_KEY` secret'ları,
+`.env.prod`, prod nginx/TLS yapılandırması, `prod-deploy.yml` workflow'u ve
+`docker-compose.prod.yml`'deki eksik env değişkenleri.
 
-Tag, `production` GitHub Environment'ını tetikler; zorunlu onaylayıcı deploy'u başlatır.
-Rollback tag tabanlıdır (`.github/workflows/rollback.yml`).
-
-### Hotfix
-
-```bash
-git checkout -b hotfix/v1.3.1-aciklama v1.3.0
-# düzelt
-gh pr create --base main --head hotfix/v1.3.1-aciklama
-# merge sonrası
-git tag v1.3.1 && git push origin v1.3.1
-```
-
----
-
-## Merge Stratejisi
-
-**Tercih edilen: Merge Commit.** Branch commit geçmişi korunur, `git bisect` çalışır.
-
-{% hint style="info" %}
-PR açmadan önce anlamsız commit'leri temizleyin (bkz. [Commit Kuralları](COMMITS.md)).
-Tek mantıksal değişiklik için 10 ayrı "prettier düzeltmesi" commit'i bırakmayın.
+Detay: [devops-backlog.md](../devops/devops-backlog.md) madde 2.1–2.3,
+[known-issues.md](../devops/known-issues.md) madde 2 ve 5.
 {% endhint %}
 
+Prod açıldığında `main` → production deploy'u `production` GitHub Environment'ı
+üzerinden zorunlu onaylayıcı ile çalışacaktır. Rollback tag tabanlıdır
+(`.github/workflows/rollback.yml`, `infra/scripts/rollback.sh`).
+
 ---
 
-## Eski Modelden Geçiş
+## Arşivlenmiş Branch'ler
 
-`dev` ve `test` branch'leri artık **kullanılmıyor**. `main` ile aynı içeriği taşıyan
-dondurulmuş kopyalardır ve CI tetiklemezler; ekip onayıyla silineceklerdir.
-
-Eskiden silinen tüm branch'ler `archive/<branch-adı>` tag'i olarak korunmaktadır:
+2026-08-03 temizliğinde silinen tüm branch'ler `archive/<branch-adı>` tag'i olarak korunmaktadır:
 
 ```bash
 git fetch --tags
 git checkout -b feat/US-XXX-devam archive/feature/eski-branch-adi
 ```
-
-Geçiş gerekçesi ve ölçümler: `docs/context/branching-proposal.md`.
 
 ---
 


### PR DESCRIPTION
## Ne yapıldı

Üç dallı terfi modeline geçiş. Akış: `feat/* → dev → test → main`

| Dal | Deploy hedefi |
|-----|---------------|
| `dev` | Yok, sadece CI |
| `test` | **Test sunucusu** (gösterim + QA) |
| `main` | İleride production — şimdilik yalnızca sürüm etiketi |

## Değişiklikler

**`test-deploy.yml`** — Deploy kaynağı `main` → `test`. Sunucu artık `test` dalını checkout ediyor. Migration kontrolü `test`/`main` PR'larında, image build + GHCR push `test`'te.

**`ci.yml`** — PR hedefleri `dev`/`test`/`main`. Yeni **Terfi Zinciri Kontrolü** job'u:
- `test`'e yalnızca `dev`'den PR açılabilir
- `main`'e yalnızca `test` veya `hotfix/*` üzerinden PR açılabilir

Bu, #482'de yaşanan (`dev` atlandı → `sync/test-to-dev` yaması gerekti) ayrışmayı yapısal olarak engelliyor.

**`release-tag.yml`** (yeni) — `main`'e her terfide otomatik `v0.<n>.0` etiketi. Prod sunucusu yokken bile `rollback.sh` tag tabanlı çalıştığı için sürüm geçmişi hazır olur.

**`BRANCHING.md`** — Üç dallı modelle yeniden yazıldı. Merge yöntemi kuralı (`dev`'e squash, terfilerde **merge commit**), hotfix geri-merge zorunluluğu, required check tablosu.

## Merge sonrası

1. `dev → test` terfisi — sunucu `test` dalına geçer
2. `test → main` terfisi — ilk sürüm etiketi
3. Ruleset'ler güncellenir (dal bazında merge yöntemi + required check'ler)

## Not

Production pipeline hâlâ yok: `PROD_SSH_*` secret'ları, `.env.prod`, prod nginx/TLS ve `docker-compose.prod.yml`'deki eksik env değişkenleri (`Minio__*`, `OAuth__Google__*`, `Cors__*`, `Resend__*`) duruyor.