### PR TITLE
chore: dokumanlar uc dalli terfi modeline guncellendi

### DIFF
--- a/docs/context/branch-audit.md
+++ b/docs/context/branch-audit.md
@@ -2,7 +2,8 @@
 
 **Tarih:** 2026-08-03 · **Referans:** `origin/test` @ `3c42f65a` (denetim anı)
 **Durum:** ✅ **Tamamlandı ve uygulandı.** Sonuç: **29 branch → 3** (`main`, `test`, `dev`),
-26 `archive/*` tag'i, açık PR yok. Ardından trunk geçişi yapıldı — bkz. §8.
+26 `archive/*` tag'i, açık PR yok. Ardından trunk geçişi yapıldı (§8), aynı gün üç dallı
+terfi modeline dönüldü (§9) — **yürürlükteki model §9'dur.**
 
 ---
 
@@ -234,12 +235,54 @@ Bu üçü çözülmeden yazılacak pipeline ilk çalıştırmada patlar. Sıra:
 
 ### `dev` ve `test` branch'leri
 
-Silinmediler — kullanıcı üçünün de eşitlenmesini istedi. Artık `main` ile aynı içeriği taşıyan,
-CI tetiklemeyen **dondurulmuş kopyalar**. Ekip onayıyla silinebilirler;
-`archive/main-2026-08-03` ve `archive/dev-2026-08-03` tag'leri geçiş öncesi durumu tutuyor.
+Silinmediler. Aynı gün üç dallı modele dönüldüğü için tekrar aktif kullanımdalar — bkz. §9.
 
