### PR TITLE
fix: prod compose eksik env degiskenleri ve healthcheck

### DIFF
--- a/docs/context/project-snapshot.md
+++ b/docs/context/project-snapshot.md
@@ -103,7 +103,7 @@ geri-merge zorunlu olurdu.
 |---|------|--------|
 | 1 | Production stack hiç deploy edilmedi (`.env.prod` yok, compose çalışmadı) | 🔴 Kritik |
 | 2 | Production CI/CD ve prod GHCR image pipeline'ı yok | 🔴 Kritik |
-| 3 | `docker-compose.prod.yml` eksik: backend healthcheck yok, OAuth/CORS/Resend env yok, `SA_PASSWORD` vs `MSSQL_SA_PASSWORD` uyumsuz | 🔴 Kritik |
+| 3 | ~~`docker-compose.prod.yml` eksik~~ → 2026-08-03'te giderildi (`Minio__*`, `OAuth__Google__*`, `Cors__*`, `Resend__*`, backend healthcheck). **Sahada hiç çalıştırılmadı.** | 🟠 Yüksek |
 | 4 | MSSQL SA parolası git geçmişinde — **rotate edilmedi** | 🔴 Güvenlik |
 | 5 | Docker image CVE: backend 4 CRITICAL/18 HIGH, frontend 6 CRITICAL/29 HIGH (Trivy, 2026-05-16) | 🟠 Yüksek |
 | 6 | Grafana alert var ama contact point yok → bildirim gitmiyor | 🟠 Yüksek |

--- a/docs/devops/known-issues.md
+++ b/docs/devops/known-issues.md
@@ -93,17 +93,29 @@ CI pipeline'da Node.js 20 kullanılıyor; deprecation uyarısı alınmaktadır.
 
 ### 5 — `docker-compose.prod.yml` Eksiklikleri
 
-{% hint style="warning" %}
-**Durum:** ⚠️ Açık
+{% hint style="success" %}
+**Durum:** ✅ Giderildi (2026-08-03) — sahada doğrulanmadı, prod stack hâlâ kurulmadı
 {% endhint %}
 
-- Backend için `healthcheck:` bloğu yok
-- OAuth, CORS, Resend ve MSSQL env var'ları eksik
-- MSSQL healthcheck'te `SA_PASSWORD` ile `MSSQL_SA_PASSWORD` uyumsuzluğu
+Prod compose, test compose ile karşılaştırıldığında şunlar eksikti:
 
-**Etkisi:** Prod deploy edildiğinde Google OAuth, e-posta gönderimi ve CORS ayarları çalışmaz. MSSQL healthcheck fail ederse bağımlı servisler başlamaz.
+| Eksik | Etkisi |
+|-------|--------|
+| `Minio__Endpoint/AccessKey/SecretKey/BucketName` | **Dosya yükleme ve PDF hiç çalışmazdı** — backend `MINIO_*` değil `Minio__*` okuyor |
+| `OAuth__Google__*` (4 değişken) | Google ile giriş çalışmazdı |
+| `Cors__AllowedOrigins__0` | Ayrı origin kullanılırsa frontend API'ye ulaşamazdı |
+| `Resend__*`, `PasswordReset__*`, `EmailChange__*` | Şifre sıfırlama ve e-posta değiştirme kırıktı |
+| Backend `healthcheck:` | Deploy "hazır mı" bilemezdi; `depends_on` sağlık koşulu kurulamazdı |
+| `platform: linux/amd64` | Mimari uyuşmazlığı riski |
 
-**Kalıcı çözüm:** Bkz. [devops-backlog.md](devops-backlog.md) madde 1.2, 1.3, 1.4.
+**Uygulanan çözüm:** Prod compose'un backend servisi test compose ile birebir aynı anahtar
+kümesine getirildi; healthcheck eklendi; frontend `backend`'in sağlıklı olmasını bekliyor.
+MSSQL'de hem `MSSQL_SA_PASSWORD` hem `SA_PASSWORD` set ediliyor (2022 image'ı ilkini bekler),
+healthcheck `MSSQL_SA_PASSWORD` kullanıyor. Bağlantı dizesi artık compose içinde kuruluyor —
+parola `.env.prod`'da tek yerde duruyor. `.env.prod.example` yeni değişkenlerle tamamlandı.
+
+**Kalan iş:** Prod stack hiç ayağa kaldırılmadığı için bu yapılandırma **çalışır hâlde
+görülmedi**. İlk deploy'da doğrulanmalı. Bkz. madde 2 ve [devops-backlog.md](devops-backlog.md) 2.1.
 
 ---
 

