### PR TITLE
fix: surum etiketi job'unda git kimligi tanimlandi

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Sıradaki sürümü belirle ve etiketle
         run: |
           set -e
+          # Annotated tag committer kimliği ister; runner'da tanımlı değil.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           git fetch --tags --force
 
           LAST=$(git tag -l 'v0.*.0' | sort -V | tail -n 1)


### PR DESCRIPTION
`release-tag.yml` ilk çalıştırmasında `fatal: empty ident name` ile düştü — annotated tag committer kimliği istiyor, runner'da tanımlı değil.

`git config user.name/email` eklendi (github-actions[bot]).

Bu PR aynı zamanda yeni akışın ilk gerçek kullanımı: `fix/* → dev → test → main`.