-> Silmeden önce güvenlik ağı: `git tag archive/<branch-adı> origin/<branch-adı> && git push origin --tags`.
-> Tag'ler commit'leri kalıcı tutar, branch listesini kirletmez, gerektiğinde geri alınır.
+---
+
+## 9. Üç Dallı Terfi Modeline Dönüş — 2026-08-03 (aynı gün)
+
+Trunk geçişinden birkaç saat sonra model tekrar değiştirildi. **Gerekçe teknik değil, bağlamsal:**
+
+1. Test ortamı fiilen **müşteriye/paydaşa gösterilen yüzey** (`known-issues.md` #2:
+   `cargopilot.divizyon.org` yalnızca test ortamını sunuyor). Hafta ortasında değişmemesi isteniyor.
+2. Ayrı bir **QA/test adımı var** — geliştiriciler *ve* DevOps/QA aynı sürümü test ediyor.
+3. `main` ileride **ayrı bir prod sunucusunda** çalışacak.
+
+Bu üçü birlikte, dondurulabilir bir dalı gerekçelendiriyor. Trunk modeli bunu ancak
+feature flag'lerle taklit edebilirdi.
+
+### Eski üç dallı modelden farkı
+
+Eskiden iş branch'i **hem `dev`'e hem `test`'e** ayrı PR açıyordu — iş başına 2 PR (§7 madde 2).
+Yeni modelde iş branch'i **yalnızca `dev`'e** PR açar; `dev → test` ve `test → main` ayrı
+**terfi PR'larıdır** ve biriken işi toplu taşır.
+
+| Uygulanan | Durum |
+|-----------|-------|
+| `main → test` ve `main → dev` hizalama (PR #896, #897) | ✅ Üç ağaç birebir aynı |
+| `test-deploy.yml` deploy kaynağı `main` → `test` | ✅ |
+| Sunucu deploy script'i `git checkout test` | ✅ `Switched to branch 'test'` |
+| `ci.yml` PR hedefleri: `dev`, `test`, `main` | ✅ |
+| **`Terfi Zinciri Kontrolü`** job'u (`ci.yml`) | ✅ PR #904 ile fiilen doğrulandı |
+| `release-tag.yml` — `main`'e terfide `v0.<n>.0` | ✅ `v0.1.0` oluştu |
+| Ruleset'ler: dal bazında merge yöntemi + required check | ✅ |
+| Bypass modu `always` → `pull_request` (dev/test) | ✅ |
+| `BRANCHING.md` üç dallı modelle yeniden yazıldı | ✅ |
+| Production pipeline | ⛔ Hâlâ yok — §8'deki gerekçeler geçerli |
+
+PR zinciri: #898 (→dev) → #899 (→test) → #900 (→main) → #901/#902/#903 (etiket düzeltmesi).
+
+### Ayrışmayı önleyen kontroller
+
+Bu modelin bilinen kırılma noktası dalların ayrışmasıdır — bu repoda bir kez yaşandı
+(`known-issues.md` #6: #482 `dev`'i atladı, `sync/test-to-dev` yaması gerekti). İki kontrol var:
+
+1. **`Terfi Zinciri Kontrolü`** — `test`'e yalnızca `dev`'den, `main`'e yalnızca `test`/`hotfix/*`.
+2. **Ruleset merge yöntemi kısıtı** — terfi PR'ında squash yapılamaz. Squash yapılsaydı hedef dal,
+   kaynakta bulunmayan yeni bir commit alır ve fark haftalar sonra ortaya çıkardı.
+
+Kalan risk **insan disiplinine bağlı** ve otomatikleştirilmedi:
+`hotfix/* → main` sonrası `main → test → dev` geri-merge'ünün unutulması.
 
 ---
 

--- a/docs/context/branching-proposal.md
+++ b/docs/context/branching-proposal.md
@@ -1,11 +1,19 @@
 # Branch Stratejisi Önerisi — 5 Kişilik Ekip
 
-**Tarih:** 2026-08-03 · **Durum:** ✅ **Kabul edildi ve uygulandı** (production pipeline hariç)
+**Tarih:** 2026-08-03 · **Durum:** ⛔ **Yürürlükte değil — aynı gün geri alındı**
 **Ekip:** DevOps · Backend · Algoritma · Frontend (4 rol / 5 kişi)
 
-Yürürlükteki kurallar artık [`docs/conventions/BRANCHING.md`](../conventions/BRANCHING.md)'de.
-Bu doküman **gerekçe ve ölçüm kaydı** olarak duruyor.
-Uygulama detayı: [branch-audit.md](branch-audit.md) §8.
+> **Bu doküman tarihsel bir kayıttır.** Önerilen trunk modeli uygulandı, ardından aynı gün
+> **üç dallı terfi modeline** (`dev → test → main`) dönüldü.
+>
+> **Neden:** §7'de "bu öneriyi reddetmenin makul nedeni" olarak yazılan koşul gerçekte mevcuttu —
+> test ortamı müşteriye gösterilen yüzey ve ayrı bir QA adımı var. Dondurulabilir bir dal gerekiyor.
+>
+> Yürürlükteki kurallar: [`docs/conventions/BRANCHING.md`](../conventions/BRANCHING.md)
+> Karar geçmişi: [branch-audit.md](branch-audit.md) §8–§9
+>
+> §1'deki ölçümler (2 PR/iş, 10/30 kapatılmış PR) hâlâ geçerli ve yeni modelde
+> **terfi PR'ı** düzeniyle giderildi: iş branch'i yalnızca `dev`'e PR açar.
 
 ---
 

--- a/docs/context/project-snapshot.md
+++ b/docs/context/project-snapshot.md
@@ -59,29 +59,41 @@ Ek: `DIVIZYON` ERP veritabanı (müşteri `.bak` restore'u) test MSSQL container
 
 Workflow'lar: `ci.yml`, `test-deploy.yml`, `cache-cleanup.yml`, `sync-base-images.yml`, `rollback.yml`.
 
+Workflow'lar ayrıca: `release-tag.yml` (2026-08-03'te eklendi).
+
 | Tetikleyici | Sonuç |
 |-------------|-------|
-| push `feat/**`, `fix/**`, `hotfix/**`, `chore/**`, `infra/**` (+ eski `feature/**`, `bugfix/**`) | CI + Deploy (Test) — inline build |
-| PR → `main` | CI + Pending Migration Kontrolü + Image Build + Deploy (Test) |
-| push `main` | Image Build → GHCR → test sunucusuna deploy |
+| push `feat/**`, `fix/**`, `hotfix/**`, `chore/**`, `infra/**` (+ eski `feature/**`, `bugfix/**`) | CI + geçici stack doğrulaması (inline build) |
+| PR → `dev` | CI + Docker Image Build |
+| PR → `test` | CI + Terfi Zinciri + Migration + Image Build + Deploy (Test) |
+| push `test` | Image Build → GHCR → **test sunucusuna deploy** |
+| PR → `main` | CI + Terfi Zinciri + Migration |
+| push `main` | `v0.<n>.0` sürüm etiketi (deploy yok) |
 | `v*` tag | **hiçbir şey — production pipeline yok** (devops-backlog 2.2) |
 
-- `enforce-test-base` job'u **kaldırıldı** (2026-08-03 trunk geçişi) — iki dallı model bittiği için gereksizdi.
+- `enforce-test-base` job'u kaldırıldı; yerine **`Terfi Zinciri Kontrolü`** (`ci.yml`) geldi:
+  `test`'e yalnızca `dev`'den, `main`'e yalnızca `test` veya `hotfix/*` üzerinden PR açılabilir.
+  2026-08-03'te boş bir PR ile fiilen doğrulandı (PR #904 engellendi).
 - GHCR image'ları **public**; geliştirici login'i gerekmiyor. Immutable tag: `test-{sha}`.
 - Koruma **repository ruleset** ile yapılıyor (klasik branch protection API'si 404 döner — yanıltıcıdır):
   `main-protection`, `test-protection`, `dev-protection` aktif; `freeze` kapalı.
 
-| Ruleset | PR zorunlu | Onay | Required check | Bypass |
-|---------|-----------|------|----------------|--------|
-| `main-protection` | ✅ | 1 + son push onayı | **yok** | Team / sadece PR ile |
-| `test-protection` | ✅ | 1 + son push onayı | `Deploy (Test)`, `Image Build`, `Test PR Dev Kontrolü` (strict) | Team / **her zaman** |
-| `dev-protection` | ✅ | 1 + son push onayı | `Deploy (Test)` | Team / **her zaman** |
+| Ruleset | Merge yöntemi | Required check |
+|---------|---------------|----------------|
+| `dev-protection` | sadece **squash** | `Frontend CI`, `Backend CI` |
+| `test-protection` | sadece **merge commit** | `Terfi Zinciri`, `Frontend CI`, `Backend CI`, `Migration`, `Image Build`, `Deploy (Test)` |
+| `main-protection` | sadece **merge commit** | `Terfi Zinciri`, `Frontend CI`, `Backend CI`, `Migration` |
 
-Üçünde de: sadece merge commit, push'ta eski onaylar düşer, review thread'leri çözülmüş olmalı,
-branch silme ve force-push kapalı. `main`'de ayrıca `update` kuralı → doğrudan push engelli.
+Merge yöntemi kısıtı kritik: terfi PR'ında squash yapılırsa hedef dal, kaynakta olmayan yeni bir
+commit alır ve dallar kalıcı ayrışır. Ruleset yanlış seçimi mümkün kılmıyor.
 
-- Boşluk: `main`'de hiç required status check yok — CI geçmeden merge edilebilir.
-- `delete_branch_on_merge` = **false** → merge sonrası branch'ler birikiyor.
+Üçünde de: PR zorunlu, 1 onay + son push onayı, push'ta eski onaylar düşer, review thread'leri
+çözülmüş olmalı, branch silme ve force-push kapalı, bypass **sadece PR ile** (eski `always` kaldırıldı).
+`main`'de ayrıca `update` kuralı → doğrudan push engelli.
+`strict_required_status_checks_policy` üçünde de **false** — aksi hâlde her terfiden sonra
+geri-merge zorunlu olurdu.
+
+- `delete_branch_on_merge` = **true**.
 
 ---
 
@@ -102,18 +114,33 @@ branch silme ve force-push kapalı. `main`'de ayrıca `update` kuralı → doğr
 
 ---
 
-## 6. Branch Modeli — Trunk (2026-08-03'ten itibaren)
+## 6. Branch Modeli — Üç Dallı Terfi (2026-08-03'ten itibaren)
 
 ```
-main ──► feat|fix|chore|infra/* ──► PR → main ──► test ortamına otomatik deploy
+feat/* ──PR(squash)──► dev ──PR(merge)──► test ──PR(merge)──► main
+                        │                  │                    │
+                       CI          TEST SUNUCUSU         ileride PRODUCTION
+                                (gösterim + QA testi)    (şimdilik sadece tag)
 ```
 
-- Tek uzun ömürlü branch: **`main`** (default). İş branch'leri kısa ömürlü, merge sonrası otomatik silinir.
-- İş başına **1 PR**. Eski `feature → dev → test → main` modeli kaldırıldı.
-- `dev` ve `test` branch'leri `main` ile aynı içeriği taşıyan **dondurulmuş kopyalar**; CI tetiklemezler,
-  ekip onayıyla silinecekler.
-- Silinen tüm eski branch'ler `archive/<branch-adı>` tag'i olarak korunuyor (26 tag).
-- Kurallar: [BRANCHING.md](../conventions/BRANCHING.md) · Gerekçe ve ölçümler: [branching-proposal.md](branching-proposal.md)
+| Dal | Rol | Deploy hedefi | Terfi ritmi |
+|-----|-----|---------------|-------------|
+| `dev` | Günlük entegrasyon | Yok, sadece CI | — |
+| `test` | QA / gösterim ortamı | Test sunucusu | İş onaylandıkça |
+| `main` | Production'a hazır sürüm | *(prod sunucusu yok)* | Haftalık |
+
+- `main` **default** branch ve production'a ayrılmış. Prod sunucusu kurulana kadar deploy tetiklemez;
+  her terfide `release-tag.yml` otomatik `v0.<n>.0` etiketi atar (ilk etiket: `v0.1.0`).
+- `test` ve `main` üzerinde **commit üretilmez** — içerikleri yalnızca terfi ile değişir.
+  Test ortamında bulunan bug `dev`'den açılan `fix/*` ile düzeltilip yeniden terfi edilir.
+- `hotfix/*` → `main` tek istisna; ardından `main → test → dev` geri-merge **zorunlu**.
+- `dev` her an çıkılabilir olmalı: erken terfide `dev`'deki her şey birlikte gider.
+- Silinen tüm eski branch'ler `archive/<branch-adı>` tag'i olarak korunuyor (28 tag).
+- Kurallar: [BRANCHING.md](../conventions/BRANCHING.md) · Karar geçmişi: [branching-proposal.md](branching-proposal.md)
+
+**Not:** 2026-08-03 sabahı kısa süreliğine trunk modeline (`main` tek dal) geçildi, aynı gün
+üç dallı modele dönüldü. Gerekçe: test ortamı fiilen müşteriye gösterilen yüzey ve ayrı bir
+QA adımı var — dondurulabilir bir dal gerekiyor. Detay: [branch-audit.md](branch-audit.md) §8–§9.
 
 ---
 

--- a/docs/devops/known-issues.md
+++ b/docs/devops/known-issues.md
@@ -10,8 +10,8 @@
 
 ### 0 — Sunucuda Bayat GHCR Kimlik Bilgisi (INC-003)
 
-{% hint style="warning" %}
-**Durum:** 🔧 Düzeltme uygulandı — doğrulama bekliyor
+{% hint style="success" %}
+**Durum:** ✅ Çözüldü — doğrulandı (2026-08-03)
 {% endhint %}
 
 2026-08-03'te test sunucusuna deploy `error from registry: denied` ile kırıldı. Son başarılı
@@ -109,15 +109,17 @@ CI pipeline'da Node.js 20 kullanılıyor; deprecation uyarısı alınmaktadır.
 
 ### 6 — `dev` Branch'inin Test'in Gerisine Düşme Riski
 
-{% hint style="info" %}
-**Durum:** ℹ️ Süreç Uyarısı
+{% hint style="success" %}
+**Durum:** ✅ Yapısal olarak engellendi (2026-08-03)
 {% endhint %}
 
 `US-REP-04` (#482) dev'i atlayarak doğrudan test'e merge edildi. Bu, dev'in test'in gerisinde kalmasına neden oldu. PR #493 ile giderildi.
 
-**Süreç kuralı:** Feature branch'ler **her zaman** önce `dev`'e, ardından aynı branch'ten `test`'e PR açılmalı. Hiçbir değişiklik dev'i atlayarak test'e gitmemelidir.
+**Uygulanan çözüm:** `ci.yml`'deki **`Terfi Zinciri Kontrolü`** job'u bunu artık CI seviyesinde engelliyor: `test`'e yalnızca `dev`'den, `main`'e yalnızca `test` veya `hotfix/*` üzerinden PR açılabilir. Ayrıca ruleset terfi PR'larında squash'ı kapatıyor — squash, kaynakta bulunmayan yeni bir commit üreterek aynı ayrışmayı yaratırdı.
 
-**Geçici çözüm:** Uyumsuzluk tespit edildiğinde `sync/test-to-dev` branch'i açılarak test → dev sync yapılır.
+**Süreç kuralı:** İş branch'leri yalnızca `dev`'e PR açar. `dev → test` ve `test → main` ayrı terfi PR'larıdır. Test ortamında bulunan bug `test`'te değil, `dev`'den açılan `fix/*` ile düzeltilir.
+
+**Kalan risk:** `hotfix/* → main` sonrası `main → test → dev` geri-merge'ünün unutulması. Bu adım otomatikleştirilmedi — bkz. [BRANCHING.md](../conventions/BRANCHING.md) "Hotfix".
 
 ---
 


### PR DESCRIPTION
Trunk geçişiyle güncellenmiş dokümanlar artık yanlış modeli anlatıyordu.

- `docs/context/project-snapshot.md` — CI/CD tetikleyici + ruleset tabloları, §6 branch modeli
- `docs/context/branch-audit.md` — yeni **§9**: üç dallı modele dönüş kaydı ve gerekçesi
- `docs/context/branching-proposal.md` — "yürürlükte değil" olarak işaretlendi
- `docs/devops/known-issues.md` — madde 6 (dev geride kalma riski) yapısal olarak çözüldü; INC-003 doğrulandı