--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -2,7 +2,9 @@ name: cargo-pilot-prod
 
 services:
   backend:
+    # Image GHCR'dan çekilir; build yalnızca local doğrulama için.
     image: ghcr.io/${GHCR_OWNER:-divizyon}/cargo-pilot-backend:${IMAGE_TAG:-prod}
+    platform: linux/amd64
     build:
       context: ../../apps/backend
       dockerfile: Dockerfile
@@ -10,13 +12,37 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Production
       ASPNETCORE_URLS: http://+:8080
-      ConnectionStrings__DefaultConnection: ${DATABASE_CONNECTION_STRING}
+      MSSQL_HOST: mssql
+      MSSQL_PORT: 1433
+      MSSQL_DATABASE: ${MSSQL_DATABASE}
+      MSSQL_USER: sa
+      MSSQL_PASSWORD: ${MSSQL_SA_PASSWORD}
+      # Bağlantı dizesi buradan kurulur; parola .env'de tek yerde tutulur.
+      # Harici/managed veritabanı için bir compose override dosyası kullanın.
+      ConnectionStrings__DefaultConnection: "Server=mssql,1433;Database=${MSSQL_DATABASE};User Id=sa;Password=${MSSQL_SA_PASSWORD};TrustServerCertificate=True;Encrypt=False"
       MINIO_ENDPOINT: minio:9000
       MINIO_BUCKET: ${MINIO_BUCKET}
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
-      Jwt__Secret: ${JWT_SECRET}
+      # Backend Minio__* anahtarlarını okur; MINIO_* tek başına YETERLİ DEĞİLDİR.
+      Minio__Endpoint: minio:9000
+      Minio__AccessKey: ${MINIO_ROOT_USER}
+      Minio__SecretKey: ${MINIO_ROOT_PASSWORD}
+      Minio__BucketName: ${MINIO_BUCKET}
+      Minio__PublicEndpoint: ${MINIO_PUBLIC_ENDPOINT:-}
       Seed__DefaultAdminPassword: ${Seed__DefaultAdminPassword}
+      Jwt__Secret: ${JWT_SECRET}
+      OAuth__Google__ClientId: ${GOOGLE_CLIENT_ID:-}
+      OAuth__Google__ClientSecret: ${GOOGLE_CLIENT_SECRET:-}
+      OAuth__Google__CallbackUrl: ${GOOGLE_OAUTH_CALLBACK_URL:-}
+      OAuth__Google__FrontendCallbackUrl: ${GOOGLE_OAUTH_FRONTEND_CALLBACK_URL:-}
+      Cors__AllowedOrigins__0: ${CORS_ALLOWED_ORIGIN_0:-}
+      Resend__ApiKey: ${RESEND_API_KEY:-}
+      Resend__FromEmail: ${RESEND_FROM_EMAIL:-}
+      Resend__FromName: ${RESEND_FROM_NAME:-}
+      PasswordReset__FrontendResetUrl: ${PASSWORD_RESET_FRONTEND_URL:-}
+      EmailChange__FrontendConfirmUrl: ${EMAIL_CHANGE_FRONTEND_CONFIRM_URL:-}
+      EmailChange__TokenExpiryMinutes: ${EMAIL_CHANGE_TOKEN_EXPIRY_MINUTES:-60}
     ports:
       - "${BACKEND_PORT}:8080"
     depends_on:
@@ -24,17 +50,25 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
     restart: unless-stopped
     networks:
       - cargo-pilot-prod
 
   frontend:
     image: ghcr.io/${GHCR_OWNER:-divizyon}/cargo-pilot-frontend:${IMAGE_TAG:-prod}
+    platform: linux/amd64
     build:
       context: ../../apps/frontend
       dockerfile: Dockerfile
       args:
-        VITE_API_BASE_URL: ${VITE_API_BASE_URL}
+        # Boş bırakılırsa nginx /api proxy devreye girer (CORS gerekmez).
+        VITE_API_BASE_URL: ${VITE_API_BASE_URL-}
         VITE_APP_VERSION: ${APP_VERSION:-latest}
         VITE_APP_ENV: production
         VITE_OAUTH_GOOGLE_URL: ${VITE_OAUTH_GOOGLE_URL:-}
@@ -45,7 +79,8 @@ services:
     ports:
       - "${FRONTEND_PORT}:80"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - cargo-pilot-prod
@@ -58,23 +93,26 @@ services:
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_PID: Standard
+      # MSSQL_SA_PASSWORD 2022 image'ının beklediği ad; SA_PASSWORD geriye dönük uyumluluk için.
+      MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
       SA_PASSWORD: ${MSSQL_SA_PASSWORD}
     ports:
       - "${MSSQL_PORT}:1433"
     volumes:
       - mssql_data_prod:/var/opt/mssql
     healthcheck:
-      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$${SA_PASSWORD}\" -C -Q \"SELECT 1\" || exit 1"]
-      interval: 20s
-      timeout: 10s
-      retries: 10
-      start_period: 40s
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$${MSSQL_SA_PASSWORD}\" -C -Q \"SELECT 1\" || exit 1"]
+      interval: 15s
+      timeout: 15s
+      retries: 12
+      start_period: 90s
     restart: unless-stopped
     networks:
       - cargo-pilot-prod
 
   minio:
     image: quay.io/minio/minio:RELEASE.2022-01-08T03-11-54Z
+    platform: linux/amd64
     container_name: cargo-pilot-minio-prod
     command: server /data --console-address ":9001"
     environment:

--- a/infra/env/.env.prod.example
+++ b/infra/env/.env.prod.example
@@ -28,9 +28,10 @@ MSSQL_PORT=1433
 MSSQL_DATABASE=CargoPilot
 MSSQL_SA_PASSWORD=<GENERATE_STRONG_PASSWORD_MIN_16_CHARS>
 
-# Backend'in runtime'da okuduğu tek bağlantı dizesi.
-# Docker network içinde servis adı 'mssql' kullanılır.
-DATABASE_CONNECTION_STRING=Server=mssql,1433;Database=CargoPilot;User Id=sa;Password=<MSSQL_SA_PASSWORD>;TrustServerCertificate=True;
+# NOT: Bağlantı dizesi artık compose içinde yukarıdaki değerlerden kuruluyor.
+# Parolayı ikinci bir yere yazmanız gerekmez. Harici/managed bir veritabanı
+# kullanılacaksa bir compose override dosyasıyla ConnectionStrings__DefaultConnection
+# değerini değiştirin.
 
 # ─── MinIO ───────────────────────────────────
 # Object storage için gerekli yapılandırma
@@ -40,6 +41,9 @@ MINIO_CONSOLE_PORT=9001
 MINIO_ROOT_USER=<GENERATE_SECURE_USERNAME>
 MINIO_ROOT_PASSWORD=<GENERATE_STRONG_PASSWORD_MIN_16_CHARS>
 MINIO_BUCKET=cargo-pilot
+# Tarayıcının erişebileceği public MinIO adresi (presigned URL üretiminde kullanılır).
+# Boş bırakılırsa dosya bağlantıları container içi adresi gösterir ve dışarıdan açılmaz.
+MINIO_PUBLIC_ENDPOINT=https://<YOUR_DOMAIN>/files
 
 # ─── JWT ─────────────────────────────────────
 # En az 32 karakter, production için güçlü random değer kullan
@@ -57,7 +61,37 @@ SERVER_HOST=<YOUR_SERVER_IP_OR_DOMAIN>
 # Uygulama sürümü (release tag ile eşleşmeli)
 APP_VERSION=<RELEASE_VERSION>
 
-# ─── OAuth (opsiyonel) ───────────────────────
+# ─── OAuth — Frontend (opsiyonel) ────────────
 # Tanımlanmazsa login ekranındaki OAuth butonları pasif kalır
 VITE_OAUTH_GOOGLE_URL=https://<YOUR_DOMAIN>/api/v1/auth/google
 VITE_OAUTH_MICROSOFT_URL=https://<YOUR_DOMAIN>/api/v1/auth/microsoft
+
+# ─── OAuth — Backend (Google ile giriş) ──────
+# Boş bırakılırsa Google ile giriş çalışmaz. Değerler Google Cloud Console'dan alınır.
+# Callback URL'i Console'daki "Authorized redirect URIs" ile birebir aynı olmalıdır.
+GOOGLE_CLIENT_ID=<GOOGLE_OAUTH_CLIENT_ID>
+GOOGLE_CLIENT_SECRET=<GOOGLE_OAUTH_CLIENT_SECRET>
+GOOGLE_OAUTH_CALLBACK_URL=https://<YOUR_DOMAIN>/api/v1/auth/google/callback
+GOOGLE_OAUTH_FRONTEND_CALLBACK_URL=https://<YOUR_DOMAIN>/auth/callback
+
+# ─── CORS ────────────────────────────────────
+# VITE_API_BASE_URL ile frontend aynı origin'den servis ediliyorsa (nginx /api proxy)
+# bu değere gerek yoktur. Ayrı origin kullanılıyorsa ZORUNLUDUR.
+CORS_ALLOWED_ORIGIN_0=https://<YOUR_DOMAIN>
+
+# ─── E-posta (Resend) ────────────────────────
+# Boş bırakılırsa şifre sıfırlama ve e-posta değiştirme akışları çalışmaz.
+# FROM_EMAIL için domain'in Resend'de doğrulanmış olması gerekir (bkz. known-issues #1).
+RESEND_API_KEY=<RESEND_API_KEY>
+RESEND_FROM_EMAIL=noreply@<YOUR_DOMAIN>
+RESEND_FROM_NAME=Cargo Pilot
+
+# Kullanıcının e-postadaki bağlantıyla döneceği frontend adresleri
+PASSWORD_RESET_FRONTEND_URL=https://<YOUR_DOMAIN>/auth/reset-password
+EMAIL_CHANGE_FRONTEND_CONFIRM_URL=https://<YOUR_DOMAIN>/confirm-email-change
+EMAIL_CHANGE_TOKEN_EXPIRY_MINUTES=60
+
+# ─── Image kaynağı ───────────────────────────
+# Deploy edilecek image tag'i. Sürüm etiketiyle eşleşmeli (ör. v0.2.0).
+GHCR_OWNER=divizyon
+IMAGE_TAG=prod


### PR DESCRIPTION
## Sorun

`docker-compose.prod.yml`, `docker-compose.test.yml` ile karşılaştırıldığında backend servisinde kritik yapılandırma eksikti. Bu hâliyle prod'a çıkılsaydı:

| Eksik | Sonuç |
|---|---|
| `Minio__Endpoint/AccessKey/SecretKey/BucketName` | **Dosya yükleme ve PDF hiç çalışmazdı** — backend `MINIO_*` değil `Minio__*` okuyor |
| `OAuth__Google__*` (4) | Google ile giriş çalışmazdı |
| `Cors__AllowedOrigins__0` | Ayrı origin'de frontend API'ye ulaşamazdı |
| `Resend__*`, `PasswordReset__*`, `EmailChange__*` | Şifre sıfırlama / e-posta değiştirme kırıktı |
| Backend `healthcheck` | Deploy hazırlığı ölçülemezdi |

## Yapılan

- Backend env seti test compose ile **birebir aynı anahtar kümesine** getirildi (doğrulandı: eksik yok)
- Backend healthcheck eklendi; frontend `condition: service_healthy` ile bekliyor
- Bağlantı dizesi compose içinde kuruluyor → parola `.env.prod`'da **tek yerde**
- MSSQL'de hem `MSSQL_SA_PASSWORD` hem `SA_PASSWORD` (2022 image'ı ilkini bekler)
- `platform: linux/amd64` backend/frontend/minio'ya eklendi
- `.env.prod.example` yeni değişkenlerle tamamlandı (Google OAuth, CORS, Resend, MinIO public endpoint, GHCR_OWNER/IMAGE_TAG)

## Doğrulama sınırı

Lokalde docker yok; `docker compose config` çalıştırılamadı. Doğrulama, test compose ile anahtar kümesi karşılaştırmasıyla yapıldı. **Prod stack hiç ayağa kaldırılmadığı için bu yapılandırma sahada çalışır hâlde görülmedi** — ilk deploy'da doğrulanmalı.

Bu nedenle iç içe `\${VAR:-...\${VAR2}...}` varsayılanı kullanmaktan kaçındım; test compose'daki denenmiş düz kalıp tercih edildi.

`known-issues.md` #5 güncellendi.