### PR TITLE
Doküman seti revizyonu: standart şablon, arşiv yapısı ve dil düzeltmeleri

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,10 +15,14 @@
 
 - [ ] Manuel test yapıldı
 
+## Ekran Görüntüleri
+
+<!-- UI değişikliği içeren PR'larda zorunludur; önce/sonra görselleri ekleyin. UI değişikliği yoksa "UI değişikliği yok" yazın. -->
+
 ## Kontrol Listesi
 
 - [ ] Kod standartlarına uygun
-- [ ] Commit mesajları [commit kurallarına](docs/conventions/COMMITS.md) uygun
+- [ ] Commit mesajları [commit kurallarına](docs/conventions/commits.md) uygun
 - [ ] Linter hataları yok
 - [ ] Self-review yapıldı
 - [ ] Dokümantasyon güncellendi (gerekiyorsa)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,9 @@
 
 \- When working with Git, first check these files:
 
-\- `cargo-pilot/docs/conventions/BRANCHING.md`
+\- `cargo-pilot/docs/conventions/branching.md`
 
-\- `cargo-pilot/docs/conventions/COMMITS.md`
+\- `cargo-pilot/docs/conventions/commits.md`
 
 \- Git workflow, branch, PR, and commit rules are defined there; do not duplicate or invent them here.
 
@@ -38,7 +38,7 @@
 
 \## Frontend Stack
 
-\- React 18 + Vite + React Router v6.
+\- React 18 + Vite + React Router v7.
 
 \- TypeScript strict mode is required.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Katkı Sağlama
+
+Bu doküman, Cargo Pilot'a katkı sağlarken izlenecek temel akışı özetler: kurulum, branch modeli, commit kuralları ve PR süreci. Detaylar için her bölümdeki bağlantılı dokümana bakın.
+
+---
+
+## Başlarken
+
+Local geliştirme ortamını ayağa kaldırmak için [Local Setup](docs/setup/local-setup.md) dokümanını izleyin — ön koşullar, `.env` dosyasını hazırlama, stack'i başlatma (tam Docker veya Vite + Docker hibrit) ve sık karşılaşılan sorunlar orada anlatılır.
+
+---
+
+## Branch Modeli
+
+Proje üç dallı terfi (promotion) modelini kullanır:
+
+```
+feat/US-142-x ──PR (squash)──► dev ──PR (merge)──► test ──PR (merge)──► main
+```
+
+- Tüm iş branch'leri (`feat/*`, `fix/*`, `chore/*`, `infra/*`) **`dev`'den** açılır ve **≤ 3 gün** ömürlüdür.
+- `test`'e yalnızca `dev`'den, `main`'e yalnızca `test`'ten (veya `hotfix/*`'ten) PR açılabilir.
+- `dev`, `test` ve `main`'e doğrudan push yapılmaz; ruleset bunu engeller.
+- Branch adları `<tür>/<iş-kodu>-<kısa-açıklama>` biçimindedir, örn. `feat/US-142-login-form`.
+
+Detaylı akış, isimlendirme kuralları, merge stratejisi ve hotfix süreci için bkz. [Branching Strategy](docs/conventions/branching.md).
+
+---
+
+## Commit Kuralları
+
+Commit mesajları sade, açıklayıcı ve mümkünse Türkçe olmalıdır. **1 anlamlı değişiklik = 1 commit** kuralına uyun; "fix", "update", "son" gibi genel ifadelerden kaçının. PR açmadan önce anlamsız commit'leri temizleyin.
+
+Detay için bkz. [Commit Kuralları](docs/conventions/commits.md).
+
+---
+
+## Kod Standartları
+
+- Frontend değişiklikleri için kök `CLAUDE.md` ve ilgili sub-domain klasöründeki kuralları izleyin.
+- Backend değişiklikleri için [Mimari Rehberi](apps/backend/docs/architecture.md) dokümanındaki katman ve konvansiyonlara uyun.
+
+---
+
+## PR Süreci
+
+1. PR açarken [PR şablonunu](.github/pull_request_template.md) eksiksiz doldurun (özet, ilgili user story/issue, değişiklik tipi, test durumu, ekran görüntüleri, kontrol listesi).
+2. En az **1 onaylayan review** gerekir; push sonrası eski onaylar düşer, yeniden review istenir. Tüm review thread'leri çözülmüş olmalıdır.
+3. CI kapılarının geçmesi zorunludur:
+   - **Frontend:** `tsc`, `eslint`, `vitest`, `build`
+   - **Backend:** `dotnet build`
+4. UI değişikliği içeren PR'larda öncesi/sonrası ekran görüntüsü zorunludur; 3D/algoritma değişikliklerinde öncesi–sonrası plan karşılaştırması eklenir.
+
+---
+
+## Doküman Güncelleme
+
+Yeni bir `.md` dosyası eklediğinizde şunları da güncelleyin:
+
+- `SUMMARY.md` — GitBook içindekiler tablosuna yeni dosyayı ekleyin.
+- `docs/context/doc-map.md` — yeni dosyanın özetini ve satır sayısını haritaya işleyin.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ cargo-pilot/
 │   └── backend/      # .NET 8 Web API
 ├── database/         # Migration, seed ve DB scriptleri
 ├── docs/             # Proje dokümantasyonu
+│   ├── archive/      # Tarihsel doküman arşivi (algoritma tasarımı, geçmiş planlar)
+│   ├── context/      # Proje bağlamı, anlık görüntüler, doküman haritası
 │   ├── conventions/  # Branching ve commit kuralları
 │   ├── devops/       # Sunucu, monitoring, secret yönetimi
 │   └── setup/        # Local kurulum
@@ -80,8 +82,8 @@ cargo-pilot/
 [Local Setup](docs/setup/local-setup.md)
 {% endcontent-ref %}
 
-{% content-ref url="docs/conventions/BRANCHING.md" %}
-[Branching Strategy](docs/conventions/BRANCHING.md)
+{% content-ref url="docs/conventions/branching.md" %}
+[Branching Strategy](docs/conventions/branching.md)
 {% endcontent-ref %}
 
 {% content-ref url="docs/devops/server-access.md" %}
@@ -91,3 +93,9 @@ cargo-pilot/
 {% content-ref url="docs/devops/known-issues.md" %}
 [Bilinen Sorunlar](docs/devops/known-issues.md)
 {% endcontent-ref %}
+
+---
+
+## Katkı Sağlama
+
+Depoya katkı sağlamadan önce [CONTRIBUTING.md](CONTRIBUTING.md) dosyasını okuyun: branch modeli, commit kuralları ve PR süreci orada özetlenir.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -5,26 +5,47 @@
 ## 🚀 Başlangıç
 
 * [Local Setup](docs/setup/local-setup.md)
-* [Deployment Bilgileri](PRODUCTION_DEPLOYMENT_INFO.md)
+* [Katkı Sağlama](CONTRIBUTING.md)
+* [Ortam Değişkenleri (infra)](infra/env/README.md)
 
 ## 📋 Geliştirme Kuralları
 
-* [Branching Strategy](docs/conventions/BRANCHING.md)
-* [Commit Kuralları](docs/conventions/COMMITS.md)
-
-## 🧭 Proje Bağlamı
-
-* [Bağlam Kütüphanesi](docs/context/README.md)
-* [Proje Anlık Görüntüsü](docs/context/project-snapshot.md)
-* [Doküman Haritası](docs/context/doc-map.md)
-* [Branch & PR Denetimi](docs/context/branch-audit.md)
-* [Branch Stratejisi Önerisi](docs/context/branching-proposal.md)
+* [Branch Stratejisi](docs/conventions/branching.md)
+* [Commit Kuralları](docs/conventions/commits.md)
 
 ## 🛠️ DevOps
 
+* [Deployment](docs/devops/deployment.md)
 * [Sunucu Gereksinimleri](docs/devops/server-requirements.md)
 * [Sunucu Erişim & Ağ](docs/devops/server-access.md)
 * [Secret Yönetimi](docs/devops/secret-management.md)
 * [Monitoring & Alerting](docs/devops/monitoring-setup.md)
 * [Bilinen Sorunlar](docs/devops/known-issues.md)
 * [DevOps Backlog](docs/devops/devops-backlog.md)
+* [İyileştirme Analizi — Ağustos 2026](docs/devops/iyilestirme-analizi-2026-08.md)
+
+## 🧱 Backend
+
+* [Mimari Rehberi](apps/backend/docs/architecture.md)
+* [Developer Setup](apps/backend/docs/developer-setup.md)
+* [Environment Variables](apps/backend/docs/environment-variables.md)
+* [Database Migrations](apps/backend/docs/database-migrations.md)
+* [User Story Tracker](apps/backend/docs/user-story-tracker.md)
+* [ERP Veri Modeli](apps/backend/docs/erp-integration/data-model.md)
+* [ERP Şeması — DIVIZYON](apps/backend/docs/erp-integration/erp-schema-divizyon.md)
+
+## 🧭 Proje Bağlamı
+
+* [Bağlam Kütüphanesi](docs/context/README.md)
+* [Proje Anlık Görüntüsü](docs/context/project-snapshot.md)
+* [Doküman Haritası](docs/context/doc-map.md)
+* [Kod Taraması — Ağustos 2026](docs/context/kod-taramasi-2026-08.md)
+* [Branch & PR Denetimi](docs/context/branch-audit.md)
+
+## 🗄️ Arşiv
+
+* [Denetim Test Planı — Ağustos 2026](docs/archive/audit-test-plani-2026-08.md)
+* [Branch Stratejisi Önerisi — Ağustos 2026](docs/archive/branching-proposal-2026-08.md)
+* [Matematiksel Model](docs/archive/algoritma-tasarimi/matematiksel-model.md)
+* [Sistem Mimarisi](docs/archive/algoritma-tasarimi/sistem-mimarisi.md)
+* [Bin Packing Uygulama Planı](docs/archive/algoritma-tasarimi/bin-packing-uygulama-plani.md)

--- a/apps/backend/docs/architecture.md
+++ b/apps/backend/docs/architecture.md
@@ -1,28 +1,30 @@
 # CargoPilot Backend Mimari Rehberi
 
-Bu dokuman, backend projesinin katmanli yapisini ve temel mimari kararlarini ozetler. Amac; ekip icinde tek bir referans nokta tanimlamak ve yeni gelistirmelerin ayni standartla yapilmasini saglamaktir.
+**Son güncelleme:** 2026-08-04 · **Durum:** Aktif
 
-> **Guncelleme (2026-08-04):** Dokumandaki "service-based, MediatR kullanilmaz" karari kod
-> tabaniyla celisiyordu — kod uctan uca MediatR (Command/Query/Handler) kullaniyor. Dokuman
-> kodun gercegine gore duzeltildi. Kurgusal `Cargo`/`TrackingNumber` ornekleri gercek
-> entity'lerle degistirildi. Detay: `docs/context/kod-taramasi-2026-08.md`.
+Bu doküman, backend projesinin katmanlı yapısını ve temel mimari kararlarını özetler. Amaç; ekip içinde tek bir referans nokta tanımlamak ve yeni geliştirmelerin aynı standartla yapılmasını sağlamaktır.
+
+> **Güncelleme (2026-08-04):** Dokümandaki "service-based, MediatR kullanılmaz" kararı kod
+> tabanıyla çelişiyordu — kod uçtan uca MediatR (Command/Query/Handler) kullanıyor. Doküman
+> kodun gerçeğine göre düzeltildi. Kurgusal `Cargo`/`TrackingNumber` örnekleri gerçek
+> entity'lerle değiştirildi. Detay: `docs/context/kod-taramasi-2026-08.md`.
 
 ---
 
-## 1) Mimari Yaklasim
+## 1) Mimari Yaklaşım
 
-Backend, Clean Architecture prensiplerine gore 4 katmana ayrilmistir:
+Backend, Clean Architecture prensiplerine göre 4 katmana ayrılmıştır:
 
 | Katman | Proje | Sorumluluk |
 |--------|-------|------------|
-| Presentation | `CargoPilot.WebAPI` | HTTP giris noktasi, controller'lar, middleware, Swagger |
+| Presentation | `CargoPilot.WebAPI` | HTTP giriş noktası, controller'lar, middleware, Swagger |
 | Application | `CargoPilot.Application` | Use-case / feature servisleri, validator'lar, soyutlamalar |
-| Domain | `CargoPilot.Domain` | Entity, value object, enum; is kurallari |
-| Infrastructure | `CargoPilot.Infrastructure` | EF Core, DbContext, repository implementasyonlari |
+| Domain | `CargoPilot.Domain` | Entity, value object, enum; iş kuralları |
+| Infrastructure | `CargoPilot.Infrastructure` | EF Core, DbContext, repository implementasyonları |
 
-### 1.1 Referans Yonu
+### 1.1 Referans Yönü
 
-Bagimlilik sadece ice dogru akar. Dis katmanlar icteki soyutlamalari referans alir; ic katman dis katmani bilmez.
+Bağımlılık sadece içe doğru akar. Dış katmanlar içteki soyutlamaları referans alır; iç katman dış katmanı bilmez.
 
 ```
 WebAPI ──► Application ──► Domain
@@ -32,35 +34,35 @@ Infrastructure ─┘
 
 Kurallar:
 
-- `Domain` hicbir katmana referans vermez.
-- `Application` yalnizca `Domain`'e referans verir.
+- `Domain` hiçbir katmana referans vermez.
+- `Application` yalnızca `Domain`'e referans verir.
 - `Infrastructure` `Application` ve `Domain`'e referans verir (Application'daki interface'leri implemente eder).
-- `WebAPI` hem `Application`'i hem `Infrastructure`'i referans alir (yalnizca DI composition amaciyla).
+- `WebAPI` hem `Application`'i hem `Infrastructure`'i referans alır (yalnızca DI composition amacıyla).
 
-Bu yon sayesinde Domain ve Application, framework/DB degisikliklerinden izole kalir.
+Bu yön sayesinde Domain ve Application, framework/DB değişikliklerinden izole kalır.
 
 ---
 
-## 2) Katman Icerikleri
+## 2) Katman İçerikleri
 
 ### 2.1 Domain
 
-- `Entities/` — `AppUser`, `Company`, `Item`, `Vehicle`, `LoadingPlan*` (Placement, ItemGroup, InputItem, UnplacedItem, Warning), `Integration`, `SyncLog`, `ErpUserMapping` vb. Tumu `BaseEntity`'den turer (audit + soft delete alanlari).
+- `Entities/` — `AppUser`, `Company`, `Item`, `Vehicle`, `LoadingPlan*` (Placement, ItemGroup, InputItem, UnplacedItem, Warning), `Integration`, `SyncLog`, `ErpUserMapping` vb. Tümü `BaseEntity`'den türer (audit + soft delete alanları).
 - `Enums/` — `FragilityType`, `AllowedRotations`, `LoadingType`, `SubscriptionType` vb.
 
 Kurallar:
 - Domain nesneleri framework, EF Core veya HTTP bilmez.
-- Davranis entity uzerinde tutulur (anemic modelden kacinilir).
+- Davranış entity üzerinde tutulur (anemic modelden kaçınılır).
 
 ### 2.2 Application
 
-- `Features/<Aggregate>/<UseCase>/` klasor standardi kullanilir.
-- Her use-case bir **MediatR** Command/Query + Handler ciftidir (`IRequestHandler<TRequest, TResponse>`).
-- Validator'lar ayni klasor altinda `<UseCase>CommandValidator.cs` olarak durur.
-- Repository soyutlamalari `Common/Interfaces/` altinda yasar (`I*Repository`, aggregate-specific).
-- Ortak modeller `Common/Models/` altinda (`Result<T>`, `Error`, `OptimizationInput/Result`).
+- `Features/<Aggregate>/<UseCase>/` klasör standardı kullanılır.
+- Her use-case bir **MediatR** Command/Query + Handler çiftidir (`IRequestHandler<TRequest, TResponse>`).
+- Validator'lar aynı klasör altında `<UseCase>CommandValidator.cs` olarak durur.
+- Repository soyutlamaları `Common/Interfaces/` altında yaşar (`I*Repository`, aggregate-specific).
+- Ortak modeller `Common/Models/` altında (`Result<T>`, `Error`, `OptimizationInput/Result`).
 
-Ornek klasor (gercek koddan):
+Örnek klasör (gerçek koddan):
 ```
 Features/
   Plans/
@@ -73,59 +75,59 @@ Features/
 
 ### 2.3 Infrastructure
 
-- `Persistence/AppDbContext.cs` (25 DbSet; audit alanlari `SaveChanges` override'inda otomatik dolar)
+- `Persistence/AppDbContext.cs` (25 DbSet; audit alanları `SaveChanges` override'inda otomatik dolar)
 - `Persistence/Repositories/<Entity>Repository.cs`
-- `Persistence/Configurations/` — entity konfigurasyonlari + soft delete global query filter
-- `Services/` — `OptimizationEngine` (yuk yerlestirme motoru), `ResendEmailService`, ERP connector'lari (`LogoErpConnector`, `NetsisErpConnector`)
-- `Jobs/` — Hangfire job'lari (`ErpExportJob`, trial expiry, notification cleanup)
-- EF Core + SQL Server saglayicisi kullanilir.
+- `Persistence/Configurations/` — entity konfigürasyonları + soft delete global query filter
+- `Services/` — `OptimizationEngine` (yük yerleştirme motoru), `ResendEmailService`, ERP connector'ları (`LogoErpConnector`, `NetsisErpConnector`)
+- `Jobs/` — Hangfire job'ları (`ErpExportJob`, trial expiry, notification cleanup)
+- EF Core + SQL Server sağlayıcısı kullanılır.
 
 ### 2.4 WebAPI
 
-- Controller'lar ince tutulur; is mantigi Application katmaninda.
-- Swagger yalnizca Development ortaminda aktiftir.
-- Middleware zinciri `DependencyInjection.UsePresentation()` icinde kurulur.
+- Controller'lar ince tutulur; iş mantığı Application katmanında.
+- Swagger yalnızca Development ortamında aktiftir.
+- Middleware zinciri `DependencyInjection.UsePresentation()` içinde kurulur.
 
 ---
 
 ## 3) Temel Mimari Kararlar
 
-### 3.1 MediatR ile Use-case Yapisi
+### 3.1 MediatR ile Use-case Yapısı
 
-Her use-case bir MediatR request'idir: `<UseCase>Command`/`<UseCase>Query` + `<UseCase>CommandHandler` (`IRequestHandler<>`). Controller'lar is mantigi icermez; `IMediator.Send(...)` ile ilgili handler'i cagirir. Command/Query ayrimi ayri proje olarak degil, ayni proje icinde isimlendirme ile yapilir.
+Her use-case bir MediatR request'idir: `<UseCase>Command`/`<UseCase>Query` + `<UseCase>CommandHandler` (`IRequestHandler<>`). Controller'lar iş mantığı içermez; `IMediator.Send(...)` ile ilgili handler'ı çağırır. Command/Query ayrımı ayrı proje olarak değil, aynı proje içinde isimlendirme ile yapılır.
 
-> Not: Dokumanin onceki surumu "service-based, MediatR kullanilmaz" diyordu; bu karar
-> uygulamada terk edildi. Kod tabani ~150+ dosyada MediatR desenini kullaniyor.
+> Not: Dokümanın önceki sürümü "service-based, MediatR kullanılmaz" diyordu; bu karar
+> uygulamada terk edildi. Kod tabanı ~150+ dosyada MediatR desenini kullanıyor.
 
 ### 3.2 Repository Pattern
 
-Veri erisimi `Application/Common/Interfaces/` altindaki interface'ler uzerinden yapilir (17 aggregate-specific interface). Application katmani `DbContext`'i dogrudan bilmez.
+Veri erişimi `Application/Common/Interfaces/` altındaki interface'ler üzerinden yapılır (17 aggregate-specific interface). Application katmanı `DbContext`'i doğrudan bilmez.
 
 - Interface: `IItemRepository`, `IVehicleRepository`, `ILoadingPlanRepository`, ... (Application)
 - Implementasyon: `Persistence/Repositories/*Repository.cs` (Infrastructure, EF Core)
 
 ### 3.3 FluentValidation
 
-Girdi dogrulama standardi olarak FluentValidation kullanilir.
+Girdi doğrulama standardı olarak FluentValidation kullanılır.
 
 - Paketler: `FluentValidation`, `FluentValidation.DependencyInjectionExtensions`
-- `Application/DependencyInjection.cs` icinde `AddValidatorsFromAssembly(...)` ile assembly scanning yapilir.
-- Validator'lar `<UseCase>CommandValidator.cs` olarak use-case klasorunde durur.
-- Validation hatalari `Result<T>.Failure` uzerinden donulur; exception-for-control-flow kullanilmaz.
+- `Application/DependencyInjection.cs` içinde `AddValidatorsFromAssembly(...)` ile assembly scanning yapılır.
+- Validator'lar `<UseCase>CommandValidator.cs` olarak use-case klasöründe durur.
+- Validation hataları `Result<T>.Failure` üzerinden dönülür; exception-for-control-flow kullanılmaz.
 
-### 3.4 Result<T> ile Hata Akisi
+### 3.4 Result<T> ile Hata Akışı
 
-Use-case'ler exception firlatmaz; sonuc `Result<T>` zarfinda donulur.
+Use-case'ler exception fırlatmaz; sonuç `Result<T>` zarfında dönülür.
 
-- Basari: `Result<T>.Success(value)`
+- Başarı: `Result<T>.Success(value)`
 - Hata: `Result<T>.Failure(Error)`
-- Kod tarafinda try/catch ile akis kontrolu yapilmaz.
+- Kod tarafında try/catch ile akış kontrolü yapılmaz.
 
-Not: Ortak API response envelope'u US-Story 8 kapsaminda olgunlastirilacaktir.
+Not: Ortak API response envelope'u US-Story 8 kapsamında olgunlaştırılacaktır.
 
 ### 3.5 Composition Root (DI)
 
-Her katman kendi `DependencyInjection.cs` dosyasini sunar; `Program.cs` yalnizca orkestrasyon yapar.
+Her katman kendi `DependencyInjection.cs` dosyasını sunar; `Program.cs` yalnızca orkestrasyon yapar.
 
 ```csharp
 builder.Services
@@ -135,67 +137,67 @@ builder.Services
 ```
 
 Kurallar:
-- `Program.cs` concrete tip veya EF Core referansi icermez.
-- Ortam bazli kararlar (`IsDevelopment`) `Program.cs`'de alinir; Infrastructure, Hosting soyutlamasina bagimli olmaz.
-- Middleware zinciri `UsePresentation()` uzerinden kurulur.
+- `Program.cs` concrete tip veya EF Core referansı içermez.
+- Ortam bazlı kararlar (`IsDevelopment`) `Program.cs`'de alınır; Infrastructure, Hosting soyutlamasına bağımlı olmaz.
+- Middleware zinciri `UsePresentation()` üzerinden kurulur.
 
-### 3.6 ~~Development'ta Veritabansiz Calisma~~ (calismiyor — kullanmayin)
+### 3.6 ~~Development'ta Veritabansız Çalışma~~ (çalışmıyor — kullanmayın)
 
-`UseInMemoryDatabase` bayragi konfigurasyonda mevcut ama **fiilen calismaz durumda**:
-bayrak `true` iken `AppDbContext`/Hangfire kayitlari atlanir fakat SQL-backed repository'ler
-yine de kayitli kalir — DI cozumlemesi calisma zamaninda patlar. Hicbir `InMemory*` repository
-implementasyonu yazilmamistir. Lokal gelistirme icin `docs/setup/local-setup.md`'deki
-Docker MSSQL akisi kullanilir.
+`UseInMemoryDatabase` bayrağı konfigürasyonda mevcut ama **fiilen çalışmaz durumda**:
+bayrak `true` iken `AppDbContext`/Hangfire kayıtları atlanır fakat SQL-backed repository'ler
+yine de kayıtlı kalır — DI çözümlemesi çalışma zamanında patlar. Hiçbir `InMemory*` repository
+implementasyonu yazılmamıştır. Lokal geliştirme için `docs/setup/local-setup.md`'deki
+Docker MSSQL akışı kullanılır.
 
-Bu bolum ya bayragin tamamlanmasiyla ya da bayragin koddan temizlenmesiyle kapanacaktir
+Bu bölüm ya bayrağın tamamlanmasıyla ya da bayrağın koddan temizlenmesiyle kapanacaktır
 (karar bekliyor — bkz. `docs/context/kod-taramasi-2026-08.md` §3).
 
-Production ve CI/CD'de connection string `ConnectionStrings__DefaultConnection` env var'i uzerinden verilir.
+Production ve CI/CD'de connection string `ConnectionStrings__DefaultConnection` env var'ı üzerinden verilir.
 
 ### 3.7 Configuration ve Secret
 
-- Yapilandirma: `appsettings.json` + `appsettings.{Environment}.json`
+- Yapılandırma: `appsettings.json` + `appsettings.{Environment}.json`
 - Development secret: User Secrets (planlanan)
-- Prod/Staging secret: env var (`Section__SubSection__Key` formatinda)
+- Prod/Staging secret: env var (`Section__SubSection__Key` formatında)
 - Detay: [environment-variables.md](./environment-variables.md)
 
 ---
 
-## 4) Kod Standardi
+## 4) Kod Standardı
 
-- `.editorconfig` ile stil kurallari sabitlenmistir.
+- `.editorconfig` ile stil kuralları sabitlenmiştir.
 - Analyzer paketleri: `Microsoft.CodeAnalysis.NetAnalyzers`, `SonarAnalyzer.CSharp`.
-- `ImplicitUsings` ve `Nullable` tum projelerde aciktir.
+- `ImplicitUsings` ve `Nullable` tüm projelerde açıktır.
 - Hedef framework: `net8.0` (bkz. `global.json`).
 
 ---
 
-## 5) Yeni Use-case Eklerken Izlenecek Akis
+## 5) Yeni Use-case Eklerken İzlenecek Akış
 
-1. `Application/Features/<Aggregate>/<UseCase>/` klasorunu ac.
+1. `Application/Features/<Aggregate>/<UseCase>/` klasörünü aç.
 2. `<UseCase>Command.cs` veya `<UseCase>Query.cs` yaz (`IRequest<Result<T>>` implemente eder).
 3. `<UseCase>CommandValidator.cs` (FluentValidation) yaz.
-4. `<UseCase>CommandHandler.cs` icinde is mantigini kur (`IRequestHandler<>`); `Result<T>` donur.
-5. Gerekli ise `Application/Common/Interfaces/` altinda yeni repository interface'i tanimla.
-6. Infrastructure'da karsilik gelen repository implementasyonunu yaz.
-7. `WebAPI` tarafinda controller endpoint'ini ekle; yalnizca `IMediator.Send(...)` cagir ve sonucu map et.
-8. DI kayitlari gerekiyorsa ilgili katmanin `DependencyInjection.cs` dosyasina ekle.
+4. `<UseCase>CommandHandler.cs` içinde iş mantığını kur (`IRequestHandler<>`); `Result<T>` döner.
+5. Gerekli ise `Application/Common/Interfaces/` altında yeni repository interface'i tanımla.
+6. Infrastructure'da karşılık gelen repository implementasyonunu yaz.
+7. `WebAPI` tarafında controller endpoint'ini ekle; yalnızca `IMediator.Send(...)` çağır ve sonucu map et.
+8. DI kayıtları gerekiyorsa ilgili katmanın `DependencyInjection.cs` dosyasına ekle.
 
 ---
 
-## 6) Yapilmayacaklar (Scope Disi)
+## 6) Yapılmayacaklar (Scope Dışı)
 
-Bu mimaride bilincli olarak tercih edilmeyenler:
+Bu mimaride bilinçli olarak tercih edilmeyenler:
 
-- Domain event altyapisi (ilerideki story'de degerlendirilecek)
-- CQRS'in proje duzeyinde ayrilmasi (command/query ayrimi ayni proje icinde, isimlendirme ile yapilir)
-- Assembly-scanning framework'u olarak Scrutor (yalnizca FluentValidation icin assembly scan yapilir)
+- Domain event altyapısı (ilerideki story'de değerlendirilecek)
+- CQRS'in proje düzeyinde ayrılması (command/query ayrımı aynı proje içinde, isimlendirme ile yapılır)
+- Assembly-scanning framework'ü olarak Scrutor (yalnızca FluentValidation için assembly scan yapılır)
 - Generic repository (repository'ler aggregate-specific tutulur)
 
 ---
 
-## 7) Ilgili Dokumanlar
+## 7) İlgili Dokümanlar
 
-- [developer-setup.md](./developer-setup.md) — Gelistirici ortam kurulumu
-- [environment-variables.md](./environment-variables.md) — Env var naming ve yapilandirma
-- [user-story-tracker.md](./user-story-tracker.md) — Story bazli ilerleme takibi
+- [developer-setup.md](./developer-setup.md) — Geliştirici ortam kurulumu
+- [environment-variables.md](./environment-variables.md) — Env var naming ve yapılandırma
+- [user-story-tracker.md](./user-story-tracker.md) — Story bazlı ilerleme takibi

--- a/apps/backend/docs/database-migrations.md
+++ b/apps/backend/docs/database-migrations.md
@@ -1,26 +1,28 @@
-# Database Migrations Akisi
+# Database Migrations Akışı
 
-Bu dokuman, CargoPilot backend'inde ilk migration'in nasil uretildigini, veritabaninin nasil olusturuldugunu ve bu akisin her ortamda nasil isletildigini aciklar.
+**Son güncelleme:** 2026-04-17 · **Durum:** Aktif
+
+Bu doküman, CargoPilot backend'inde ilk migration'ın nasıl üretildiğini, veritabanının nasıl oluşturulduğunu ve bu akışın her ortamda nasıl işletildiğini açıklar.
 
 ---
 
-## 1) On Kosullar
+## 1) Ön Koşullar
 
-### 1.1 EF Core CLI Araci
+### 1.1 EF Core CLI Aracı
 
-Global `dotnet-ef` araci bir kez kurulur:
+Global `dotnet-ef` aracı bir kez kurulur:
 
 ```powershell
 dotnet tool install --global dotnet-ef
 ```
 
-Zaten kuruluysa guncelle:
+Zaten kuruluysa güncelle:
 
 ```powershell
 dotnet tool update --global dotnet-ef
 ```
 
-Dogrulama:
+Doğrulama:
 
 ```powershell
 dotnet ef --version
@@ -28,18 +30,18 @@ dotnet ef --version
 
 ### 1.2 Connection String
 
-Migration komutlari `AppDbContextFactory` araciligiyla connection string'i su kaynak siralamasindan okur:
+Migration komutları `AppDbContextFactory` aracılığıyla connection string'i şu kaynak sıralamasından okur:
 
-1. Ortam degiskeni: `ConnectionStrings__DefaultConnection`
-2. Fallback (yalnizca local dev icin): `Server=localhost;Database=CargoPilotDev;Trusted_Connection=True;TrustServerCertificate=True;`
+1. Ortam değişkeni: `ConnectionStrings__DefaultConnection`
+2. Fallback (yalnızca local dev için): `Server=localhost;Database=CargoPilotDev;Trusted_Connection=True;TrustServerCertificate=True;`
 
-Yerel ornekleri:
+Yerel örnekleri:
 
 ```powershell
 # Windows authentication (lokal SQL Server / LocalDB)
 $env:ConnectionStrings__DefaultConnection = "Server=localhost;Database=CargoPilotDev;Trusted_Connection=True;TrustServerCertificate=True;"
 
-# SA hesabi ile (Docker icin)
+# SA hesabı ile (Docker için)
 $env:ConnectionStrings__DefaultConnection = "Server=localhost,1433;Database=CargoPilotDev;User Id=sa;Password=Your_password123;TrustServerCertificate=True;"
 ```
 
@@ -48,13 +50,13 @@ $env:ConnectionStrings__DefaultConnection = "Server=localhost,1433;Database=Carg
 export ConnectionStrings__DefaultConnection="Server=localhost;Database=CargoPilotDev;Trusted_Connection=True;TrustServerCertificate=True;"
 ```
 
-> **Not:** Production'da env var mutlaka set edilmeli; `docker-compose.*.yml` ve CI/CD pipeline'larinda bu degiskenin varligi zorunlu tutulmalidir.
+> **Not:** Production'da env var mutlaka set edilmeli; `docker-compose.*.yml` ve CI/CD pipeline'larında bu değişkenin varlığı zorunlu tutulmalıdır.
 
 ---
 
-## 2) Calisma Dizini
+## 2) Çalışma Dizini
 
-Komutlar `apps/backend/` dizininden calistirilir. Bu dizinde `CargoPilot.slnx` ve tum katman klasorleri yer alir:
+Komutlar `apps/backend/` dizininden çalıştırılır. Bu dizinde `CargoPilot.slnx` ve tüm katman klasörleri yer alır:
 
 ```powershell
 cd apps/backend
@@ -62,9 +64,9 @@ cd apps/backend
 
 ---
 
-## 3) Ilk Migration
+## 3) İlk Migration
 
-Baslangic migration'ini uret:
+Başlangıç migration'ını üret:
 
 ```powershell
 dotnet ef migrations add InitialCreate `
@@ -73,13 +75,13 @@ dotnet ef migrations add InitialCreate `
   --output-dir Persistence/Migrations
 ```
 
-Parametrelerin anlamlari:
+Parametrelerin anlamları:
 
-- `--project` — migration dosyalarinin uretilecegi proje (`DbContext`'in yasadigi yer).
-- `--startup-project` — uygulamanin giris projesi; host yapilandirmasi ve configuration buradan okunur.
-- `--output-dir` — migration dosyalarinin hangi klasor altinda tutulacagi. Projede standart `Persistence/Migrations`.
+- `--project` — migration dosyalarının üretileceği proje (`DbContext`'in yaşadığı yer).
+- `--startup-project` — uygulamanın giriş projesi; host yapılandırması ve configuration buradan okunur.
+- `--output-dir` — migration dosyalarının hangi klasör altında tutulacağı. Projede standart `Persistence/Migrations`.
 
-Komut basariyla tamamlaninca asagidaki dosyalar olusur:
+Komut başarıyla tamamlanınca aşağıdaki dosyalar oluşur:
 
 ```
 CargoPilot.Infrastructure/Persistence/Migrations/
@@ -90,9 +92,9 @@ CargoPilot.Infrastructure/Persistence/Migrations/
 
 ---
 
-## 4) Veritabanini Olustur / Guncelle
+## 4) Veritabanını Oluştur / Güncelle
 
-Migration'i uygula:
+Migration'ı uygula:
 
 ```powershell
 dotnet ef database update `
@@ -102,11 +104,11 @@ dotnet ef database update `
 
 Bu komut:
 
-- Hedef sunucuda veritabani yoksa olusturur (`CREATE DATABASE`).
-- Bekleyen migration'lari sirayla uygular.
-- `__EFMigrationsHistory` tablosunu olusturup uygulanmis migration kaydini tutar.
+- Hedef sunucuda veritabanı yoksa oluşturur (`CREATE DATABASE`).
+- Bekleyen migration'ları sırayla uygular.
+- `__EFMigrationsHistory` tablosunu oluşturup uygulanmış migration kaydını tutar.
 
-Belirli bir migration'a donmek icin:
+Belirli bir migration'a dönmek için:
 
 ```powershell
 dotnet ef database update <MigrationAdi> `
@@ -114,7 +116,7 @@ dotnet ef database update <MigrationAdi> `
   --startup-project CargoPilot.WebAPI
 ```
 
-Tum migration'lari geri almak icin `0` hedef verilir:
+Tüm migration'ları geri almak için `0` hedef verilir:
 
 ```powershell
 dotnet ef database update 0 `
@@ -126,7 +128,7 @@ dotnet ef database update 0 `
 
 ## 5) Yeni Bir Migration Eklerken
 
-Domain / mapping degistiginde yeni migration uretilir:
+Domain / mapping değiştiğinde yeni migration üretilir:
 
 ```powershell
 dotnet ef migrations add <AnlamliIsim> `
@@ -135,7 +137,7 @@ dotnet ef migrations add <AnlamliIsim> `
   --output-dir Persistence/Migrations
 ```
 
-Isim kurali: `PascalCase`, ne yaptigini ozetleyen ifadeler. Ornekler:
+İsim kuralı: `PascalCase`, ne yaptığını özetleyen ifadeler. Örnekler:
 
 ```
 AddCargoWeightColumn
@@ -145,9 +147,9 @@ AddCargoStatusIndex
 
 ---
 
-## 6) Yanlis Migration'i Iptal Etme
+## 6) Yanlış Migration'ı İptal Etme
 
-### 6.1 Henuz DB'ye uygulanmamissa
+### 6.1 Henüz DB'ye uygulanmamışsa
 
 ```powershell
 dotnet ef migrations remove `
@@ -155,11 +157,11 @@ dotnet ef migrations remove `
   --startup-project CargoPilot.WebAPI
 ```
 
-Bu komut **son** migration dosyalarini siler ve snapshot'i oncesine geri alir.
+Bu komut **son** migration dosyalarını siler ve snapshot'ı öncesine geri alır.
 
-### 6.2 DB'ye uygulanmissa
+### 6.2 DB'ye uygulanmışsa
 
-Once bir onceki migration'a geri don:
+Önce bir önceki migration'a geri dön:
 
 ```powershell
 dotnet ef database update <OncekiMigration> `
@@ -167,34 +169,34 @@ dotnet ef database update <OncekiMigration> `
   --startup-project CargoPilot.WebAPI
 ```
 
-Sonra dosyayi `remove` ile kaldir.
+Sonra dosyayı `remove` ile kaldır.
 
 ---
 
-## 7) Ortam Bazli Akis
+## 7) Ortam Bazlı Akış
 
 ### 7.1 Development
 
-- Default konfigurasyon `useInMemoryRepository: true` ile calisir (bkz. `Program.cs`).
-- Bu modda `DbContext` runtime'da kaydedilmez; uygulama DB'siz ayaga kalkar.
-- Migration komutlari `AppDbContextFactory` araciligiyla bagimsiz calisir; runtime DI'ya ihtiyac duymaz.
-- Gerçek DB uzerinde calismak icin `Program.cs`'teki flag `false`'a cekilir veya ortam degiskeni uzerinden override edilir (Story 5 kapsami).
+- Default konfigürasyon `useInMemoryRepository: true` ile çalışır (bkz. `Program.cs`).
+- Bu modda `DbContext` runtime'da kaydedilmez; uygulama DB'siz ayağa kalkar.
+- Migration komutları `AppDbContextFactory` aracılığıyla bağımsız çalışır; runtime DI'ya ihtiyaç duymaz.
+- Gerçek DB üzerinde çalışmak için `Program.cs`'teki flag `false`'a çekilir veya ortam değişkeni üzerinden override edilir (Story 5 kapsamı).
 
 ### 7.2 Staging / Production
 
-- Runtime'da `useInMemoryRepository: false` olmalidir.
-- `ConnectionStrings__DefaultConnection` env var'i **zorunludur**; uygulama bu olmadan calismaz.
-- Migration'lar iki yontemden biriyle uygulanir:
-  - **Uygulama acilisinda otomatik** — `AppDbContext.Database.Migrate()` cagrisi `Program.cs` baslangicinda calistirilir. Kolaydir ama scale-out / blue-green senaryolarinda yarisa yol acabilir.
-  - **Deployment adimi olarak ayrik** — CI/CD pipeline'inda `dotnet ef database update` komutu uygulama deploy'undan once calistirilir. Tercih edilen yaklasim budur; rollback ve gozlemlenebilirlik daha nettir.
+- Runtime'da `useInMemoryRepository: false` olmalıdır.
+- `ConnectionStrings__DefaultConnection` env var'ı **zorunludur**; uygulama bu olmadan çalışmaz.
+- Migration'lar iki yöntemden biriyle uygulanır:
+  - **Uygulama açılışında otomatik** — `AppDbContext.Database.Migrate()` çağrısı `Program.cs` başlangıcında çalıştırılır. Kolaydır ama scale-out / blue-green senaryolarında yarışa yol açabilir.
+  - **Deployment adımı olarak ayrık** — CI/CD pipeline'ında `dotnet ef database update` komutu uygulama deploy'undan önce çalıştırılır. Tercih edilen yaklaşım budur; rollback ve gözlemlenebilirlik daha nettir.
 
-> **Not:** Uretim ortamina otomatik migrate policy'si Story 5 ve CI/CD story'leri ile birlikte kesinlestirilecektir.
+> **Not:** Üretim ortamına otomatik migrate policy'si Story 5 ve CI/CD story'leri ile birlikte kesinleştirilecektir.
 
 ---
 
-## 8) SQL Script Uretmek (Opsiyonel)
+## 8) SQL Script Üretmek (Opsiyonel)
 
-DB degisiklikleri once SQL olarak incelenip onaylanmak istenirse script uretilir:
+DB değişiklikleri önce SQL olarak incelenip onaylanmak istenirse script üretilir:
 
 ```powershell
 dotnet ef migrations script `
@@ -203,7 +205,7 @@ dotnet ef migrations script `
   --output ./migration.sql
 ```
 
-Belirli iki migration arasini almak icin:
+Belirli iki migration arasını almak için:
 
 ```powershell
 dotnet ef migrations script <From> <To> `
@@ -212,24 +214,24 @@ dotnet ef migrations script <From> <To> `
   --output ./migration.sql
 ```
 
-DBA / release ekibi tarafindan prod uygulamasi icin kullanisli.
+DBA / release ekibi tarafından prod uygulaması için kullanışlı.
 
 ---
 
 ## 9) Sorun Giderme
 
-| Sorun | Sebep / Cozum |
+| Sorun | Sebep / Çözüm |
 |-------|---------------|
-| `No DbContext was found` | `--startup-project CargoPilot.WebAPI` parametresi eksik veya yanlis proje gosteriyor. |
-| `Unable to create an object of type 'AppDbContext'` | `AppDbContextFactory` eksik ya da connection string bos. Env var'i set et ya da factory'nin fallback satirini kontrol et. |
-| `Login failed for user 'sa'` | Connection string'teki kullanici / sifre yanlis. Docker parolasinin `MSSQL_SA_PASSWORD` ile ayni oldugunu dogrula. |
-| `A network-related or instance-specific error` | SQL Server calismiyor ya da firewall 1433 portunu kapatmis. `docker ps` veya `services.msc` ile dogrula. |
-| `The specified framework 'Microsoft.NETCore.App', version 'x.y.z' was not found` | `global.json`'daki SDK surumu makinede yok. `dotnet --list-sdks` kontrol et, gerekirse kur. |
+| `No DbContext was found` | `--startup-project CargoPilot.WebAPI` parametresi eksik veya yanlış proje gösteriyor. |
+| `Unable to create an object of type 'AppDbContext'` | `AppDbContextFactory` eksik ya da connection string boş. Env var'ı set et ya da factory'nin fallback satırını kontrol et. |
+| `Login failed for user 'sa'` | Connection string'teki kullanıcı / şifre yanlış. Docker parolasının `MSSQL_SA_PASSWORD` ile aynı olduğunu doğrula. |
+| `A network-related or instance-specific error` | SQL Server çalışmıyor ya da firewall 1433 portunu kapatmış. `docker ps` veya `services.msc` ile doğrula. |
+| `The specified framework 'Microsoft.NETCore.App', version 'x.y.z' was not found` | `global.json`'daki SDK sürümü makinede yok. `dotnet --list-sdks` kontrol et, gerekirse kur. |
 
 ---
 
-## 10) Ilgili Dokumanlar
+## 10) İlgili Dokümanlar
 
 - [developer-setup.md](./developer-setup.md) — SDK ve tooling kurulumu
-- [environment-variables.md](./environment-variables.md) — Env var naming standardi
-- [architecture.md](./architecture.md) — Katman yapisi ve Infrastructure sorumlulugu
+- [environment-variables.md](./environment-variables.md) — Env var naming standardı
+- [architecture.md](./architecture.md) — Katman yapısı ve Infrastructure sorumluluğu

--- a/apps/backend/docs/developer-setup.md
+++ b/apps/backend/docs/developer-setup.md
@@ -1,40 +1,44 @@
 # CargoPilot Developer Setup
 
-Bu dokumanin amaci, tum gelistiricilerin projeyi ayni arac seti ile sorunsuz derlemesini saglamaktir.
+**Son güncelleme:** 2026-04-17 · **Durum:** Aktif
 
-## 1) Gerekli araclar
+Bu dokümanın amacı, tüm geliştiricilerin projeyi aynı araç seti ile sorunsuz derlemesini sağlamaktır.
 
-- Visual Studio 2022 (17.8 veya ustu onerilir)
+---
+
+## 1) Gerekli araçlar
+
+- Visual Studio 2022 (17.8 veya üstü önerilir)
 - .NET SDK 8.0.x
 - Git
 
 ## 2) Visual Studio kurulumu (zorunlu)
 
-Visual Studio Installer uzerinden asagidaki workloadlari kurun:
+Visual Studio Installer üzerinden aşağıdaki workloadları kurun:
 
 - ASP.NET and web development
 - Data storage and processing
 
-Ek olarak su individual componentlerin kurulu oldugunu dogrulayin:
+Ek olarak şu individual componentlerin kurulu olduğunu doğrulayın:
 
 - .NET 8.0 SDK
-- SQL Server Data Tools (SSDT) (onerilir)
+- SQL Server Data Tools (SSDT) (önerilir)
 
-## 3) SDK standardi
+## 3) SDK standardı
 
-Bu repository, kok dizindeki `global.json` dosyasi ile SDK surumunu sabitler:
+Bu repository, kök dizindeki `global.json` dosyası ile SDK sürümünü sabitler:
 
 - `version`: `8.0.419`
 - `rollForward`: `latestPatch`
 
-Anlamlari:
+Anlamları:
 
-- `version`: Takimin temel SDK surumunu belirler.
-- `latestPatch`: Ayni feature band icindeki en guncel patch surumune izin verir.
+- `version`: Takımın temel SDK sürümünü belirler.
+- `latestPatch`: Aynı feature band içindeki en güncel patch sürümüne izin verir.
 
-## 4) Kurulum sonrasi dogrulama
+## 4) Kurulum sonrası doğrulama
 
-Repository kok dizininde su komutlari calistirin:
+Repository kök dizininde şu komutları çalıştırın:
 
 ```powershell
 dotnet --info
@@ -46,29 +50,29 @@ dotnet build .\CargoPilot.WebAPI\CargoPilot.WebAPI.csproj
 
 Beklenen durum:
 
-- `dotnet --version` cikti degeri `8.0.419` olmali (veya ayni bandda `latestPatch` ile secilen patch).
-- Restore ve build adimlari hata vermeden tamamlanmali.
+- `dotnet --version` çıktı değeri `8.0.419` olmalı (veya aynı bandda `latestPatch` ile seçilen patch).
+- Restore ve build adımları hata vermeden tamamlanmalı.
 
-## 5) Siklikla karsilasilan sorunlar
+## 5) Sıklıkla karşılaşılan sorunlar
 
-- **SDK uyusmazligi:** `global.json` bulunan klasorde komut calistirdiginizdan emin olun.
-- **.NET 8 bulunamadi hatasi:** Visual Studio Installer veya .NET installer ile .NET 8 SDK kurun.
-- **NuGet restore sorunu:** Internet/proxy ayarlarinizi ve kurum sertifika politikasini kontrol edin.
+- **SDK uyuşmazlığı:** `global.json` bulunan klasörde komut çalıştırdığınızdan emin olun.
+- **.NET 8 bulunamadı hatası:** Visual Studio Installer veya .NET installer ile .NET 8 SDK kurun.
+- **NuGet restore sorunu:** Internet/proxy ayarlarınızı ve kurum sertifika politikasını kontrol edin.
 
-## 6) Takim standardi
+## 6) Takım standardı
 
-- Projede SDK surumu `global.json` ile yonetilir.
-- SDK degisiklikleri chapter lead onayi ile yapilir.
-- Yeni surume geciste once local dogrulama, sonra CI dogrulamasi yapilir.
+- Projede SDK sürümü `global.json` ile yönetilir.
+- SDK değişiklikleri chapter lead onayı ile yapılır.
+- Yeni sürüme geçişte önce local doğrulama, sonra CI doğrulaması yapılır.
 
-## 7) CI tarafinda SDK sabitleme
+## 7) CI tarafında SDK sabitleme
 
-CI tarafinda da ayni SDK surumu kullanilir. Bu repository'de GitHub Actions pipeline dosyasi:
+CI tarafında da aynı SDK sürümü kullanılır. Bu repository'de GitHub Actions pipeline dosyası:
 
 - `.github/workflows/ci.yml`
 
-Bu dosyada `actions/setup-dotnet@v4` ile su surum pinlenmistir:
+Bu dosyada `actions/setup-dotnet@v4` ile şu sürüm pinlenmiştir:
 
 - `.NET SDK 8.0.419`
 
-Boylece local (`global.json`) ve CI ayni SDK surumu ile build alir.
+Böylece local (`global.json`) ve CI aynı SDK sürümü ile build alır.

--- a/apps/backend/docs/environment-variables.md
+++ b/apps/backend/docs/environment-variables.md
@@ -1,16 +1,18 @@
 # CargoPilot Environment Variables
 
-Bu dokuman, CargoPilot projesinde yapilandirma degerlerinin environment
-variable olarak nasil isimlendirilecegini tanimlar. Dokuman, ekip icinde
-tutarli bir standart saglamak icin referans olarak kullanilir.
+**Son güncelleme:** 2026-04-25 · **Durum:** Aktif
+
+Bu doküman, CargoPilot projesinde yapılandırma değerlerinin environment
+variable olarak nasıl isimlendirileceğini tanımlar. Doküman, ekip içinde
+tutarlı bir standart sağlamak için referans olarak kullanılır.
 
 ---
 
 ## Naming Standard
 
-Yapilandirma degerleri `appsettings.json` icinde nested JSON olarak
-tutulur. Bir degeri environment variable ile override etmek icin, ayni
-yol **cift alt cizgi (`__`)** ile yazilir.
+Yapılandırma değerleri `appsettings.json` içinde nested JSON olarak
+tutulur. Bir değeri environment variable ile override etmek için, aynı
+yol **çift alt çizgi (`__`)** ile yazılır.
 
 | appsettings JSON path                 | Environment variable name              |
 | ------------------------------------- | -------------------------------------- |
@@ -22,40 +24,40 @@ yol **cift alt cizgi (`__`)** ile yazilir.
 
 ---
 
-## Neden `__` (cift alt cizgi)?
+## Neden `__` (çift alt çizgi)?
 
-JSON yolunda kullanilan `:` karakteri, Linux/bash ve POSIX kabuklarinda
-environment variable isminde **gecerli degildir**. ASP.NET Core
-`EnvironmentVariablesConfigurationProvider`'i, cift alt cizgi gordugunde
-otomatik olarak `:` ile replace edip nested key'e donusturur.
+JSON yolunda kullanılan `:` karakteri, Linux/bash ve POSIX kabuklarında
+environment variable isminde **geçerli değildir**. ASP.NET Core
+`EnvironmentVariablesConfigurationProvider`'i, çift alt çizgi gördüğünde
+otomatik olarak `:` ile replace edip nested key'e dönüştürür.
 
-Bu sayede ayni env var:
+Bu sayede aynı env var:
 - Windows (`cmd`, `PowerShell`),
 - Linux/macOS (`bash`, `zsh`),
 - Docker / Kubernetes / CI pipeline
 
-ortamlarinda tek bir isimle calisir.
+ortamlarında tek bir isimle çalışır.
 
 ---
 
 ## Kurallar
 
-- **Buyuk/kucuk harf duyarsiz**: `ConnectionStrings__DefaultConnection` ile
-  `connectionstrings__defaultconnection` ayni degeri set eder. Yine de
-  okunabilirlik icin `PascalCase__PascalCase` tercih edilmelidir.
-- **Ozel prefix gerekmez**: `ASPNETCORE_` ya da `DOTNET_` gibi prefix'ler
-  ASP.NET Core'un kendi degiskenleri (ornegin `ASPNETCORE_ENVIRONMENT`)
-  icindir; uygulama yapilandirmasi icin kullanilmaz.
+- **Büyük/küçük harf duyarsız**: `ConnectionStrings__DefaultConnection` ile
+  `connectionstrings__defaultconnection` aynı değeri set eder. Yine de
+  okunabilirlik için `PascalCase__PascalCase` tercih edilmelidir.
+- **Özel prefix gerekmez**: `ASPNETCORE_` ya da `DOTNET_` gibi prefix'ler
+  ASP.NET Core'un kendi değişkenleri (örneğin `ASPNETCORE_ENVIRONMENT`)
+  içindir; uygulama yapılandırması için kullanılmaz.
 - **Bir seviye nesting**: `SectionA:SectionB:Key` -> `SectionA__SectionB__Key`.
-  Ic ice sayi sinirsizdir ama 3'ten derine inmekten kacinin; bu yapilandirmada
+  İç içe sayı sınırsızdır ama 3'ten derine inmekten kaçının; bu yapılandırmada
   refactor sinyali verir.
-- **Liste/array degerleri**: `ArraySection:0:Name` -> `ArraySection__0__Name`
-  seklinde indekslenir. Array kullanimi bu projede yoktur; eklenirse bu
-  dokuman guncellenmelidir.
+- **Liste/array değerleri**: `ArraySection:0:Name` -> `ArraySection__0__Name`
+  şeklinde indekslenir. Array kullanımı bu projede yoktur; eklenirse bu
+  doküman güncellenmelidir.
 
 ---
 
-## Ornek: SQL Baglanti Dizesini Set Etme
+## Örnek: SQL Bağlantı Dizesini Set Etme
 
 **Windows (PowerShell):**
 ```powershell
@@ -74,9 +76,9 @@ ENV ConnectionStrings__DefaultConnection=Server=db;Database=CargoPilot;...
 
 ---
 
-## Yapilandirma Oncelik Sirasi
+## Yapılandırma Öncelik Sırası
 
-ASP.NET Core yapilandirmayi asagidaki siraya gore ust uste yukler (son kaynak kazanir):
+ASP.NET Core yapılandırmayı aşağıdaki sıraya göre üst üste yükler (son kaynak kazanır):
 
 1. `appsettings.json`
 2. `appsettings.{Environment}.json`
@@ -86,11 +88,11 @@ ASP.NET Core yapilandirmayi asagidaki siraya gore ust uste yukler (son kaynak ka
 
 ---
 
-## Ortam Bazli Secret Kaynaklari
+## Ortam Bazlı Secret Kaynakları
 
-| Ortam | Connection String Kaynagi | Nasil Set Edilir |
+| Ortam | Connection String Kaynağı | Nasıl Set Edilir |
 |---|---|---|
-| Development (local, Docker'siz) | User Secrets | `dotnet user-secrets set` |
+| Development (local, Docker'sız) | User Secrets | `dotnet user-secrets set` |
 | Test (Docker) | `.env.test` → compose env | `infra/env/.env.test` |
 | Production (Docker) | `.env.prod` → compose env | `/opt/cargo-pilot/infra/env/.env.prod` |
 
@@ -98,8 +100,8 @@ ASP.NET Core yapilandirmayi asagidaki siraya gore ust uste yukler (son kaynak ka
 
 ## Development: User Secrets Kurulumu
 
-`UserSecretsId` `CargoPilot.WebAPI.csproj` icinde `cargo-pilot-backend` olarak tanimlidir.
-Docker kullanmadan `dotnet run` ile local calistirirken:
+`UserSecretsId` `CargoPilot.WebAPI.csproj` içinde `cargo-pilot-backend` olarak tanımlıdır.
+Docker kullanmadan `dotnet run` ile local çalıştırırken:
 
 **Windows (PowerShell):**
 ```powershell
@@ -111,18 +113,18 @@ dotnet user-secrets set "ConnectionStrings:DefaultConnection" "Server=localhost,
 dotnet user-secrets set "ConnectionStrings:DefaultConnection" "Server=localhost,1433;Database=CargoPilotDev;User Id=sa;Password=SIFRE;TrustServerCertificate=True;" --project apps/backend/CargoPilot.WebAPI
 ```
 
-Kayitli secrets listesi:
+Kayıtlı secrets listesi:
 ```bash
 dotnet user-secrets list --project apps/backend/CargoPilot.WebAPI
 ```
 
-User Secrets dosyalari `%APPDATA%/Microsoft/UserSecrets/cargo-pilot-backend/` altinda saklanir; repoya eklenmez.
+User Secrets dosyaları `%APPDATA%/Microsoft/UserSecrets/cargo-pilot-backend/` altında saklanır; repoya eklenmez.
 
 ---
 
-## Production: Bulut DB Baglantisi ve Guvenlik Policy
+## Production: Bulut DB Bağlantısı ve Güvenlik Policy
 
-### Baglanti Akisi
+### Bağlantı Akışı
 
 ```
 .env.prod  (DATABASE_CONNECTION_STRING)
@@ -131,33 +133,33 @@ User Secrets dosyalari `%APPDATA%/Microsoft/UserSecrets/cargo-pilot-backend/` al
           └─> GetConnectionString("DefaultConnection")
 ```
 
-### Connection String Formati
+### Connection String Formatı
 
 ```
 Server=mssql,1433;Database=CargoPilot;User Id=sa;Password=SIFRE;TrustServerCertificate=True;
 ```
 
-- `mssql` — Docker network icindeki servis adi; sunucu disından erisimde IP/hostname kullanilir
-- `TrustServerCertificate=True` — Docker icinde self-signed sertifika ile calistigi icin gerekli
-- Production TLS icin backend onune reverse proxy (Nginx/Caddy) konulmalidir
+- `mssql` — Docker network içindeki servis adı; sunucu dışından erişimde IP/hostname kullanılır
+- `TrustServerCertificate=True` — Docker içinde self-signed sertifika ile çalıştığı için gerekli
+- Production TLS için backend önüne reverse proxy (Nginx/Caddy) konulmalıdır
 
 ### Secret Management Policy
 
 - `.env.prod` sunucuda `/opt/cargo-pilot/infra/env/.env.prod` konumunda `chmod 600` ile korunur
 - `.env.prod` repoya eklenmez (`.gitignore` korumalı)
-- Credentials asla `appsettings.json`, `appsettings.Production.json` veya kaynak koda yazilmaz
-- PR review'larinda connection string iceren dosyalar reddedilir
+- Credentials asla `appsettings.json`, `appsettings.Production.json` veya kaynak koda yazılmaz
+- PR review'larında connection string içeren dosyalar reddedilir
 
 ---
 
-## Zorunlu / Opsiyonel Degiskenler
+## Zorunlu / Opsiyonel Değişkenler
 
-| Degisken | Zorunlu | Aciklama |
+| Değişken | Zorunlu | Açıklama |
 |---|---|---|
-| `ConnectionStrings__DefaultConnection` | **Evet** | SQL Server baglanti dizesi |
+| `ConnectionStrings__DefaultConnection` | **Evet** | SQL Server bağlantı dizesi |
 | `ASPNETCORE_ENVIRONMENT` | **Evet** | `Production` veya `Development` |
-| `ASPNETCORE_URLS` | **Evet** | Dinlenecek adres (orn. `http://+:8080`) |
-| `MINIO_ENDPOINT` | MinIO kullaniliyorsa | MinIO API endpoint |
-| `MINIO_BUCKET` | MinIO kullaniliyorsa | Hedef bucket adi |
-| `MINIO_ROOT_USER` | MinIO kullaniliyorsa | MinIO erisim kullanici adi |
-| `MINIO_ROOT_PASSWORD` | MinIO kullaniliyorsa | MinIO erisim sifresi |
+| `ASPNETCORE_URLS` | **Evet** | Dinlenecek adres (örn. `http://+:8080`) |
+| `MINIO_ENDPOINT` | MinIO kullanılıyorsa | MinIO API endpoint |
+| `MINIO_BUCKET` | MinIO kullanılıyorsa | Hedef bucket adı |
+| `MINIO_ROOT_USER` | MinIO kullanılıyorsa | MinIO erişim kullanıcı adı |
+| `MINIO_ROOT_PASSWORD` | MinIO kullanılıyorsa | MinIO erişim şifresi |

--- a/apps/backend/docs/erp-integration/data-model.md
+++ b/apps/backend/docs/erp-integration/data-model.md
@@ -1,5 +1,11 @@
 # ERP Entegrasyon — Veri Modeli
 
+**Son güncelleme:** 2026-05-08 · **Durum:** Aktif
+
+Bu doküman, ERP entegrasyonu için CargoPilot veri modelinde eklenecek yeni tabloları ve mevcut tablolara eklenecek alanları tanımlar.
+
+---
+
 ## Integration
 | Alan | Tip | Not |
 |------|-----|-----|

--- a/apps/backend/docs/erp-integration/erp-schema-divizyon.md
+++ b/apps/backend/docs/erp-integration/erp-schema-divizyon.md
@@ -1,5 +1,9 @@
 # ERP Veritabanı Şeması — DIVIZYON
 
+**Son güncelleme:** 2026-05-15 · **Durum:** Aktif
+
+Bu doküman, DIVIZYON ERP sisteminin veritabanı şemasını ve Cargo Pilot alan eşleştirmelerini tanımlar.
+
 Kaynak: `DIVIZYON.bak` (SQL Server 2019, 4.35 MB)  
 Restore: `erp-schema-inspect` Docker container, port 1435  
 Tablo sayısı: 3 | `TBLSTSABIT` (134 kol), `TBLSIPAMAS` (106 kol), `TBLSIPATRA` (97 kol)

--- a/apps/backend/docs/user-story-tracker.md
+++ b/apps/backend/docs/user-story-tracker.md
@@ -1,63 +1,65 @@
 # CargoPilot User Story Tracker
 
-Bu dosya, her user story altindaki tum alt isleri tek tek takip etmek icin kullanilir.
-Hem daha once yapilanlar hem de bu sohbette tamamlananlar ayni listede isaretlenir.
+**Son güncelleme:** 2026-05-08 · **Durum:** Aktif
 
-Durum gostergeleri:
-- `✅ Tamamlandi`
-- `🟡 Kismi / Devam ediyor`
-- `⬜ Baslanmadi`
+Bu dosya, her user story altındaki tüm alt işleri tek tek takip etmek için kullanılır.
+Hem daha önce yapılanlar hem de bu sohbette tamamlananlar aynı listede işaretlenir.
+
+Durum göstergeleri:
+- `✅ Tamamlandı`
+- `🟡 Kısmi / Devam ediyor`
+- `⬜ Başlanmadı`
 
 ---
 
-## 1) Gelistirici ortam standardizasyonu (VS bilesenleri + SDK)
-**Story:** Backend Chapter Lead olarak, tum gelistiricilerin projeyi sorunsuz derleyebilmesi ve ayni arac setini kullanmasi icin gerekli olan Visual Studio bilesenlerinin ve SDK surumlerinin kurulumlarinin yapilmasini isterim.
+## 1) Geliştirici ortam standardizasyonu (VS bileşenleri + SDK)
+**Story:** Backend Chapter Lead olarak, tüm geliştiricilerin projeyi sorunsuz derleyebilmesi ve aynı araç setini kullanması için gerekli olan Visual Studio bileşenlerinin ve SDK sürümlerinin kurulumlarının yapılmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
 ### Kabul Kriterleri
-- Repo kokunde, proje hedef frameworku ile uyumlu .NET SDK surumunu sabitleyen bir `global.json` bulunmalidir.
-- Gerekli Visual Studio workload'larini, kurulum adimlarini ve dogrulama komutlarini aciklayan bir `docs/developer-setup.md` dokumani bulunmalidir.
-- Temiz bir gelistirici ortaminda, dokumanda tanimlanan `dotnet restore` ve `dotnet build` komutlari basariyla calistirilabilmelidir.
+- Repo kökünde, proje hedef frameworku ile uyumlu .NET SDK sürümünü sabitleyen bir `global.json` bulunmalıdır.
+- Gerekli Visual Studio workload'larını, kurulum adımlarını ve doğrulama komutlarını açıklayan bir `docs/developer-setup.md` dokümanı bulunmalıdır.
+- Temiz bir geliştirici ortamında, dokümanda tanımlanan `dotnet restore` ve `dotnet build` komutları başarıyla çalıştırılabilmelidir.
 
-### Alt Isler
-- `✅` Repo kokunde `global.json` ile SDK surumunu sabitle
-- `✅` Proje hedef framework ile uyumlu SDK secimi yap (`net8.0` icin `.NET 8`)
-- `✅` Developer setup dokumani hazirla (`docs/developer-setup.md`)
-- `✅` Gerekli Visual Studio workload listesi dokumanda yazsin
-- `✅` Kurulum dogrulama komutlarini dokumanda tanimla
-- `✅` Komutlari ekip makinesinde calistirarak dogrula (`dotnet --info`, `--list-sdks`, `--version`, `restore`, `build`)
-- `✅` CI tarafinda ayni SDK bandinin pinlendigi bilgisini dokumana bagla
+### Alt İşler
+- `✅` Repo kökünde `global.json` ile SDK sürümünü sabitle
+- `✅` Proje hedef framework ile uyumlu SDK seçimi yap (`net8.0` için `.NET 8`)
+- `✅` Developer setup dokümanı hazırla (`docs/developer-setup.md`)
+- `✅` Gerekli Visual Studio workload listesi dokümanda yazsın
+- `✅` Kurulum doğrulama komutlarını dokümanda tanımla
+- `✅` Komutları ekip makinesinde çalıştırarak doğrula (`dotnet --info`, `--list-sdks`, `--version`, `restore`, `build`)
+- `✅` CI tarafında aynı SDK bandının pinlendiği bilgisini dokümana bağla
 
-**Kanitlar:**
+**Kanıtlar:**
 - `global.json`
 - `docs/developer-setup.md`
 - `.github/workflows/ci.yml`
 
 ---
 
-## 2) Clean Architecture standardi
-**Story:** Backend Chapter Lead olarak, projenin ve dizin yapisinin surdurulebilir, test edilebilir ve moduler olmasi icin Clean Architecture standartlarinda olusturulmasini isterim.
+## 2) Clean Architecture standardı
+**Story:** Backend Chapter Lead olarak, projenin ve dizin yapısının sürdürülebilir, test edilebilir ve modüler olması için Clean Architecture standartlarında oluşturulmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
-**Bu story icin teknik kararlar (netlestirildi):**
-- `Application` katmaninda servis bazli yaklasim kullanilacak.
-- Veri erisiminde repository pattern uygulanacak.
-- Dogrulama standardi olarak FluentValidation kullanilacak.
+**Bu story için teknik kararlar (netleştirildi):**
+- `Application` katmanında servis bazlı yaklaşım kullanılacak.
+- Veri erişiminde repository pattern uygulanacak.
+- Doğrulama standardı olarak FluentValidation kullanılacak.
 
-### Alt Isler
-- `✅` Katmanli cozum yapisini olustur (`WebAPI`, `Application`, `Domain`, `Infrastructure`)
-- `✅` Katmanlar arasi referans yonunu Clean Architecture prensibine gore kur
-- `✅` Application icin feature/use-case klasor standardini olustur (`Features/Cargos/CreateCargo`, `GetCargoById`, `ListCargos`, `UpdateCargoStatus`, `CancelCargo`)
-- `✅` Domain tarafinda temel entity/value object/aggregate iskeletini olustur (Kapsam: `Entities/Cargo`, `ValueObjects/TrackingNumber`, `Enums/CargoStatus`; Disinda: domain event, ileri seviye state-machine, adres/agırlik gibi ek modeller)
-- `✅` Application katmaninda repository interface'lerini tanimla (Kapsam: `Abstractions/Persistence/ICargoRepository` contract; Disinda: EF/SQL implementasyonu)
-- `✅` Infrastructure katmaninda EF Core tabanli repository implementasyonlarini yaz (Kapsam: `Persistence/Repositories/CargoRepository`, `AppDbContext` uzerinden `DbSet<Cargo>` ve `TrackingNumber` conversion; Disinda: migration/ileri query optimizasyonu)
-- `✅` Composition root (DI registration extensionlari) standardini kur (Kapsam: her katmanin kendi `DependencyInjection.cs` uzerinden `IServiceCollection` extension sunmasi. `CargoPilot.Application/DependencyInjection.cs` icinde `AddApplication()` use-case kayitlarini yapar; `CargoPilot.Infrastructure/DependencyInjection.cs` icinde `AddInfrastructure(IConfiguration, bool useInMemoryRepository)` `AppDbContext`+connection string okumasi ve `ICargoRepository` icin SQL/InMemory secimini ustlenir; `CargoPilot.WebAPI/DependencyInjection.cs` icinde `AddPresentation()` ve `UsePresentation()` controllers/Swagger/middleware zincirini kurar. `Program.cs` artik ~50 satirdan ~15 satira indi; concrete tip veya EF Core referansi icermiyor, sadece orkestrasyon yapiyor. Application'a DI extension'i kurabilmek icin `Microsoft.Extensions.DependencyInjection.Abstractions 8.0.2` paket referansi eklendi; Infrastructure'in Hosting abstraction'ina bagimliligini onlemek icin environment karari `Program.cs`'de `builder.Environment.IsDevelopment()` flag'i uzerinden geciliyor. Disinda: assembly-scanning (Scrutor), FluentValidation pipeline kayitlari, auth/CORS middleware)
-- `✅` FluentValidation paket ve pipeline entegrasyonunu yap, ilk validatorlari ekle (Kapsam: `CargoPilot.Application` projesine `FluentValidation 11.11.0` ve `FluentValidation.DependencyInjectionExtensions 11.11.0` paketleri eklendi. Assembly scanning ile tum `AbstractValidator<T>` turevleri `Application/DependencyInjection.cs` icindeki `AddValidatorsFromAssembly(typeof(DependencyInjection).Assembly)` cagrisi sayesinde otomatik olarak DI konteynirina kaydediliyor. Ilk validator olarak `Features/Cargos/CreateCargo/CreateCargoRequestValidator.cs` yazildi; `TrackingNumber` icin `NotEmpty` ve `MaximumLength(64)` kurallari, `Status` icin ise deger gonderildiginde `IsInEnum` kurali tanimli. `CreateCargoUseCase` constructor'ina `IValidator<CreateCargoRequest>` inject edildi; use-case bastan `ValidateAsync` cagirarak hatalari `Result<T>.Failure` ile `ValidationError` kodlu tek bir mesajda (`;` ile birlestirilmis) dondurur; boylece onceki ham `if (request is null)` kontrolu ve `try/catch (ArgumentException)` exception-for-control-flow kalibi ortadan kalkti. Disinda: MediatR pipeline behavior kurgusu (projede MediatR yok), cok-hatali structured `ValidationError` tipi (Story 8 response envelope standardi ile birlikte ele alinacak), ileri seviye kurallar (async DB kontrolleri, cross-field/cross-aggregate kurallar), validator icin unit test projesi (ayri story))
-- `✅` Architecture decision record veya mimari rehber dokumani ekle (Kapsam: `apps/backend/docs/architecture.md` dosyasi olusturuldu. Icerik: (1) katmanli yapi tablosu ve bagimlilik akisi diyagrami (Domain <- Application <- Infrastructure / WebAPI), (2) her katmanin icerik standardi ve orneklerle klasor yapisi (`Features/<Aggregate>/<UseCase>/`), (3) mimari kararlarin gerekcesi: service-based Application (MediatR neden alinmadi), repository pattern (aggregate-specific, generic degil), FluentValidation standardi ve assembly scanning yaklasimi, `Result<T>` ile exception-free akis, composition root (her katmanda `DependencyInjection.cs`), dev ortaminda `InMemoryCargoRepository` ile DB-siz calisma, configuration ve secret kaynaklari, (4) yeni use-case eklerken izlenecek 8 adimlik akis, (5) scope disi tutulan yaklasimlar (CQRS, domain event, Scrutor, generic repository). Developer setup ve environment-variables dokumanlariyla cross-link yapildi. Disinda: formal ADR numaralandirma/template akisi (ilerideki story'de), her karar icin ayri ADR dosyasi; bu surum tek bir rehber dokumanda konsolide edilmistir)
+### Alt İşler
+- `✅` Katmanlı çözüm yapısını oluştur (`WebAPI`, `Application`, `Domain`, `Infrastructure`)
+- `✅` Katmanlar arası referans yönünü Clean Architecture prensibine göre kur
+- `✅` Application için feature/use-case klasör standardını oluştur (`Features/Cargos/CreateCargo`, `GetCargoById`, `ListCargos`, `UpdateCargoStatus`, `CancelCargo`)
+- `✅` Domain tarafında temel entity/value object/aggregate iskeletini oluştur (Kapsam: `Entities/Cargo`, `ValueObjects/TrackingNumber`, `Enums/CargoStatus`; Dışında: domain event, ileri seviye state-machine, adres/ağırlık gibi ek modeller)
+- `✅` Application katmanında repository interface'lerini tanımla (Kapsam: `Abstractions/Persistence/ICargoRepository` contract; Dışında: EF/SQL implementasyonu)
+- `✅` Infrastructure katmanında EF Core tabanlı repository implementasyonlarını yaz (Kapsam: `Persistence/Repositories/CargoRepository`, `AppDbContext` üzerinden `DbSet<Cargo>` ve `TrackingNumber` conversion; Dışında: migration/ileri query optimizasyonu)
+- `✅` Composition root (DI registration extensionları) standardını kur (Kapsam: her katmanın kendi `DependencyInjection.cs` üzerinden `IServiceCollection` extension sunması. `CargoPilot.Application/DependencyInjection.cs` içinde `AddApplication()` use-case kayıtlarını yapar; `CargoPilot.Infrastructure/DependencyInjection.cs` içinde `AddInfrastructure(IConfiguration, bool useInMemoryRepository)` `AppDbContext`+connection string okuması ve `ICargoRepository` için SQL/InMemory seçimini üstlenir; `CargoPilot.WebAPI/DependencyInjection.cs` içinde `AddPresentation()` ve `UsePresentation()` controllers/Swagger/middleware zincirini kurar. `Program.cs` artık ~50 satırdan ~15 satıra indi; concrete tip veya EF Core referansı içermiyor, sadece orkestrasyon yapıyor. Application'a DI extension'i kurabilmek için `Microsoft.Extensions.DependencyInjection.Abstractions 8.0.2` paket referansı eklendi; Infrastructure'in Hosting abstraction'ina bağımlılığını önlemek için environment kararı `Program.cs`'de `builder.Environment.IsDevelopment()` flag'i üzerinden geçiliyor. Dışında: assembly-scanning (Scrutor), FluentValidation pipeline kayıtları, auth/CORS middleware)
+- `✅` FluentValidation paket ve pipeline entegrasyonunu yap, ilk validatorları ekle (Kapsam: `CargoPilot.Application` projesine `FluentValidation 11.11.0` ve `FluentValidation.DependencyInjectionExtensions 11.11.0` paketleri eklendi. Assembly scanning ile tüm `AbstractValidator<T>` türevleri `Application/DependencyInjection.cs` içindeki `AddValidatorsFromAssembly(typeof(DependencyInjection).Assembly)` çağrısı sayesinde otomatik olarak DI konteynirina kaydediliyor. İlk validator olarak `Features/Cargos/CreateCargo/CreateCargoRequestValidator.cs` yazıldı; `TrackingNumber` için `NotEmpty` ve `MaximumLength(64)` kuralları, `Status` için ise değer gönderildiğinde `IsInEnum` kuralı tanımlı. `CreateCargoUseCase` constructor'ina `IValidator<CreateCargoRequest>` inject edildi; use-case baştan `ValidateAsync` çağırarak hataları `Result<T>.Failure` ile `ValidationError` kodlu tek bir mesajda (`;` ile birleştirilmiş) döndürür; böylece önceki ham `if (request is null)` kontrolü ve `try/catch (ArgumentException)` exception-for-control-flow kalıbı ortadan kalktı. Dışında: MediatR pipeline behavior kurgusu (projede MediatR yok), çok-hatalı structured `ValidationError` tipi (Story 8 response envelope standardı ile birlikte ele alınacak), ileri seviye kurallar (async DB kontrolleri, cross-field/cross-aggregate kurallar), validator için unit test projesi (ayrı story))
+- `✅` Architecture decision record veya mimarı rehber dokümanı ekle (Kapsam: `apps/backend/docs/architecture.md` dosyası oluşturuldu. İçerik: (1) katmanlı yapı tablosu ve bağımlılık akışı diyagramı (Domain <- Application <- Infrastructure / WebAPI), (2) her katmanın içerik standardı ve örneklerle klasör yapısı (`Features/<Aggregate>/<UseCase>/`), (3) mimarı kararların gerekçesi: service-based Application (MediatR neden alınmadı), repository pattern (aggregate-specific, generic değil), FluentValidation standardı ve assembly scanning yaklaşımı, `Result<T>` ile exception-free akış, composition root (her katmanda `DependencyInjection.cs`), dev ortamında `InMemoryCargoRepository` ile DB-siz çalışma, configuration ve secret kaynakları, (4) yeni use-case eklerken izlenecek 8 adımlık akış, (5) scope dışı tutulan yaklaşımlar (CQRS, domain event, Scrutor, generic repository). Developer setup ve environment-variables dokümanlarıyla cross-link yapıldı. Dışında: formal ADR numaralandırma/template akışı (ilerideki story'de), her karar için ayrı ADR dosyası; bu sürüm tek bir rehber dokümanda konsolide edilmiştir)
 
-**Kanitlar:**
+**Kanıtlar:**
 - `CargoPilot.Application/DependencyInjection.cs`
 - `CargoPilot.Infrastructure/DependencyInjection.cs`
 - `CargoPilot.WebAPI/DependencyInjection.cs`
@@ -70,43 +72,43 @@ Durum gostergeleri:
 ---
 
 ## 3) Environment variables / .env kurgusu
-**Story:** Gelistirici Takimi icin uygulamanin farkli ortamlarda farkli API uc noktalarina baglanabilmesi icin ortam degiskenleri (environment variables / .env yapisi) kurgulanmali.
+**Story:** Geliştirici Takımı için uygulamanın farklı ortamlarda farklı API uç noktalarına bağlanabilmesi için ortam değişkenleri (environment variables / .env yapısı) kurgulanmalı.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
-### Alt Isler
-- `✅` Ortam bazli appsettings dosyalarini olustur (`Development`, `Staging`)
-- `✅` Repo kokunde `.gitignore` olustur (Kapsam: repo koku `.gitignore` dosyasi elle yazildi; Microsoft'un `dotnet new gitignore` template'indeki ~300 satirlik genis liste yerine projenin fiilen kullandigi kalemler secildi. Bolumler: (a) build ciktilari `bin/`, `obj/`, `[Dd]ebug/`, `[Rr]elease/`, `x64/`, `x86/`; (b) Visual Studio/Rider kullanici dosyalari `.vs/`, `.idea/`, `*.user`, `*.suo`, `*.userosscache`, `*.sln.docstates`; (c) test & log `TestResults/`, `*.log`; (d) secret & env `appsettings.*.Local.json`, `.env`, `.env.local`, `.env.*.local`, `secrets.json`, `*.pfx`, `*.key`; (e) NuGet `*.nupkg`, `packages/`; (f) publish ciktilari `publish/`, `*.publishsettings`; (g) OS `Thumbs.db`, `.DS_Store`. `.env.example` pattern'den otomatik haric (farkli isim). User Secrets dosyalari zaten `%APPDATA%/Microsoft/UserSecrets/` altinda, repo disinda kaldigi icin ekstra kural gerekmedi. Disinda: `.vscode/` blok listesi (paylasima acik tutuldu), CI/CD runner-ozel ciktilari, resmi Microsoft template'indeki kullanilmayan ASP.NET Classic/Azure Tools/StyleCop kurallari)
-- `✅` Mevcut `appsettings.Development.json` ve `appsettings.Staging.json` icindeki placeholder connection string'leri kaldir (Kapsam: `appsettings.Development.json` icinden `ConnectionStrings.DefaultConnection` degeri (`Server=SUNUCU_IP_ADRESI;Database=CargoPilot_Dev;User Id=GELISTIRICI_USER;Password=GUCLU_SIFRE;TrustServerCertificate=True;`) ve `appsettings.Staging.json` icinden `ConnectionStrings.DefaultConnection` degeri (`Server=STAGING_SERVER_IP;Database=CargoPilot_Test;Trusted_Connection=True;`) tamamen silindi; her iki dosyada sadece `Logging` blogu kaldi. Yan etki olarak `Infrastructure/DependencyInjection.cs` icindeki `AddDbContext<AppDbContext>` cagrisi artik kosullu: `useInMemoryRepository == true` ise ne `AppDbContext` ne de SQL repository kaydedilir (boylece null connection string yuzunden `UseSqlServer` hata firlatmaz); `false` ise SQL modu `AddDbContext` + `CargoRepository` ikilisi kaydedilir. Development'ta `dotnet run` connection string olmadan sorunsuz baslatilabildigi runtime dogrulamasi ile teyit edildi. Program.cs'teki `useInMemoryRepository: builder.Environment.IsDevelopment()` secimi korundu; DB geldiginde bu tek satirin false'a cekilmesi ve user-secrets/env var ile `ConnectionStrings__DefaultConnection` set edilmesi yeterli. Disinda: config-driven otomatik switch (Yaklasim B) bilincli olarak ertelendi, staging icin Key Vault/secret store entegrasyonu (Story 5 kapsaminda ele alinacak))
-- `✅` Environment variable isim standardini tanimla (Kapsam: `docs/environment-variables.md` dosyasi olusturuldu ve naming standardi bolumu ile dolduruldu. Standart: `appsettings.json` icindeki nested key yolu (`Section:SubSection:Key`) env var'da cift alt cizgi (`Section__SubSection__Key`) olarak ifade edilir; bu .NET `EnvironmentVariablesConfigurationProvider`'inin otomatik destekledigi kanonik konvansiyondur. Dokumantasyonda (a) mevcut projedeki tum key'ler icin JSON-path -> env-var donusum tablosu (ConnectionStrings, Logging, ApplicationSettings), (b) neden `__` tercih edildigi (`:` POSIX kabuklarinda gecersiz, `__` Windows/Linux/macOS/Docker/K8s ortamlarinda tek isimle calisir), (c) kurallar (buyuk/kucuk harf duyarsizligi, `ASPNETCORE_`/`DOTNET_` prefix'lerin farki, nesting derinligi tavsiyesi, array indeksleme sozdizimi), (d) PowerShell/bash/Docker icin pratik set ornekleri yer aliyor. Kod tarafinda degisiklik yok, .NET zaten bu konvansiyonu destekliyor. Disinda: oncelik sirasi, ortam bazli kaynak tablosu, zorunlu/opsiyonel degisken listesi ve policy bolumleri (sonraki alt islerde ayni dosyaya eklenecek))
+### Alt İşler
+- `✅` Ortam bazlı appsettings dosyalarını oluştur (`Development`, `Staging`)
+- `✅` Repo kökünde `.gitignore` oluştur (Kapsam: repo koku `.gitignore` dosyası elle yazıldı; Microsoft'un `dotnet new gitignore` template'indeki ~300 satırlık geniş liste yerine projenin fiilen kullandığı kalemler seçildi. Bölümler: (a) build çıktıları `bin/`, `obj/`, `[Dd]ebug/`, `[Rr]elease/`, `x64/`, `x86/`; (b) Visual Studio/Rider kullanıcı dosyaları `.vs/`, `.idea/`, `*.user`, `*.suo`, `*.userosscache`, `*.sln.docstates`; (ç) test & log `TestResults/`, `*.log`; (d) secret & env `appsettings.*.Local.json`, `.env`, `.env.local`, `.env.*.local`, `secrets.json`, `*.pfx`, `*.key`; (e) NuGet `*.nupkg`, `packages/`; (f) publish çıktıları `publish/`, `*.publishsettings`; (g) OS `Thumbs.db`, `.DS_Store`. `.env.example` pattern'den otomatik hariç (farklı isim). User Secrets dosyaları zaten `%APPDATA%/Microsoft/UserSecrets/` altında, repo dışında kaldığı için ekstra kural gerekmedi. Dışında: `.vscode/` blok listesi (paylaşıma açık tutuldu), CI/CD runner-özel çıktıları, resmi Microsoft template'indeki kullanılmayan ASP.NET Classic/Azure Tools/StyleCop kuralları)
+- `✅` Mevcut `appsettings.Development.json` ve `appsettings.Staging.json` içindeki placeholder connection string'leri kaldır (Kapsam: `appsettings.Development.json` içinden `ConnectionStrings.DefaultConnection` değeri (`Server=SUNUCU_IP_ADRESI;Database=CargoPilot_Dev;User Id=GELISTIRICI_USER;Password=GUCLU_SIFRE;TrustServerCertificate=True;`) ve `appsettings.Staging.json` içinden `ConnectionStrings.DefaultConnection` değeri (`Server=STAGING_SERVER_IP;Database=CargoPilot_Test;Trusted_Connection=True;`) tamamen silindi; her iki dosyada sadece `Logging` bloğu kaldı. Yan etki olarak `Infrastructure/DependencyInjection.cs` içindeki `AddDbContext<AppDbContext>` çağrısı artık koşullu: `useInMemoryRepository == true` ise ne `AppDbContext` ne de SQL repository kaydedilir (böylece null connection string yüzünden `UseSqlServer` hata fırlatmaz); `false` ise SQL modu `AddDbContext` + `CargoRepository` ikilisi kaydedilir. Development'ta `dotnet run` connection string olmadan sorunsuz başlatılabildiği runtime doğrulaması ile teyit edildi. Program.cs'teki `useInMemoryRepository: builder.Environment.IsDevelopment()` seçimi korundu; DB geldiğinde bu tek satırın false'a çekilmesi ve user-secrets/env var ile `ConnectionStrings__DefaultConnection` set edilmesi yeterli. Dışında: config-driven otomatik switch (Yaklaşım B) bilinçli olarak ertelendi, staging için Key Vault/secret store entegrasyonu (Story 5 kapsamında ele alınacak))
+- `✅` Environment variable isim standardını tanımla (Kapsam: `docs/environment-variables.md` dosyası oluşturuldu ve naming standardı bölümü ile dolduruldu. Standart: `appsettings.json` içindeki nested key yolu (`Section:SubSection:Key`) env var'da çift alt çizgi (`Section__SubSection__Key`) olarak ifade edilir; bu .NET `EnvironmentVariablesConfigurationProvider`'inin otomatik desteklediği kanonik konvansiyondur. Dokümantasyonda (a) mevcut projedeki tüm key'ler için JSON-path -> env-var dönüşüm tablosu (ConnectionStrings, Logging, ApplicationSettings), (b) neden `__` tercih edildiği (`:` POSIX kabuklarında geçersiz, `__` Windows/Linux/macOS/Docker/K8s ortamlarında tek isimle çalışır), (ç) kurallar (büyük/küçük harf duyarsızlığı, `ASPNETCORE_`/`DOTNET_` prefix'lerin farkı, nesting derinliği tavsiyesi, array indeksleme sözdizimi), (d) PowerShell/bash/Docker için pratik set örnekleri yer alıyor. Kod tarafında değişiklik yok, .NET zaten bu konvansiyonu destekliyor. Dışında: öncelik sırası, ortam bazlı kaynak tablosu, zorunlu/opsiyonel değişken listesi ve policy bölümleri (sonraki alt işlerde aynı dosyaya eklenecek))
 
-- `✅` Development icin User Secrets kurulumunu yap (`UserSecretsId` ekle, kullanim komutlarini belgele) (Kapsam: `CargoPilot.WebAPI.csproj` dosyasina `<UserSecretsId>cargo-pilot-backend</UserSecretsId>` eklendi. ASP.NET Core `WebApplication.CreateBuilder`, `ASPNETCORE_ENVIRONMENT=Development` oldugunda User Secrets'i otomatik yukler; `Program.cs`'de ekstra kod gerekmez. `docs/environment-variables.md` dosyasina "Development: User Secrets Kurulumu" bolumu eklendi; Windows/Linux icin `dotnet user-secrets set` ve `dotnet user-secrets list` komutlari, dosya konumu (`%APPDATA%/Microsoft/UserSecrets/cargo-pilot-backend/`) belgelendi. Disinda: CI ortami icin User Secrets devre disi birakma (CI'da env var kullanilir zaten), per-developer secrets rotation politikasi)
-- `✅` Local gelistirme icin secret/config yukleme stratejisini belirle (User Secrets + `launchSettings.json` profilleri) (Kapsam: `docs/environment-variables.md` dosyasinda yapilandirma oncelik sirasi ve ortam bazli kaynak tablosu tanimlandi: Docker'siz local gelistirmede User Secrets, Docker dev ortaminda `.env.dev` -> compose env var zinciri kullanilir. `launchSettings.json` mevcut profili `ASPNETCORE_ENVIRONMENT: Development` ile korundu; bu ayar User Secrets'i otomatik aktive eder, ayri bir profil gerekmedi. Disinda: `launchSettings.json`'a Docker Compose profili eklenmesi (Visual Studio'nun Docker destegi bu senaryoyu ayri kurgular), Staging ortami icin local profil)
-- `✅` `.env.example` olustur ve zorunlu/opsiyonel degiskenleri belgele (Kapsam: `infra/env/.env.dev.example` ve `infra/env/.env.prod.example` dosyalari olusturuldu ve guncel tutuldu. `.env.dev.example` gelistirici icin calisan default degerlerle (MSSQL, MinIO, port'lar, `DATABASE_CONNECTION_STRING`) dolduruldu; `cp .env.dev.example .env.dev` ile hemen kullanilabilir. `.env.prod.example` production icin placeholder degerler ve guvenlik uyarilariyla dolduruldu. Zorunlu/opsiyonel degisken tablosu `docs/environment-variables.md` dosyasina eklendi. `.gitignore` `.env.dev`, `.env.prod`, `.env.test` dosyalarini repoya girmeyi engeller; `.env.*.example` dosyalari repoda kalir. Disinda: `.env.staging.example` (staging altyapisi kurulunca eklenecek), Kubernetes Secret manifest ornegi)
-- `✅` `docs/environment-variables.md` olustur: naming standardi, oncelik sirasi, ortam bazli kaynak tablosu (user-secrets / env var / appsettings) (Kapsam: Dosya onceki story'de naming standardi bolumuyle olusturulmustu; bu story kapsaminda genisletildi. Eklenen bölümler: (1) Yapilandirma Oncelik Sirasi (appsettings.json -> appsettings.{Env}.json -> User Secrets -> Environment Variables -> CLI args), (2) Ortam Bazli Secret Kaynaklari tablosu (local/Docker dev, production), (3) Development User Secrets kurulum komutlari, (4) Production baglanti akis diyagrami (.env.prod -> compose -> IConfiguration -> GetConnectionString), (5) zorunlu/opsiyonel degisken tablosu. Disinda: Staging ortami icin ayri tablo satiri (staging altyapisi netlesince eklenecek))
-- `✅` Gizli verilerin dosyalarda tutulmamasini garanti edecek policy ekle (dokumanda + `.gitignore` + code review kurali) (Kapsam: Uc katmanli guvence kuruldu. (1) `.gitignore`: `infra/env/.env.dev`, `infra/env/.env.test`, `infra/env/.env.prod`, `.env`, `.env.*` satirlari ile tum gercek env dosyalari engellendi; `!.env.*.example` ve `!infra/env/.env.*.example` satirlari ile sadece ornek dosyalara izin verildi. (2) `docs/environment-variables.md` "Secret Management Policy" bolumu: `.env.prod` icin `chmod 600` zorunlulugu, credentials'in appsettings/kaynak koda yazilmamasi kurali ve "PR review'larinda connection string iceren dosyalar reddedilir" politikasi dokumante edildi. (3) Uygulama kodu: `AppDbContextFactory` fallback connection string kaldirildigi icin sert kodlanmis secret girme imkani ortadan kaldirildi; `Program.cs`'de hassas veri loglayan `Console.WriteLine` satirlari daha once temizlenmisti. Disinda: otomatik secret tarama (git-secrets / trufflehog CI entegrasyonu), branch protection rule olarak secret scan zorunlulugu)
+- `✅` Development için User Secrets kurulumunu yap (`UserSecretsId` ekle, kullanım komutlarını belgele) (Kapsam: `CargoPilot.WebAPI.csproj` dosyasına `<UserSecretsId>cargo-pilot-backend</UserSecretsId>` eklendi. ASP.NET Core `WebApplication.CreateBuilder`, `ASPNETCORE_ENVIRONMENT=Development` olduğunda User Secrets'i otomatik yükler; `Program.cs`'de ekstra kod gerekmez. `docs/environment-variables.md` dosyasına "Development: User Secrets Kurulumu" bölümü eklendi; Windows/Linux için `dotnet user-secrets set` ve `dotnet user-secrets list` komutları, dosya konumu (`%APPDATA%/Microsoft/UserSecrets/cargo-pilot-backend/`) belgelendi. Dışında: CI ortamı için User Secrets devre dışı bırakma (CI'da env var kullanılır zaten), per-developer secrets rotation politikası)
+- `✅` Local geliştirme için secret/config yükleme stratejisini belirle (User Secrets + `launchSettings.json` profilleri) (Kapsam: `docs/environment-variables.md` dosyasında yapılandırma öncelik sırası ve ortam bazlı kaynak tablosu tanımlandı: Docker'siz local geliştirmede User Secrets, Docker dev ortamında `.env.dev` -> compose env var zinciri kullanılır. `launchSettings.json` mevcut profili `ASPNETCORE_ENVIRONMENT: Development` ile korundu; bu ayar User Secrets'i otomatik aktıve eder, ayrı bir profil gerekmedi. Dışında: `launchSettings.json`'a Docker Compose profili eklenmesi (Visual Studio'nun Docker desteği bu senaryoyu ayrı kurgular), Staging ortamı için local profil)
+- `✅` `.env.example` oluştur ve zorunlu/opsiyonel değişkenleri belgele (Kapsam: `infra/env/.env.dev.example` ve `infra/env/.env.prod.example` dosyaları oluşturuldu ve güncel tutuldu. `.env.dev.example` geliştirici için çalışan default değerlerle (MSSQL, MinIO, port'lar, `DATABASE_CONNECTION_STRING`) dolduruldu; `cp .env.dev.example .env.dev` ile hemen kullanılabilir. `.env.prod.example` production için placeholder değerler ve güvenlik uyarılarıyla dolduruldu. Zorunlu/opsiyonel değişken tablosu `docs/environment-variables.md` dosyasına eklendi. `.gitignore` `.env.dev`, `.env.prod`, `.env.test` dosyalarını repoya girmeyi engeller; `.env.*.example` dosyaları repoda kalır. Dışında: `.env.staging.example` (staging altyapısı kurulunca eklenecek), Kubernetes Secret manifest örneği)
+- `✅` `docs/environment-variables.md` oluştur: naming standardı, öncelik sırası, ortam bazlı kaynak tablosu (user-secrets / env var / appsettings) (Kapsam: Dosya önceki story'de naming standardı bölümüyle oluşturulmuştu; bu story kapsamında genişletildi. Eklenen bölümler: (1) Yapılandırma Öncelik Sırası (appsettings.json -> appsettings.{Env}.json -> User Secrets -> Environment Variables -> CLI args), (2) Ortam Bazlı Secret Kaynakları tablosu (local/Docker dev, production), (3) Development User Secrets kurulum komutları, (4) Production bağlantı akış diyagramı (.env.prod -> compose -> IConfiguration -> GetConnectionString), (5) zorunlu/opsiyonel değişken tablosu. Dışında: Staging ortamı için ayrı tablo satırı (staging altyapısı netlesince eklenecek))
+- `✅` Gizli verilerin dosyalarda tutulmamasını garanti edecek policy ekle (dokümanda + `.gitignore` + code review kuralı) (Kapsam: Uç katmanlı güvence kuruldu. (1) `.gitignore`: `infra/env/.env.dev`, `infra/env/.env.test`, `infra/env/.env.prod`, `.env`, `.env.*` satırları ile tüm gerçek env dosyaları engellendi; `!.env.*.example` ve `!infra/env/.env.*.example` satırları ile sadece örnek dosyalara izin verildi. (2) `docs/environment-variables.md` "Secret Management Policy" bölümü: `.env.prod` için `chmod 600` zorunluluğu, credentials'in appsettings/kaynak koda yazılmaması kuralı ve "PR review'larında connection string içeren dosyalar reddedilir" politikası dokümante edildi. (3) Uygulama kodu: `AppDbContextFactory` fallback connection string kaldırıldığı için sert kodlanmış secret girme imkanı ortadan kaldırıldı; `Program.cs`'de hassas veri loglayan `Console.WriteLine` satırları daha önce temizlenmişti. Dışında: otomatik secret tarama (git-secrets / trufflehog CI entegrasyonu), branch protection rule olarak secret scan zorunluluğu)
 
-**Kanitlar:**
-- `apps/backend/.gitignore` (env dosya koruma kurallari)
+**Kanıtlar:**
+- `apps/backend/.gitignore` (env dosya koruma kuralları)
 - `infra/env/.env.prod.example`
 - `CargoPilot.WebAPI/CargoPilot.WebAPI.csproj` (UserSecretsId)
 - `CargoPilot.WebAPI/Properties/launchSettings.json`
 - `docs/environment-variables.md`
 
 
-## 4) Kod yazim standartlari (.editorconfig + statik analiz)
-**Story:** Backend Chapter Lead olarak, tum ekip uyelerinin ayni kod yazim standartlarina uymasini zorunlu kilmak icin `.editorconfig` ve statik kod analiz araclarinin projeye dahil edilmesini isterim.
+## 4) Kod yazım standartları (.editorconfig + statik analiz)
+**Story:** Backend Chapter Lead olarak, tüm ekip üyelerinin aynı kod yazım standartlarına uymasını zorunlu kılmak için `.editorconfig` ve statik kod analiz araçlarının projeye dahil edilmesini isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
-### Alt Isler
-- `✅` `.editorconfig` olustur
-- `✅` Kod stili kurallarini tanimla (indent, newline, naming)
+### Alt İşler
+- `✅` `.editorconfig` oluştur
+- `✅` Kod stili kurallarını tanımla (indent, newline, naming)
 - `✅` Analyzer paketlerini projeye ekle ve merkezileştir (Kapsam: `Microsoft.CodeAnalysis.NetAnalyzers` paket referansı `Directory.Build.props` altına taşındı, proje bazlı tekrarlar silindi.)
 - `✅` Sonar analyzer paketini projeye ekle ve merkezileştir (Kapsam: `SonarAnalyzer.CSharp` paket referansı `Directory.Build.props` altına taşındı, versiyon kayması riski önlendi.)
-- `✅` Warning policy (treat as error, quality gate) seviyesini netlestir (Kapsam: `apps/backend/Directory.Build.props` olusturuldu; tum backend projelerine ortak kural seti uygulanir. Ayarlar: (1) `TreatWarningsAsErrors=true` — lokal ve CI build'leri uyari bulursa kirmiziya gecer, (2) `EnforceCodeStyleInBuild=true` — `.editorconfig` IDE kurallari build sirasinda dogrulanir, (3) `AnalysisLevel=latest` + `AnalysisMode=Recommended`, (4) `GenerateDocumentationFile=true`. `WarningsNotAsErrors` ile `CS1591;CA1000;CA1716` muaf tutuldu. Ayrıca lokal hata duzeltmeleri (`S4144`, `IDE0005`, `S3400`, `S6966`) yapildi.)
+- `✅` Warning policy (treat as error, quality gate) seviyesini netleştir (Kapsam: `apps/backend/Directory.Build.props` oluşturuldu; tüm backend projelerine ortak kural seti uygulanır. Ayarlar: (1) `TreatWarningsAsErrors=true` — lokal ve CI build'leri uyarı bulursa kırmızıya geçer, (2) `EnforceCodeStyleInBuild=true` — `.editorconfig` IDE kuralları build sırasında doğrulanır, (3) `AnalysisLevel=latest` + `AnalysisMode=Recommended`, (4) `GenerateDocumentationFile=true`. `WarningsNotAsErrors` ile `CS1591;CA1000;CA1716` muaf tutuldu. Ayrıca lokal hata düzeltmeleri (`S4144`, `IDE0005`, `S3400`, `S6966`) yapıldı.)
 
-**Kanitlar:**
+**Kanıtlar:**
 - `.editorconfig`
 - `Directory.Build.props`
 - `CargoPilot.WebAPI/CargoPilot.WebAPI.csproj`
@@ -120,27 +122,27 @@ Durum gostergeleri:
 
 ---
 
-## 5) Connection string'in merkezi okunmasi + bulut DB baglantisi
-**Story:** Backend Chapter Lead olarak, uygulamanin veritabani ile iletisim kurabilmesi icin gerekli baglanti bilgilerinin (Connection String) merkezi bir dosyadan okunmasini ve bulut uzerindeki veri tabanina baglantisini saglanilmasini isterim.
+## 5) Connection string'in merkezi okunması + bulut DB bağlantısı
+**Story:** Backend Chapter Lead olarak, uygulamanın veritabanı ile iletişim kurabilmesi için gerekli bağlantı bilgilerinin (Connection String) merkezi bir dosyadan okunmasını ve bulut üzerindeki veri tabanına bağlantısını sağlanılmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
-### Alt Isler
-- `✅` Connection string'i configuration uzerinden oku (`GetConnectionString("DefaultConnection")`)
-- `✅` Ortam bazli connection string tanimlari ekle (`appsettings.*.json`)
-- `✅` Secret management'e tasi (User Secrets / Key Vault / env vars) (Kapsam: `CargoPilot.WebAPI.csproj` dosyasina `<UserSecretsId>cargo-pilot-backend</UserSecretsId>` eklendi; Docker'siz local gelistirmede `dotnet user-secrets set` ile connection string set edilebilir. Production icin `docker-compose.prod.yml` backend servisine `ConnectionStrings__DefaultConnection: ${DATABASE_CONNECTION_STRING}` env binding'i eklendi; `.env.prod.example` dosyasina `DATABASE_CONNECTION_STRING` degiskeni eklendi. Disinda: Azure Key Vault / AWS Secrets Manager entegrasyonu (proje su an self-hosted Docker ortaminda))
-- `✅` Bulut DB endpoint ve guvenli baglanti policy'sini dokumante et (Kapsam: `docs/environment-variables.md` dosyasi genisletildi; eklenenler: (1) yapilandirma oncelik sirasi (appsettings -> User Secrets -> env vars), (2) ortam bazli secret kaynak tablosu (local/Docker dev, production), (3) User Secrets kurulum komutlari, (4) production baglanti akis diyagrami, (5) `TrustServerCertificate=True` aciklamasi ve reverse proxy TLS notu, (6) secret management policy (chmod 600, gitignore, PR review kurali), (7) zorunlu/opsiyonel degisken tablosu. Disinda: Nginx TLS konfigurasyonu, SSL sertifika kurulumu (infra story kapsaminda))
-- `✅` Connection resiliency/retry policy ekle (Kapsam: `CargoPilot.Infrastructure/DependencyInjection.cs` icindeki `AddDbContext` cagrisi `EnableRetryOnFailure(maxRetryCount: 5, maxRetryDelay: 30s, errorNumbersToAdd: null)` ile guncellendi. EF Core SQL Server provider'in built-in transient fault detection'i kullaniliyor; gecici ag kesintileri ve SQL Server yeniden baslatma senaryolarinda otomatik retry yapilir. Disinda: Polly ile HTTP client retry policy, circuit breaker pattern)
-- `✅` Hassas bilgi loglamasini kaldir (Kapsam: `Program.cs` icindeki `ApplicationSettings:AppName` ve `ConnectionStrings:DefaultConnection` degerlerini konsola yazan `Console.WriteLine` satirlari, composition root refactor'u sirasinda tamamen kaldirildi. Boylece baglanti dizesi ve uygulama meta verisi artik standart cikti akimina yazilmiyor. Disinda: yapilandirilmis log cercevesi (Serilog/ILogger) entegrasyonu ve hassas alan maskeleme kurallari)
+### Alt İşler
+- `✅` Connection string'i configuration üzerinden oku (`GetConnectionString("DefaultConnection")`)
+- `✅` Ortam bazlı connection string tanımları ekle (`appsettings.*.json`)
+- `✅` Secret management'e taşı (User Secrets / Key Vault / env vars) (Kapsam: `CargoPilot.WebAPI.csproj` dosyasına `<UserSecretsId>cargo-pilot-backend</UserSecretsId>` eklendi; Docker'siz local geliştirmede `dotnet user-secrets set` ile connection string set edilebilir. Production için `docker-compose.prod.yml` backend servisine `ConnectionStrings__DefaultConnection: ${DATABASE_CONNECTION_STRING}` env binding'i eklendi; `.env.prod.example` dosyasına `DATABASE_CONNECTION_STRING` değişkeni eklendi. Dışında: Azure Key Vault / AWS Secrets Manager entegrasyonu (proje su an self-hosted Docker ortamında))
+- `✅` Bulut DB endpoint ve güvenli bağlantı policy'sini dokümante et (Kapsam: `docs/environment-variables.md` dosyası genişletildi; eklenenler: (1) yapılandırma öncelik sırası (appsettings -> User Secrets -> env vars), (2) ortam bazlı secret kaynak tablosu (local/Docker dev, production), (3) User Secrets kurulum komutları, (4) production bağlantı akış diyagramı, (5) `TrustServerCertificate=True` açıklaması ve reverse proxy TLS notu, (6) secret management policy (chmod 600, gitignore, PR review kuralı), (7) zorunlu/opsiyonel değişken tablosu. Dışında: Nginx TLS konfigürasyonu, SSL sertifika kurulumu (infra story kapsamında))
+- `✅` Connection resiliency/retry policy ekle (Kapsam: `CargoPilot.Infrastructure/DependencyInjection.cs` içindeki `AddDbContext` çağrısı `EnableRetryOnFailure(maxRetryCount: 5, maxRetryDelay: 30s, errorNumbersToAdd: null)` ile güncellendi. EF Core SQL Server provider'in built-in transient fault detection'i kullanılıyor; geçici ağ kesintileri ve SQL Server yeniden başlatma senaryolarında otomatik retry yapılır. Dışında: Polly ile HTTP client retry policy, circuit breaker pattern)
+- `✅` Hassas bilgi loglamasını kaldır (Kapsam: `Program.cs` içindeki `ApplicationSettings:AppName` ve `ConnectionStrings:DefaultConnection` değerlerini konsola yazan `Console.WriteLine` satırları, composition root refactor'u sırasında tamamen kaldırıldı. Böylece bağlantı dizesi ve uygulama meta verisi artık standart çıktı akımına yazılmıyor. Dışında: yapılandırılmış log çerçevesi (Serilog/ILogger) entegrasyonu ve hassas alan maskeleme kuralları)
 
-### US-DB01: Merkezi baglanti yonetimi — `✅ Tamamlandi`
-Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglanti dizesi artik tek kaynaktan (`infra/env/.env.dev`) okunuyor; ikinci bir hard-coded degere duzelme ihtiyaci kalmadi.
+### US-DB01: Merkezi bağlantı yönetimi — `✅ Tamamlandı`
+Bağımlı branch: `feature/US-DB01-centralized-connection-string`. Runtime bağlantı dizesi artık tek kaynaktan (`infra/env/.env.dev`) okunuyor; ikinci bir hard-coded değere düzelme ihtiyacı kalmadı.
 
-- `✅` `.env.dev.example` + `.env.dev` dosyalarina `DATABASE_CONNECTION_STRING` degiskeni eklendi (Kapsam: MSSQL blogu altina, Docker network icinde gecerli `Server=mssql,1433;Database=CargoPilotDev;User Id=sa;Password=DevPassword123!;TrustServerCertificate=True;` degeri ile; host uzerinden `dotnet ef` calistirilirken `mssql` yerine `localhost` kullanilmasi gerektigi yorum satirinda belirtildi. Disinda: `.env.test.example` ve `.env.prod.example` icin benzer degiskenlerin tanimlanmasi (ilgili ortam compose dosyalari US-D03e kapsaminda tamamlaninca eklenecek))
-- `✅` `docker-compose.dev.yml` backend servisine `ConnectionStrings__DefaultConnection: ${DATABASE_CONNECTION_STRING}` env binding'i eklendi (Kapsam: `.env.dev` -> compose -> container env var zinciri kuruldu; .NET `EnvironmentVariablesConfigurationProvider` bu degeri dogrudan `IConfiguration.GetConnectionString("DefaultConnection")` uzerinden sunuyor, ara bir mapping gerekmiyor. Container yeniden olusturulup env var'in `printenv ConnectionStrings__DefaultConnection` ile dogrulanmasi yapildi. Disinda: kullanilmayan `MSSQL_HOST/PORT/USER/PASSWORD` env entry'lerinin backend servisinden temizlenmesi (ileri bir temizlik commit'ine birakildi; fonksiyonel etki yok))
-- `✅` `AppDbContextFactory` icindeki sert kodlanmis `FallbackConnectionString` kaldirildi (Kapsam: `CargoPilot.Infrastructure/Persistence/AppDbContextFactory.cs` icindeki `Server=localhost;...Trusted_Connection=True;...` sabiti ve `?? FallbackConnectionString` null-coalescing zinciri silindi. Env var tanimsizsa tasarim zamani komutlari net bir `InvalidOperationException` ile durup "dotnet ef komutlarindan once bu degiskeni set et" mesajiyla kullaniciyi `.env.dev` degerine yonlendiriyor; sessiz localhost-fallback davranisi boylece ortadan kaldirildi. Disinda: `Program.cs:9`'daki `useInMemoryRepository: builder.Environment.IsDevelopment()` flag'i — runtime'da MSSQL'e gecis icin ayri bir commit'e birakildi, bu is sadece altyapiyi hazirladi))
+- `✅` `.env.dev.example` + `.env.dev` dosyalarına `DATABASE_CONNECTION_STRING` değişkeni eklendi (Kapsam: MSSQL bloğu altına, Docker network içinde geçerli `Server=mssql,1433;Database=CargoPilotDev;User Id=sa;Password=DevPassword123!;TrustServerCertificate=True;` değeri ile; host üzerinden `dotnet ef` çalıştırılırken `mssql` yerine `localhost` kullanılması gerektiği yorum satırında belirtildi. Dışında: `.env.test.example` ve `.env.prod.example` için benzer değişkenlerin tanımlanması (ilgili ortam compose dosyaları US-D03e kapsamında tamamlanınca eklenecek))
+- `✅` `docker-compose.dev.yml` backend servisine `ConnectionStrings__DefaultConnection: ${DATABASE_CONNECTION_STRING}` env binding'i eklendi (Kapsam: `.env.dev` -> compose -> container env var zinciri kuruldu; .NET `EnvironmentVariablesConfigurationProvider` bu değeri doğrudan `IConfiguration.GetConnectionString("DefaultConnection")` üzerinden sunuyor, ara bir mapping gerekmiyor. Container yeniden oluşturulup env var'in `printenv ConnectionStrings__DefaultConnection` ile doğrulanması yapıldı. Dışında: kullanılmayan `MSSQL_HOST/PORT/USER/PASSWORD` env entry'lerinin backend servisinden temizlenmesi (ileri bir temizlik commit'ine bırakıldı; fonksiyonel etki yok))
+- `✅` `AppDbContextFactory` içindeki sert kodlanmış `FallbackConnectionString` kaldırıldı (Kapsam: `CargoPilot.Infrastructure/Persistence/AppDbContextFactory.cs` içindeki `Server=localhost;...Trusted_Connection=True;...` sabiti ve `?? FallbackConnectionString` null-coalescing zinciri silindi. Env var tanımsızsa tasarım zamanı komutları net bir `InvalidOperationException` ile durup "dotnet ef komutlarından önce bu değişkeni set et" mesajıyla kullanıcıyı `.env.dev` değerine yönlendiriyor; sessiz localhost-fallback davranışı böylece ortadan kaldırıldı. Dışında: `Program.cs:9`'daki `useInMemoryRepository: builder.Environment.IsDevelopment()` flag'i — runtime'da MSSQL'e geçiş için ayrı bir commit'e bırakıldı, bu is sadece altyapıyı hazırladı))
 
-**Kanitlar:**
+**Kanıtlar:**
 - `CargoPilot.WebAPI/Program.cs`
 - `CargoPilot.WebAPI/appsettings.Development.json`
 - `CargoPilot.WebAPI/appsettings.Staging.json`
@@ -154,18 +156,18 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 ---
 
 ## 6) EF Core entegrasyonu + temel DbContext
-**Story:** Backend Chapter Lead olarak, uygulamanin SQL Server ve Bulut veritabanlariyla iletisim kurabilmesi icin Entity Framework Core entegrasyonunu ve temel DbContext yapisinin kurulmasini isterim.
+**Story:** Backend Chapter Lead olarak, uygulamanın SQL Server ve Bulut veritabanlarıyla iletişim kurabilmesi için Entity Framework Core entegrasyonunu ve temel DbContext yapısının kurulmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
-### Alt Isler
+### Alt İşler
 - `✅` EF Core SQL Server paketlerini ekle
-- `✅` `AppDbContext` sinifini olustur
-- `✅` DI ile `AddDbContext` kaydini yap
-- `✅` Ilk migration ve veritabani olusturma akisini dokumante et (Kapsam: `apps/backend/docs/database-migrations.md` dosyasi olusturuldu; 10 bolumluk pratik rehber. Icerik: (1) `dotnet-ef` global tool kurulumu ve dogrulama komutlari, (2) `ConnectionStrings__DefaultConnection` env var kaynak sirasi ve Windows Auth / SA / Docker icin ornek connection string'ler, (3) komutlarin `apps/backend/` dizininden calistirilma standardi, (4) ilk migration uretimi: `dotnet ef migrations add InitialCreate --project CargoPilot.Infrastructure --startup-project CargoPilot.WebAPI --output-dir Persistence/Migrations` ve parametre aciklamalari, (5) `database update` ile DB olusturma/guncelleme, belirli migration'a geri donme, `0` ile tum migration'lari geri alma, (6) yeni migration ekleme isim kurali (PascalCase, ornekler `AddCargoWeightColumn` vb), (7) migration iptal akisi (DB'ye uygulanmadan `migrations remove`, uygulandiysa once `database update <Onceki>`), (8) ortam bazli akis: Dev modunda InMemory repo aktifken factory sayesinde migration'lar calisir, prod'da env var zorunlu ve auto-migrate vs pipeline-step secimleri, (9) SQL script uretme (`migrations script`) DBA akisi, (10) sorun giderme tablosu (6 yaygin hata ve cozum). Dokumanin calisir olmasi icin `CargoPilot.Infrastructure/Persistence/AppDbContextFactory.cs` eklendi: `IDesignTimeDbContextFactory<AppDbContext>` implementasyonu, `ConnectionStrings__DefaultConnection` env var'i okur, local SQL fallback'i var; sadece tasarim zamani cagrilir, runtime'da kullanilmaz. Bu olmadan Development ortaminda (`useInMemoryRepository: true` iken `AddDbContext` kaydedilmedigi icin) `dotnet ef` komutlari "Unable to create an object of type 'AppDbContext'" hatasi verirdi; factory bu blokaji ortadan kaldirir ve EF CLI akisini runtime DI'dan bagimsiz kilar. Disinda: ilk migration dosyasinin gercek uretimi (tercihen ilk DB baglantisi story'si ile birlikte yapilacak), auto-migrate policy'sinin prod icin netlestirilmesi (Story 5 + CI/CD story'leri), seed data stratejisi (ayri story))
-- `✅` DbSet bazli domain tablolarini olustur (`DbSet<Cargo>`)
+- `✅` `AppDbContext` sınıfını oluştur
+- `✅` DI ile `AddDbContext` kaydını yap
+- `✅` İlk migration ve veritabanı oluşturma akışını dokümante et (Kapsam: `apps/backend/docs/database-migrations.md` dosyası oluşturuldu; 10 bölümlük pratik rehber. İçerik: (1) `dotnet-ef` global tool kurulumu ve doğrulama komutları, (2) `ConnectionStrings__DefaultConnection` env var kaynak sırası ve Windows Auth / SA / Docker için örnek connection string'ler, (3) komutların `apps/backend/` dizininden çalıştırılma standardı, (4) ilk migration üretimi: `dotnet ef migrations add InitialCreate --project CargoPilot.Infrastructure --startup-project CargoPilot.WebAPI --output-dir Persistence/Migrations` ve parametre açıklamaları, (5) `database update` ile DB oluşturma/güncelleme, belirli migration'a geri dönme, `0` ile tüm migration'ları geri alma, (6) yeni migration ekleme isim kuralı (PascalCase, örnekler `AddCargoWeightColumn` vb), (7) migration iptal akışı (DB'ye uygulanmadan `migrations remove`, uygulandıysa önce `database update <Onceki>`), (8) ortam bazlı akış: Dev modunda InMemory repo aktifken factory sayesinde migration'lar çalışır, prod'da env var zorunlu ve auto-migrate vs pipeline-step seçimleri, (9) SQL script üretme (`migrations script`) DBA akışı, (10) sorun giderme tablosu (6 yaygın hata ve çözüm). Dokümanın çalışır olması için `CargoPilot.Infrastructure/Persistence/AppDbContextFactory.cs` eklendi: `IDesignTimeDbContextFactory<AppDbContext>` implementasyonu, `ConnectionStrings__DefaultConnection` env var'i okur, local SQL fallback'i var; sadece tasarım zamanı çağrılır, runtime'da kullanılmaz. Bu olmadan Development ortamında (`useInMemoryRepository: true` iken `AddDbContext` kaydedilmediği için) `dotnet ef` komutları "Unable to create an object of type 'AppDbContext'" hatası verirdi; factory bu blokajı ortadan kaldırır ve EF CLI akışını runtime DI'dan bağımsız kılar. Dışında: ilk migration dosyasının gerçek üretimi (tercihen ilk DB bağlantısı story'si ile birlikte yapılacak), auto-migrate policy'sinin prod için netleştirilmesi (Story 5 + CI/CD story'leri), seed data stratejisi (ayrı story))
+- `✅` DbSet bazlı domain tablolarını oluştur (`DbSet<Cargo>`)
 
-**Kanitlar:**
+**Kanıtlar:**
 - `CargoPilot.Infrastructure/CargoPilot.Infrastructure.csproj`
 - `CargoPilot.Infrastructure/Persistence/AppDbContext.cs`
 - `CargoPilot.Infrastructure/Persistence/AppDbContextFactory.cs`
@@ -174,22 +176,22 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 
 ---
 
-## 7) Base Entity standardi
-**Story:** Backend Chapter Lead olarak, tum veritabani tablolarinda Id, CreatedDate, UpdatedDate ve IsDeleted (Soft Delete) gibi alanlarin standart olmasini saglayan bir Base Entity yapisinin kurulmasini isterim.
+## 7) Base Entity standardı
+**Story:** Backend Chapter Lead olarak, tüm veritabanı tablolarında Id, CreatedDate, UpdatedDate ve IsDeleted (Soft Delete) gibi alanların standart olmasını sağlayan bir Base Entity yapısının kurulmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
-### Alt Isler
-- `✅` Story 7 oncesi ortam dogrulamasi: `global.json` (SDK `8.0.419`, `rollForward: latestPatch`) uyumlu `8.0.420` ile `dotnet build CargoPilot.WebAPI/CargoPilot.WebAPI.csproj` basariyla tamamlandi (0 hata); boylece BaseEntity turetmesi oncesi baseline temiz build teyit edildi.
-- `✅` Ilk `InitialCreate` migration'ini uret (Kapsam: `dotnet ef migrations add InitialCreate --project CargoPilot.Infrastructure --startup-project CargoPilot.Infrastructure --output-dir Persistence/Migrations` komutu ile `20260418104913_InitialCreate.cs`, `.Designer.cs` ve `AppDbContextModelSnapshot.cs` dosyalari olusturuldu. Migration; `Cargos` tablosunu uretiyor: `Id uniqueidentifier PK`, `TrackingNumber nvarchar(64) NOT NULL`, `Status int NOT NULL`. EF CLI `AppDbContextFactory` uzerinden tasarim zamani context olusturdugu icin `ConnectionStrings__DefaultConnection` env var'i olmadan da uretim basarili oldu. Bu migration BaseEntity calismasi icin referans snapshot gorevi gorur; `BaseEntity` eklendiginde bir sonraki `AddBaseEntity` migration'i bu baseline uzerinden `CreatedDate`, `UpdatedDate`, `IsDeleted` kolonlarini getirecek. Disinda: migration'in aktif DB'ye uygulanmasi (Story 5 kapsaminda DB endpoint netlestikten sonra `database update`))
-- `✅` Migration generator ile `TreatWarningsAsErrors` kalite kapisi arasindaki catismayi mimari seviyede coz (Kapsam: `InitialCreate` uretildikten sonra ilk build `IDE0005: Using directive is unnecessary` hatasiyla kirildi. Sebep: EF Core generator her migration dosyasinin basina sabit olarak `using System;` ekler, ancak `CargoPilot.Infrastructure.csproj` icinde `<ImplicitUsings>enable</ImplicitUsings>` acik oldugu icin `System` namespace'i zaten global olarak import edilir ve satir gereksiz sayilir. Story 4'te aktif edilen `TreatWarningsAsErrors=true` + `EnforceCodeStyleInBuild=true` policy'si bu uyariyi hataya cevirdigi icin build kirildi. Her migration uretildiginde satiri elle silmek (a) gelecekteki ekip uyeleri icin ayak bagi, (b) generated koda manuel mudahale anti-pattern'i. Cozum olarak `.editorconfig` dosyasina `[**/Persistence/Migrations/*.cs]` bolumu eklendi: `generated_code = true` ile bu klasor generated kod olarak isaretlendi (analyzer'lar bu dosyalari otomatik atlar), `dotnet_diagnostic.IDE0005.severity = none` ile style analizi muafiyeti kesinlestirildi. Sonraki build 0 hata / 83 uyari (tumu CS1591, policy muaf) ile gecti. Disinda: Migrations klasoru icin baska analyzer kurali customize'i (ileri story'lerde ihtiyac dogarsa))
-- `✅` Domain'de `BaseEntity` tanimla (Kapsam: `CargoPilot.Domain/Entities/BaseEntity.cs` olusturuldu. Alanlar: `Id (Guid, protected set)`, `CreatedDate (DateTime, private set)`, `UpdatedDate (DateTime, private set)`, `IsDeleted (bool, private set)`, `CreatedBy (Guid?, private set)`, `UpdatedBy (Guid?, private set)`. `protected BaseEntity()` EF Core tasarim zamani nesnelestirmesi icin; `protected BaseEntity(Guid id)` uygulama kodu icin — `id == Guid.Empty` dogrulamasi burada merkezi olarak yapiliyor. Audit property'leri `private set` ile korunuyor; EF Core `ChangeTracker.CurrentValue` API'si CLR seviyesinde setter'i atlayarak alanlara yazacagi icin Sonar S1144 ("kullanilmayan private setter") yanh pozitif uretir. Bunu suppress etmek icin iki adim atildi: (a) `apps/backend/.editorconfig` dosyasina `[**/Domain/Entities/BaseEntity.cs]` bolumu ile `dotnet_diagnostic.S1144.severity = none` eklendi — ancak Sonar Roslyn analyzer bu glob pattern'i build sirasinda okuyamadi, (b) dogrudan kaynak dosyaya `#pragma warning disable S1144 / #pragma warning restore S1144` eklendi — bu Roslyn tabanli her analyzer icin garantili calisir. Disinda: `CreatedBy`/`UpdatedBy` icin gercek userId (auth story'si ile gelecek), domain event pattern, `DeletedDate` stamp)
-- `✅` Tum aggregate/entity siniflarini `BaseEntity`den turet (Kapsam: `Cargo` sinifi `BaseEntity`'den turetildi. `Id` property'si `Cargo`'dan kaldirildi (artik `BaseEntity`'de). Constructor `base(id)` cagrisi ile id dogrulamasini `BaseEntity`'ye delege ediyor. EF Core icin `protected Cargo() : base() { TrackingNumber = null!; }` constructor'i eklendi — `private` yerine `protected` kullanildi: Sonar S1144 private constructor'lari "kullanilmayan" olarak isaretler cunku EF Core reflection ile cagirdigini goremez; `protected` yapilarak bu false pozitif engellendi. `TrackingNumber = null!` null-forgiving atamasi CS8618 uyarisini susturur — bu EF Core constructor'i oldugu icin compiler dogrulama yapamaz, anlambilim olarak dogru. Disinda: baska aggregate/entity yoktur; yenisi eklendigi zaman ayni pattern izlenecek)
-- `✅` `SaveChanges` seviyesinde audit alanlarini otomatik set et ve `CreatedBy`/`UpdatedBy` icin `ICurrentUserService` altyapisini kur (Kapsam: `AppDbContext.SaveChangesAsync` ve `SaveChanges` override edilerek `ApplyAuditFields()` private metodu cagrilir. Metod `ChangeTracker.Entries<BaseEntity>()` uzerinden tum tracked entity'leri tarar: `EntityState.Added` ise `CreatedDate`, `UpdatedDate`, `CreatedBy`, `UpdatedBy` set edilir; `EntityState.Modified` ise sadece `UpdatedDate` ve `UpdatedBy` set edilir. Set islemi `entry.Property(x => x.CreatedDate).CurrentValue = now` seklinde EF Core'un expression tree API'si uzerinden yapilir — bu yontem `private set` kisitini atlar. Kim-degistirdi bilgisi icin `ICurrentUserService` interface'i `CargoPilot.Application/Abstractions/ICurrentUserService.cs` olarak tanimlandi (tek property: `Guid? UserId`); `CargoPilot.Infrastructure/Services/AnonymousCurrentUserService.cs` `UserId => null` dondurecek sekilde implement edildi (`internal sealed`). `Infrastructure/DependencyInjection.cs` icinde `services.AddScoped<ICurrentUserService, AnonymousCurrentUserService>()` kaydedildi. `AppDbContext` constructor'ina `ICurrentUserService` inject edildi. `AppDbContextFactory` (design-time, DI'siz) `new AnonymousCurrentUserService()` ile dogrudan orneklendi. Auth story'si geldiginde yalnizca `AnonymousCurrentUserService` yerine `JwtCurrentUserService` yazilip DI kaydedilecek; `AppDbContext`, `BaseEntity`, `Cargo` degismez. Disinda: gercek `UserId` okuma (JWT/session), `IHttpContextAccessor` inject etme, `CreatedBy`/`UpdatedBy` icin navigation property)
-- `✅` Soft delete query filter'larini global olarak tanimla ve `IsDeleted` icin index ekle (Kapsam: `AppDbContext.OnModelCreating` icinde `Cargo` entity konfigurasyonuna `entity.HasQueryFilter(cargo => !cargo.IsDeleted)` eklendi — bu sayede tum `SELECT` sorgularina otomatik `WHERE IsDeleted = 0` eklenir. Silinen kaydi gormek gerektiginde `dbContext.Cargos.IgnoreQueryFilters().Where(...)` kullanilir. Performans icin `entity.HasIndex(cargo => cargo.IsDeleted)` ile `IX_Cargos_IsDeleted` indeksi tanimlandi. Audit kolonlari (`CreatedDate NOT NULL`, `UpdatedDate NOT NULL`, `IsDeleted NOT NULL DEFAULT 0`, `CreatedBy uniqueidentifier NULL`, `UpdatedBy uniqueidentifier NULL`) entity konfigurasyonunda `IsRequired()`/`HasDefaultValue(false)` ile belirtildi. Disinda: cascade soft delete (iliskili entity'ler, proje su an tek aggregate), `DeletedDate` / `DeletedBy` stamp alanlari, soft delete icin ayri repository metotlari (`ListIncludingDeleted` vb.))
-- `✅` `AddBaseEntity` migration'ini uret ve son build dogrula (Kapsam: `dotnet ef migrations add AddBaseEntity --project CargoPilot.Infrastructure --startup-project CargoPilot.Infrastructure --output-dir Persistence/Migrations` komutu basariyla tamamlandi; `20260418115212_AddBaseEntity.cs` ve `.Designer.cs` olusturuldu. Migration `Cargos` tablosuna `CreatedBy (uniqueidentifier NULL)`, `CreatedDate (datetime2 NOT NULL)`, `IsDeleted (bit NOT NULL DEFAULT 0)`, `UpdatedBy (uniqueidentifier NULL)`, `UpdatedDate (datetime2 NOT NULL)` kolonlarini ve `IX_Cargos_IsDeleted` indeksini ekler. Migration sonrasi `dotnet build CargoPilot.WebAPI/CargoPilot.WebAPI.csproj` 0 hata ile tamamlandi. Disinda: `database update` ile DB'ye uygulanmasi (Story 5 kapsaminda aktif baglanti saglannca))
+### Alt İşler
+- `✅` Story 7 öncesi ortam doğrulaması: `global.json` (SDK `8.0.419`, `rollForward: latestPatch`) uyumlu `8.0.420` ile `dotnet build CargoPilot.WebAPI/CargoPilot.WebAPI.csproj` başarıyla tamamlandı (0 hata); böylece BaseEntity türetmesi öncesi baseline temiz build teyit edildi.
+- `✅` İlk `InitialCreate` migration'ini üret (Kapsam: `dotnet ef migrations add InitialCreate --project CargoPilot.Infrastructure --startup-project CargoPilot.Infrastructure --output-dir Persistence/Migrations` komutu ile `20260418104913_InitialCreate.cs`, `.Designer.cs` ve `AppDbContextModelSnapshot.cs` dosyaları oluşturuldu. Migration; `Cargos` tablosunu üretiyor: `Id uniqueidentifier PK`, `TrackingNumber nvarchar(64) NOT NULL`, `Status int NOT NULL`. EF CLI `AppDbContextFactory` üzerinden tasarım zamanı context oluşturduğu için `ConnectionStrings__DefaultConnection` env var'i olmadan da üretim başarılı oldu. Bu migration BaseEntity çalışması için referans snapshot görevi görür; `BaseEntity` eklendiğinde bir sonraki `AddBaseEntity` migration'i bu baseline üzerinden `CreatedDate`, `UpdatedDate`, `IsDeleted` kolonlarını getirecek. Dışında: migration'in aktif DB'ye uygulanması (Story 5 kapsamında DB endpoint netleştikten sonra `database update`))
+- `✅` Migration generator ile `TreatWarningsAsErrors` kalite kapısı arasındaki çatışmayı mimarı seviyede çöz (Kapsam: `InitialCreate` üretildikten sonra ilk build `IDE0005: Using directive is unnecessary` hatasıyla kırıldı. Sebep: EF Core generator her migration dosyasının basına sabit olarak `using System;` ekler, ancak `CargoPilot.Infrastructure.csproj` içinde `<ImplicitUsings>enable</ImplicitUsings>` açık olduğu için `System` namespace'i zaten global olarak import edilir ve satır gereksiz sayılır. Story 4'te aktif edilen `TreatWarningsAsErrors=true` + `EnforceCodeStyleInBuild=true` policy'si bu uyarıyı hataya çevirdiği için build kırıldı. Her migration üretildiğinde satırı elle silmek (a) gelecekteki ekip üyeleri için ayak bağı, (b) generated koda manuel müdahale anti-pattern'i. Çözüm olarak `.editorconfig` dosyasına `[**/Persistence/Migrations/*.cs]` bölümü eklendi: `generated_code = true` ile bu klasör generated kod olarak işaretlendi (analyzer'lar bu dosyaları otomatik atlar), `dotnet_diagnostic.IDE0005.severity = none` ile style analizi muafiyeti kesinleştirildi. Sonraki build 0 hata / 83 uyarı (tümü CS1591, policy muaf) ile geçti. Dışında: Migrations klasörü için başka analyzer kuralı customize'i (ileri story'lerde ihtiyaç doğarsa))
+- `✅` Domain'de `BaseEntity` tanımla (Kapsam: `CargoPilot.Domain/Entities/BaseEntity.cs` oluşturuldu. Alanlar: `Id (Guid, protected set)`, `CreatedDate (DateTime, private set)`, `UpdatedDate (DateTime, private set)`, `IsDeleted (bool, private set)`, `CreatedBy (Guid?, private set)`, `UpdatedBy (Guid?, private set)`. `protected BaseEntity()` EF Core tasarım zamanı nesneleştirmesi için; `protected BaseEntity(Guid id)` uygulama kodu için — `id == Guid.Empty` doğrulaması burada merkezi olarak yapılıyor. Audit property'leri `private set` ile korunuyor; EF Core `ChangeTracker.CurrentValue` API'si CLR seviyesinde setter'i atlayarak alanlara yazacağı için Sonar S1144 ("kullanılmayan private setter") yanh pozitif üretir. Bunu suppress etmek için iki adım atıldı: (a) `apps/backend/.editorconfig` dosyasına `[**/Domain/Entities/BaseEntity.cs]` bölümü ile `dotnet_diagnostic.S1144.severity = none` eklendi — ancak Sonar Roslyn analyzer bu glob pattern'i build sırasında okuyamadı, (b) doğrudan kaynak dosyaya `#pragma warning disable S1144 / #pragma warning restore S1144` eklendi — bu Roslyn tabanlı her analyzer için garantili çalışır. Dışında: `CreatedBy`/`UpdatedBy` için gerçek userId (auth story'si ile gelecek), domain event pattern, `DeletedDate` stamp)
+- `✅` Tüm aggregate/entity sınıflarını `BaseEntity`den türet (Kapsam: `Cargo` sınıfı `BaseEntity`'den türetildi. `Id` property'si `Cargo`'dan kaldırıldı (artık `BaseEntity`'de). Constructor `base(id)` çağrısı ile id doğrulamasını `BaseEntity`'ye delege ediyor. EF Core için `protected Cargo() : base() { TrackingNumber = null!; }` constructor'i eklendi — `private` yerine `protected` kullanıldı: Sonar S1144 private constructor'ları "kullanılmayan" olarak işaretler çünkü EF Core reflection ile çağırdığını göremez; `protected` yapılarak bu false pozitif engellendi. `TrackingNumber = null!` null-forgiving ataması CS8618 uyarısını susturur — bu EF Core constructor'i olduğu için compiler doğrulama yapamaz, anlambilim olarak doğru. Dışında: başka aggregate/entity yoktur; yenisi eklendiği zaman aynı pattern izlenecek)
+- `✅` `SaveChanges` seviyesinde audit alanlarını otomatik set et ve `CreatedBy`/`UpdatedBy` için `ICurrentUserService` altyapısını kur (Kapsam: `AppDbContext.SaveChangesAsync` ve `SaveChanges` override edilerek `ApplyAuditFields()` private metodu çağrılır. Metod `ChangeTracker.Entries<BaseEntity>()` üzerinden tüm tracked entity'leri tarar: `EntityState.Added` ise `CreatedDate`, `UpdatedDate`, `CreatedBy`, `UpdatedBy` set edilir; `EntityState.Modified` ise sadece `UpdatedDate` ve `UpdatedBy` set edilir. Set işlemi `entry.Property(x => x.CreatedDate).CurrentValue = now` şeklinde EF Core'un expression tree API'si üzerinden yapılır — bu yöntem `private set` kısıtını atlar. Kim-değiştirdi bilgisi için `ICurrentUserService` interface'i `CargoPilot.Application/Abstractions/ICurrentUserService.cs` olarak tanımlandı (tek property: `Guid? UserId`); `CargoPilot.Infrastructure/Services/AnonymousCurrentUserService.cs` `UserId => null` döndürecek şekilde implement edildi (`internal sealed`). `Infrastructure/DependencyInjection.cs` içinde `services.AddScoped<ICurrentUserService, AnonymousCurrentUserService>()` kaydedildi. `AppDbContext` constructor'ina `ICurrentUserService` inject edildi. `AppDbContextFactory` (design-time, DI'siz) `new AnonymousCurrentUserService()` ile doğrudan örneklendi. Auth story'si geldiğinde yalnızca `AnonymousCurrentUserService` yerine `JwtCurrentUserService` yazılıp DI kaydedilecek; `AppDbContext`, `BaseEntity`, `Cargo` değişmez. Dışında: gerçek `UserId` okuma (JWT/session), `IHttpContextAccessor` inject etme, `CreatedBy`/`UpdatedBy` için navigation property)
+- `✅` Soft delete query filter'larini global olarak tanımla ve `IsDeleted` için index ekle (Kapsam: `AppDbContext.OnModelCreating` içinde `Cargo` entity konfigürasyonuna `entity.HasQueryFilter(cargo => !cargo.IsDeleted)` eklendi — bu sayede tüm `SELECT` sorgularına otomatik `WHERE IsDeleted = 0` eklenir. Silinen kaydı görmek gerektiğinde `dbContext.Cargos.IgnoreQueryFilters().Where(...)` kullanılır. Performans için `entity.HasIndex(cargo => cargo.IsDeleted)` ile `IX_Cargos_IsDeleted` indeksi tanımlandı. Audit kolonları (`CreatedDate NOT NULL`, `UpdatedDate NOT NULL`, `IsDeleted NOT NULL DEFAULT 0`, `CreatedBy uniqueidentifier NULL`, `UpdatedBy uniqueidentifier NULL`) entity konfigürasyonunda `IsRequired()`/`HasDefaultValue(false)` ile belirtildi. Dışında: cascade soft delete (ilişkili entity'ler, proje su an tek aggregate), `DeletedDate` / `DeletedBy` stamp alanları, soft delete için ayrı repository metotları (`ListIncludingDeleted` vb.))
+- `✅` `AddBaseEntity` migration'ini üret ve son build doğrula (Kapsam: `dotnet ef migrations add AddBaseEntity --project CargoPilot.Infrastructure --startup-project CargoPilot.Infrastructure --output-dir Persistence/Migrations` komutu başarıyla tamamlandı; `20260418115212_AddBaseEntity.cs` ve `.Designer.cs` oluşturuldu. Migration `Cargos` tablosuna `CreatedBy (uniqueidentifier NULL)`, `CreatedDate (datetime2 NOT NULL)`, `IsDeleted (bit NOT NULL DEFAULT 0)`, `UpdatedBy (uniqueidentifier NULL)`, `UpdatedDate (datetime2 NOT NULL)` kolonlarını ve `IX_Cargos_IsDeleted` indeksini ekler. Migration sonrası `dotnet build CargoPilot.WebAPI/CargoPilot.WebAPI.csproj` 0 hata ile tamamlandı. Dışında: `database update` ile DB'ye uygulanması (Story 5 kapsamında aktif bağlantı sağlannca))
 
-**Kanitlar:**
+**Kanıtlar:**
 - `CargoPilot.Domain/Entities/BaseEntity.cs`
 - `CargoPilot.Domain/Entities/Cargo.cs`
 - `CargoPilot.Application/Abstractions/ICurrentUserService.cs`
@@ -202,20 +204,20 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 
 ---
 
-## 8) Standart API response yapisi
-**Story:** Backend Chapter Lead olarak, API'den donen tum yanitlarin, tahmin edilebilir ve standart bir JSON yapisinda olmasini isterim.
+## 8) Standart API response yapısı
+**Story:** Backend Chapter Lead olarak, API'den dönen tüm yanıtların, tahmin edilebilir ve standart bir JSON yapısında olmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
-### Alt Isler
-- `✅` Uygulama katmaninda `Result<T>` ve `Error` modellerini olustur (Kapsam: TDD Madde 1.1'e uygun PascalCase ve isSuccess, data, error yapısını taşıyan generic sarmalayıcı sınıfları uygulandı.)
-- `✅` Tanimli tek bir response contract'i belirle (success/error envelope) (Kapsam: JSON formatının PascalCase kalmasını sağlamak için JsonSerializerOptions güncellendi ve tüm sonuçların ortak BaseController üzerinden dönülmesi standartlaştırıldı.)
-- `✅` Tum controller endpointlerini bu contract ile hizala (Kapsam: CargosController ve HomeController sınıfları BaseController'dan türetildi ve HandleResult metoduyla Result<T> dönecek şekilde düzenlendi.)
-- `✅` ErrorType enum ekle ve BaseController'da HTTP status code mapping'i kur (Kapsam: `Error.cs` dosyasina `ErrorType` enum eklendi (None/Validation/Unauthorized/Forbidden/NotFound/Conflict/BusinessRule/RateLimit/Unexpected). `Error` record constructor'i `ErrorType Type` parametresi alacak sekilde guncellendi. `BaseController.HandleResult` metodu `result.Error.Type` switch expression ile hata tipine gore dogru HTTP status code donecek sekilde yeniden yazildi: Validation→400, Unauthorized→401, Forbidden→403, NotFound→404, Conflict→409, BusinessRule→422, RateLimit→429, Unexpected→500. Onceki sabit `BadRequest(result)` donusu kaldirildi. `CreateCargoUseCase` icindeki `new Error("ValidationError", message)` cagrisi yeni constructor imzasina uygun `new Error(ErrorType.Validation, "ValidationError", message)` olarak guncellendi. `GlobalExceptionMiddleware` de ayni sekilde `ErrorType.Unexpected` kullanacak sekilde duzeltildi.)
-- `⬜` Validation hatalarini da ayni response yapisina bagla
-- `✅` Swagger uzerinde response tiplerini standart goster (Kapsam: ProducesResponseType kullanılarak Swagger dökümantasyonunda API dönüş tipleri Result<T> olacak şekilde kapsüllendi.)
+### Alt İşler
+- `✅` Uygulama katmanında `Result<T>` ve `Error` modellerini oluştur (Kapsam: TDD Madde 1.1'e uygun PascalCase ve isSuccess, data, error yapısını taşıyan generic sarmalayıcı sınıfları uygulandı.)
+- `✅` Tanımlı tek bir response contract'i belirle (success/error envelope) (Kapsam: JSON formatının PascalCase kalmasını sağlamak için JsonSerializerOptions güncellendi ve tüm sonuçların ortak BaseController üzerinden dönülmesi standartlaştırıldı.)
+- `✅` Tüm controller endpointlerini bu contract ile hizala (Kapsam: CargosController ve HomeController sınıfları BaseController'dan türetildi ve HandleResult metoduyla Result<T> dönecek şekilde düzenlendi.)
+- `✅` ErrorType enum ekle ve BaseController'da HTTP status code mapping'i kur (Kapsam: `Error.cs` dosyasına `ErrorType` enum eklendi (None/Validation/Unauthorized/Forbidden/NotFound/Conflict/BusinessRule/RateLimit/Unexpected). `Error` record constructor'i `ErrorType Type` parametresi alacak şekilde güncellendi. `BaseController.HandleResult` metodu `result.Error.Type` switch expression ile hata tipine göre doğru HTTP status code dönecek şekilde yeniden yazıldı: Validation→400, Unauthorized→401, Forbidden→403, NotFound→404, Conflict→409, BusinessRule→422, RateLimit→429, Unexpected→500. Önceki sabit `BadRequest(result)` dönüşü kaldırıldı. `CreateCargoUseCase` içindeki `new Error("ValidationError", message)` çağrısı yeni constructor imzasına uygun `new Error(ErrorType.Validation, "ValidationError", message)` olarak güncellendi. `GlobalExceptionMiddleware` de aynı şekilde `ErrorType.Unexpected` kullanacak şekilde düzeltildi.)
+- `⬜` Validation hatalarını da aynı response yapısına bağla
+- `✅` Swagger üzerinde response tiplerini standart göster (Kapsam: ProducesResponseType kullanılarak Swagger dokümantasyonunda API dönüş tipleri Result<T> olacak şekilde kapsüllendi.)
 
-**Kanitlar:**
+**Kanıtlar:**
 - `CargoPilot.Application/Common/Models/Result.cs`
 - `CargoPilot.Application/Common/Models/Error.cs`
 - `CargoPilot.WebAPI/Controllers/BaseController.cs`
@@ -226,36 +228,36 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 ---
 
 ## 9) Global Exception Handling
-**Story:** Backend Chapter Lead olarak, uygulama genelinde firlatilan tum beklenmedik hatalarin merkezi bir noktadan yakalanmasini (Global Exception Handling) isterim.
+**Story:** Backend Chapter Lead olarak, uygulama genelinde fırlatılan tüm beklenmedik hataların merkezi bir noktadan yakalanmasını (Global Exception Handling) isterim.
 
-**Genel Durum:** `🟡 Kismi / Devam ediyor`
+**Genel Durum:** `🟡 Kısmi / Devam ediyor`
 
-### Alt Isler
-- `✅` Global exception middleware veya `UseExceptionHandler` ekle (Kapsam: `IMiddleware` arayuzunu uygulayan `GlobalExceptionMiddleware` olusturuldu ve `DependencyInjection.cs` uzerinden kaydedildi.)
-- `✅` Exception-to-response map stratejisi belirle (Kapsam: Mimari dokumanlarda belirtildigi gibi hatalarin `Result<T>` formatina map edilmesi kararlastirildi.)
-- `✅` Beklenmeyen hatalarda standart error response don (Kapsam: Beklenmeyen hatalarin (`Exception`) 500 status code ile standart JSON (`IsSuccess: false`, `Error` iceren) zarfina donusturulerek donulmesi saglandi.)
-- `🟡` Correlation id ve loglama baglantisini kur (Kapsam: `[LoggerMessage]` source generator ile yuksek performansli loglama kuruldu (CA1848 ihlali onlendi). Eksik: `context.TraceIdentifier` henuz log mesajina ve response zarfina eklenmedi; correlation ID takibi tamamlanmamis.)
-- `⬜` Exception handling icin unit/integration test ekle
+### Alt İşler
+- `✅` Global exception middleware veya `UseExceptionHandler` ekle (Kapsam: `IMiddleware` arayüzünü uygulayan `GlobalExceptionMiddleware` oluşturuldu ve `DependencyInjection.cs` üzerinden kaydedildi.)
+- `✅` Exception-to-response map stratejisi belirle (Kapsam: Mimarı dokümanlarda belirtildiği gibi hataların `Result<T>` formatına map edilmesi kararlaştırıldı.)
+- `✅` Beklenmeyen hatalarda standart error response dön (Kapsam: Beklenmeyen hataların (`Exception`) 500 status code ile standart JSON (`IsSuccess: false`, `Error` içeren) zarfına dönüştürülerek dönülmesi sağlandı.)
+- `🟡` Correlation id ve loglama bağlantısını kur (Kapsam: `[LoggerMessage]` source generator ile yüksek performanslı loglama kuruldu (CA1848 ihlali önlendi). Eksik: `context.TraceIdentifier` henüz log mesajına ve response zarfına eklenmedi; correlation ID takibi tamamlanmamış.)
+- `⬜` Exception handling için unit/integration test ekle
 
-**Kanitlar:**
+**Kanıtlar:**
 - `CargoPilot.WebAPI/Middlewares/GlobalExceptionMiddleware.cs`
 - `CargoPilot.WebAPI/DependencyInjection.cs`
 
 ---
 
-## 10) Swagger dokumantasyonu
-**Story:** Backend Chapter Lead olarak 3D ve Platform squad'larinin gelistirme yapabilmesi icin API uc noktalarini Swagger ile dokumante edilmesini isterim.
+## 10) Swagger dokümantasyonu
+**Story:** Backend Chapter Lead olarak 3D ve Platform squad'larının geliştirme yapabilmesi için API uç noktalarını Swagger ile dokümante edilmesini isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
-### Alt Isler
+### Alt İşler
 - `✅` Swagger servislerini ekle (`AddEndpointsApiExplorer`, `AddSwaggerGen`)
 - `✅` Swagger middleware kur (`UseSwagger`, `UseSwaggerUI`)
-- `✅` Swagger gorunurlugunu ortamlara gore netlestir (sadece development disi gereksinim) (Kapsam: `DependencyInjection.cs` icerisinde `app.Environment.IsDevelopment()` kontrolu `!app.Environment.IsProduction()` olarak degistirildi. Boylece Swagger; Development ve Staging ortamlarinda gorunur duruma, yalnizca guvenlik amaciyla Production ortaminda erisime kapali hale getirildi.)
-- `✅` Endpoint summary/description/response kod dokumantasyonlarini tamamla (Kapsam: XML dokumantasyon uretimi icin `CargoPilot.WebAPI.csproj` dosyasina `<GenerateDocumentationFile>true</GenerateDocumentationFile>` eklendi. Gerekli olmayan `<NoWarn>1591</NoWarn>` public property yorum uyarilari sessize alindi. Projedeki `Assembly.GetExecutingAssembly().GetName().Name + ".xml"` yolu yakalanarak `SwaggerGen` `IncludeXmlComments` metoduyla baglandi. Sonrasinda `CargosController` ve `HomeController` endpoint'lerine `/// <summary>`, `/// <response>` xml dökümanları ve `[ProducesResponseType]` attribute'ları girildi. 200/400 donus modelleri (`CreateCargoResponse`, `WelcomeResponse` vs.) Swagger'a acildi. Controller isim karmasasini onlemek icin `[Tags("Cargos")]` seklinde grouping etiketleri kullanildi.)
-- `✅` Auth kullaniliyorsa Swagger auth ayarlarini ekle (Kapsam: Henuz projenin JWT akislari kurulmamis olsa da, gelecekte iskelet teskil etmesi adina Swagger tarafinda JWT token butonunu cikaracak ayarlar eklendi. `Options.AddSecurityDefinition` ve `AddSecurityRequirement` konfigleri Swashbuckle v10 standardina gore yapilandirildi. Auth story implement edildiginde Swagger uzerinden 'Authorize' tusuyla test edilebilecek hale getirildi.)
+- `✅` Swagger görünürlüğünü ortamlara göre netleştir (sadece development dışı gereksinim) (Kapsam: `DependencyInjection.cs` içerisinde `app.Environment.IsDevelopment()` kontrolü `!app.Environment.IsProduction()` olarak değiştirildi. Böylece Swagger; Development ve Staging ortamlarında görünür duruma, yalnızca güvenlik amacıyla Production ortamında erişime kapalı hale getirildi.)
+- `✅` Endpoint summary/description/response kod dokümantasyonlarını tamamla (Kapsam: XML dokümantasyon üretimi için `CargoPilot.WebAPI.csproj` dosyasına `<GenerateDocumentationFile>true</GenerateDocumentationFile>` eklendi. Gerekli olmayan `<NoWarn>1591</NoWarn>` public property yorum uyarıları sessize alındı. Projedeki `Assembly.GetExecutingAssembly().GetName().Name + ".xml"` yolu yakalanarak `SwaggerGen` `IncludeXmlComments` metoduyla bağlandı. Sonrasında `CargosController` ve `HomeController` endpoint'lerine `/// <summary>`, `/// <response>` xml dokümanları ve `[ProducesResponseType]` attribute'ları girildi. 200/400 dönüş modelleri (`CreateCargoResponse`, `WelcomeResponse` vs.) Swagger'a açıldı. Controller isim karmaşasını önlemek için `[Tags("Cargos")]` şeklinde grouping etiketleri kullanıldı.)
+- `✅` Auth kullanılıyorsa Swagger auth ayarlarını ekle (Kapsam: Henüz projenin JWT akışları kurulmamış olsa da, gelecekte iskelet teşkil etmesi adına Swagger tarafında JWT token butonunu çıkaracak ayarlar eklendi. `Options.AddSecurityDefinition` ve `AddSecurityRequirement` konfigleri Swashbuckle v10 standardına göre yapılandırıldı. Auth story implement edildiğinde Swagger üzerinden 'Authorize' tuşuyla test edilebilecek hale getirildi.)
 
-**Kanitlar:**
+**Kanıtlar:**
 - `CargoPilot.WebAPI/Program.cs`
 - `CargoPilot.WebAPI/CargoPilot.WebAPI.csproj`
 - `CargoPilot.WebAPI/DependencyInjection.cs`
@@ -265,19 +267,19 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 ---
 
 ## 11) US-AUTH-09: Refresh Token Endpoint (Token Rotation)
-**Story:** Backend Chapter Lead olarak, oturumun guvenli bir sekilde yenilenmesi icin POST /api/v1/auth/refresh endpoint'inin eklenmesini, refresh token'larin DB'de saklanmasini ve rotation + revoke kontrollerinin uygulanmasini isterim.
+**Story:** Backend Chapter Lead olarak, oturumun güvenli bir şekilde yenilenmesi için POST /api/v1/auth/refresh endpoint'inin eklenmesini, refresh token'ların DB'de saklanmasını ve rotation + revoke kontrollerinin uygulanmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
-### Alt Isler
-- `✅` Refresh Token'in HttpOnly Cookie ile dondurulmesi (Kapsam: Login endpoint'i refresh token'i artik response body'ye degil, `HttpOnly=true, Secure=true, SameSite=None` Cookie olarak yazar. Bu sayede JS ortami token'a erisemez.)
-- `✅` `POST /api/v1/auth/refresh` endpoint'inin eklenmesi (Kapsam: `AuthController`'a `[HttpPost("refresh")]` eklendi. Cookie'den token okunur, eksikse 401 doner.)
-- `✅` `RefreshTokenAsync` servisi ile Token Rotation mekanizmasinin implementasyonu (Kapsam: `IAuthService` ve `AuthService`'e `RefreshTokenAsync` eklendi. Eski session `Revoke()` ile iptal edilir, yeni access+refresh token cifti uretilip yeni `UserSession` DB'ye yazilir.)
-- `✅` `UserSession.Revoke()` domain metodu eklenmesi (Kapsam: Encapsulation kurali geregi `IsRevoked` sadece `Revoke()` metodu uzerinden `true` yapilabilir.)
-- `✅` `AuthErrors.InvalidToken` hata taniminin eklenmesi (Kapsam: Suresi dolmus, iptal edilmis veya bulunamayan token'lar icin standart hata kodu: `AUTH_INVALID_TOKEN`.)
-- `✅` `RefreshResponse` ve `LoginResponse` DTO'larinda guvenlik sikilasmasi (Kapsam: `RefreshToken` ve `RefreshTokenExpiresAt` alanlarina `[JsonIgnore]` eklendi; bu alanlar JSON body'ye yazilmaz, yalnizca controller'in cookie set etmesi icin DTO icerisinde tasinir.)
+### Alt İşler
+- `✅` Refresh Token'in HttpOnly Cookie ile döndürülmesi (Kapsam: Login endpoint'i refresh token'i artık response body'ye değil, `HttpOnly=true, Secure=true, SameSite=None` Cookie olarak yazar. Bu sayede JS ortamı token'a erişemez.)
+- `✅` `POST /api/v1/auth/refresh` endpoint'inin eklenmesi (Kapsam: `AuthController`'a `[HttpPost("refresh")]` eklendi. Cookie'den token okunur, eksikse 401 döner.)
+- `✅` `RefreshTokenAsync` servisi ile Token Rotation mekanizmasının implementasyonu (Kapsam: `IAuthService` ve `AuthService`'e `RefreshTokenAsync` eklendi. Eski session `Revoke()` ile iptal edilir, yeni access+refresh token çifti üretilip yeni `UserSession` DB'ye yazılır.)
+- `✅` `UserSession.Revoke()` domain metodu eklenmesi (Kapsam: Encapsulation kuralı gereği `IsRevoked` sadece `Revoke()` metodu üzerinden `true` yapılabilir.)
+- `✅` `AuthErrors.InvalidToken` hata tanımının eklenmesi (Kapsam: Süresi dolmuş, iptal edilmiş veya bulunamayan token'lar için standart hata kodu: `AUTH_INVALID_TOKEN`.)
+- `✅` `RefreshResponse` ve `LoginResponse` DTO'larinda güvenlik sıkılaşması (Kapsam: `RefreshToken` ve `RefreshTokenExpiresAt` alanlarına `[JsonIgnore]` eklendi; bu alanlar JSON body'ye yazılmaz, yalnızca controller'in cookie set etmesi için DTO içerisinde taşınır.)
 
-**Kanitlar:**
+**Kanıtlar:**
 - `CargoPilot.Domain/Entities/UserSession.cs`
 - `CargoPilot.Application/Features/Auth/IAuthService.cs`
 - `CargoPilot.Application/Features/Auth/DTOs/RefreshResponse.cs`
@@ -290,7 +292,7 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 ## 12) US-DASH-04: Yükleme Planı Liste ve Detay Endpoint'leri
 **Story:** Dashboard geliştirici olarak, yükleme planlarını sayfalı/sıralı listeleyebilmek ve tek bir planı tüm detaylarıyla getirebilmek için backend endpoint'lerinin hazır olmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
 ### Alt İşler
 - `✅` `ILoadingPlanRepository` interface'ini tanımla (`CargoPilot.Application/Common/Interfaces/ILoadingPlanRepository.cs`)
@@ -311,28 +313,28 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 - `CargoPilot.Infrastructure/Persistence/Repositories/LoadingPlanRepository.cs`
 - `CargoPilot.Infrastructure/DependencyInjection.cs`
 - `CargoPilot.WebAPI/Controllers/PlansController.cs`
-## 13) US-AUTH-12: Yeni Cihaz Girisi Bildirimi
-**Story:** Backend Chapter Lead olarak, kullanicinin hesabina daha once giris yapilmamis bir cihazdan/tarayicidan erisim saglandiginda e-posta bildirimi gonderilmesini ve kullanicinin tek tikla tum oturumlarini sonlandirip sifre sifirlama akisina yonlendirilmesini isterim.
+## 13) US-AUTH-12: Yeni Cihaz Girişi Bildirimi
+**Story:** Backend Chapter Lead olarak, kullanıcının hesabına daha önce giriş yapılmamış bir cihazdan/tarayıcıdan erişim sağlandığında e-posta bildirimi gönderilmesini ve kullanıcının tek tıkla tüm oturumlarını sonlandırıp şifre sıfırlama akışına yönlendirilmesini isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
 ### Kabul Kriterleri
-- AC1: Kullanici bilinen bir cihazdan giris yaptiginda hicbir bildirim gonderilmez.
-- AC2: Kullanici yeni bir cihazdan (farkli User-Agent) giris yaptiginda uyari e-postasi gonderilir; e-posta cihaz ozetini ve UTC giris zamanini icerir.
-- AC3: E-postadaki "Hesabimi Guvenlige Al" linki tiklandiginda tum aktif oturumlar iptal edilir ve kullanici sifre sifirlama sayfasina yonlendirilir.
-- AC4: Yeni cihaz tespiti OAuth (Google) girisleri icin de calisir.
+- AC1: Kullanıcı bilinen bir cihazdan giriş yaptığında hiçbir bildirim gönderilmez.
+- AC2: Kullanıcı yeni bir cihazdan (farklı User-Agent) giriş yaptığında uyarı e-postası gönderilir; e-posta cihaz özetini ve UTC giriş zamanını içerir.
+- AC3: E-postadaki "Hesabımı Güvenliğe Al" linki tıklandığında tüm aktif oturumlar iptal edilir ve kullanıcı şifre sıfırlama sayfasına yönlendirilir.
+- AC4: Yeni cihaz tespiti OAuth (Google) girişleri için de çalışır.
 
-### Alt Isler
-- `✅` `UserSession` entity'sine `DeviceSummary` kolonu ekle (Kapsam: `UserSession.cs` guncellendi; `DeviceSummary` nullable `nvarchar(500)` alani eklendi. `UserSessionConfiguration.cs` icinde EF kolon kisitlari tanimlandi. `20260501170422_AddDeviceSummaryToUserSession` migration'i uretildi.)
-- `✅` Login akisinda yeni cihaz tespiti yap (Kapsam: `AuthService.IssueTokensAsync` metodu guncellendi; User-Agent header'i `DeviceSummary` olarak kaydedilir. `UserSessions` tablosunda ayni `UserId + DeviceSummary` cifti yoksa `isNewDevice = true` set edilir.)
-- `✅` Yeni cihaz tespitinde uyari e-postasi gonder (Kapsam: `IEmailService` arabirimine `SendNewDeviceWarningEmailAsync` eklendi. `ResendEmailService` HTML + plain-text sablonlu implementasyonu yazildi. E-posta: cihaz/tarayici bilgisi, UTC tarih/saat ve "Hesabimi Guvenlige Al" butonu icerir.)
-- `✅` `GET /api/v1/auth/secure-account` endpoint'ini ekle (Kapsam: `IAuthService` ve `AuthService`'e `SecureAccountAsync` eklendi. Endpoint token'i dogrular, tum aktif oturumlarini iptal eder, yeni bir sifre sifirlama token'i uretir ve frontend sifre sifirlama sayfasina 302 yonlendirir.)
-- `✅` E-postadaki link icin guvenli token uret (Kapsam: `RandomNumberGenerator.GetBytes(32)` ile ham token uretilir; `WebEncoders.Base64UrlEncode` ile URL-safe string'e donusturulur; `SHA256(rawBytes)` ile hash hesaplanip DB'ye kaydedilir. Tuketimde `WebEncoders.Base64UrlDecode` ile ham byte'lara donulur ve hash yeniden hesaplanarak eslestirilir. Bu yaklasim string tabanli encoding farkindan kaynaklanan hash uyumsuzluklarini ortadan kaldirir.)
-- `✅` `OAuthLoginCommand` ve `OAuthLoginCommandHandler`'a `ipAddress` ve `userAgent` parametreleri ekle (Kapsam: OAuth girislerinde de cihaz tespiti ve bildirim akisi calissin diye guncellendi.)
-- `✅` `PasswordResetSettings`'e `BackendBaseUrl` alani ekle (Kapsam: `secure-account` linki uretiminde backend URL'i konfigurasyon uzerinden okunur; `appsettings.json` ve `appsettings.Development.json` guncellendi.)
-- `✅` `Microsoft.AspNetCore.WebUtilities` paketini `Infrastructure` projesine ekle (Kapsam: `WebEncoders` sinifindan faydalanmak icin `CargoPilot.Infrastructure.csproj` guncellendi.)
+### Alt İşler
+- `✅` `UserSession` entity'sine `DeviceSummary` kolonu ekle (Kapsam: `UserSession.cs` güncellendi; `DeviceSummary` nullable `nvarchar(500)` alanı eklendi. `UserSessionConfiguration.cs` içinde EF kolon kısıtları tanımlandı. `20260501170422_AddDeviceSummaryToUserSession` migration'i üretildi.)
+- `✅` Login akışında yeni cihaz tespiti yap (Kapsam: `AuthService.IssueTokensAsync` metodu güncellendi; User-Agent header'i `DeviceSummary` olarak kaydedilir. `UserSessions` tablosunda aynı `UserId + DeviceSummary` çifti yoksa `isNewDevice = true` set edilir.)
+- `✅` Yeni cihaz tespitinde uyarı e-postası gönder (Kapsam: `IEmailService` arabirimine `SendNewDeviceWarningEmailAsync` eklendi. `ResendEmailService` HTML + plain-text şablonlu implementasyonu yazıldı. E-posta: cihaz/tarayıcı bilgisi, UTC tarih/saat ve "Hesabımı Güvenliğe Al" butonu içerir.)
+- `✅` `GET /api/v1/auth/secure-account` endpoint'ini ekle (Kapsam: `IAuthService` ve `AuthService`'e `SecureAccountAsync` eklendi. Endpoint token'i doğrular, tüm aktif oturumlarını iptal eder, yeni bir şifre sıfırlama token'i üretir ve frontend şifre sıfırlama sayfasına 302 yönlendirir.)
+- `✅` E-postadaki link için güvenli token üret (Kapsam: `RandomNumberGenerator.GetBytes(32)` ile ham token üretilir; `WebEncoders.Base64UrlEncode` ile URL-safe string'e dönüştürülür; `SHA256(rawBytes)` ile hash hesaplanıp DB'ye kaydedilir. Tüketimde `WebEncoders.Base64UrlDecode` ile ham byte'lara dönülür ve hash yeniden hesaplanarak eşleştirilir. Bu yaklaşım string tabanlı encoding farkından kaynaklanan hash uyumsuzluklarını ortadan kaldırır.)
+- `✅` `OAuthLoginCommand` ve `OAuthLoginCommandHandler`'a `ipAddress` ve `userAgent` parametreleri ekle (Kapsam: OAuth girişlerinde de cihaz tespiti ve bildirim akışı çalışsın diye güncellendi.)
+- `✅` `PasswordResetSettings`'e `BackendBaseUrl` alanı ekle (Kapsam: `secure-account` linki üretiminde backend URL'i konfigürasyon üzerinden okunur; `appsettings.json` ve `appsettings.Development.json` güncellendi.)
+- `✅` `Microsoft.AspNetCore.WebUtilities` paketini `Infrastructure` projesine ekle (Kapsam: `WebEncoders` sınıfından faydalanmak için `CargoPilot.Infrastructure.csproj` güncellendi.)
 
-**Kanitlar:**
+**Kanıtlar:**
 - `CargoPilot.Domain/Entities/UserSession.cs`
 - `CargoPilot.Application/Abstractions/IEmailService.cs`
 - `CargoPilot.Application/Common/Settings/PasswordResetSettings.cs`
@@ -353,7 +355,7 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 ## 14) Loading Plan CRUD Endpoint'leri (Oluştur / İsim Güncelle / Sil)
 **Story:** Backend geliştirici olarak, yükleme planı oluşturabilmek, plan adını güncelleyebilmek ve planı soft-delete ile silebilmek için CRUD endpoint'lerinin hazır olmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
 ### Alt İşler
 - `✅` `IOptimizationEngine` interface'ini tanımla (`CargoPilot.Application/Common/Interfaces/IOptimizationEngine.cs`)
@@ -391,7 +393,7 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 ## 15) US-REP-03: Yükleme Planı Rapor Listesi Endpoint'i
 **Story:** Rapor sayfası geliştirici olarak, geçmiş yükleme planı raporlarını filtreli ve sayfalı listeleyebilmek için backend endpoint'inin hazır olmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
 ### Kabul Kriterleri
 - AC1: Rapor listesi `CreatedAtUtc` desc sıralı döner; her satırda `planName`, `createdAt`, `vehiclePlate`, `fillRate`, `status`, `reportId`, `downloadUrl` alanları bulunur.
@@ -440,7 +442,7 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 ## 16) Auth Company Scope — ICurrentUserService Genişletme + CRUD İzolasyonu (PR1)
 **Story:** Backend geliştirici olarak, tüm CRUD endpoint'lerinin (Items, Vehicles, LoadingPlans) yalnızca token sahibi kullanıcının şirketine ait verileri döndürmesi ve oluşturması için company-scope izolasyonunun uygulanmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
 **Branch:** `feature/auth-company-scope`
 
@@ -485,7 +487,7 @@ Bagimli branch: `feature/US-DB01-centralized-connection-string`. Runtime baglant
 ## 17) Auth Company Scope — Personal Company Otomatik Oluşturma + Role Policy Tanımları (PR2)
 **Story:** Backend geliştirici olarak, bireysel kayıt olan kullanıcıların JWT token'larında `company_id` claim'inin dolu gelmesi ve tüm company-scope endpoint'lere role tabanlı authorization uygulanması için gerekli altyapının kurulmasını isterim.
 
-**Genel Durum:** `✅ Tamamlandi`
+**Genel Durum:** `✅ Tamamlandı`
 
 **Branch:** `feature/auth-company-scope-pr2`
 

--- a/apps/frontend/.claude/CLAUDE.md
+++ b/apps/frontend/.claude/CLAUDE.md
@@ -1,13 +1,6 @@
 ---
-description:
+description: Cargo Pilot frontend geliştirme standartları — klasör yapısı, TypeScript, shadcn, state, form, 3D, RBAC ve export kuralları
 alwaysApply: true
----
-
----
-
-description:
-alwaysApply: true
-
 ---
 
 # Cargo Pilot — Frontend Geliştirme Standartları
@@ -21,15 +14,15 @@ alwaysApply: true
 
 | Katman           | Teknoloji                                                  |
 | ---------------- | ---------------------------------------------------------- |
-| Framework        | React 18 + Vite 5+                                         |
+| Framework        | React 18 + Vite 8+                                         |
 | Dil              | TypeScript 5+ — **strict mode zorunlu**                    |
 | Stil             | Tailwind CSS v3                                            |
 | UI Bileşen       | shadcn/ui + Radix UI primitives                            |
-| 3D               | Three.js r160+ · @react-three/fiber v8 · @react-three/drei |
-| Form             | react-hook-form v7+ + zod v3+                              |
-| Global State     | Zustand v4+                                                |
+| 3D               | Three.js r162+ · @react-three/fiber v8 · @react-three/drei |
+| Form             | react-hook-form v7+ + zod v4+                              |
+| Global State     | Zustand v5+                                                |
 | Server State     | TanStack Query v5+                                         |
-| Routing          | React Router v6+                                           |
+| Routing          | React Router v7+                                           |
 | Raporlama        | react-pdf                                                  |
 | Excel            | SheetJS / xlsx                                             |
 | Paket Yöneticisi | **npm** (pnpm/yarn kullanılmaz)                            |

--- a/apps/frontend/src/features/data-management/CLAUDE.md
+++ b/apps/frontend/src/features/data-management/CLAUDE.md
@@ -1,5 +1,5 @@
 ---
-description:
+description: Squad 1 veri yönetimi kuralları — ürün/araç form şemaları, bağımlı alanlar ve Figma referansları
 alwaysApply: true
 ---
 

--- a/apps/frontend/src/features/planning/scene/CLAUDE.md
+++ b/apps/frontend/src/features/planning/scene/CLAUDE.md
@@ -1,5 +1,5 @@
 ---
-description:
+description: Squad 2 3D sahne kuralları — scene-config, koordinat/BoxWrapper, InstancedMesh, animasyon ve bellek yönetimi
 alwaysApply: true
 ---
 

--- a/docs/archive/algoritma-tasarimi/bin-packing-uygulama-plani.md
+++ b/docs/archive/algoritma-tasarimi/bin-packing-uygulama-plani.md
@@ -1,20 +1,17 @@
 # 3D Bin Packing — Backend Geliştirme Faz Planı
 
-> **Durum: Tasarım arşivi — güncel implementasyonun birebir dokümantasyonu değildir.**
->
-> Bu doküman `feature/3D_Packing_Algorithm` branch'inde (2026-05-05) üretildi. Branch, `test`'teki
-> `CargoPilot.Infrastructure/Services/OptimizationEngine.cs` implementasyonu tarafından geride
-> bırakıldığı için kapatılmaktadır; tasarım içeriği kaybolmasın diye doküman buraya taşınmıştır.
->
-> Güncel kodla bilinen farklar:
-> - Koordinat ekseni adlandırması burada farklıdır. Güncel sözleşme: **X = genişlik, Y = yükseklik,
->   Z = derinlik**, origin kutunun **sol-alt-arka** köşesi (`apps/frontend/.claude/CLAUDE.md`,
->   `lib/config/scene-config.ts`).
-> - MediatR'a yapılan atıflar geçerli değildir; backend service-based yaklaşım kullanır
->   (`apps/backend/docs/architecture.md`).
-> - `Packing/` klasörü ve `PackingEngine` sınıfı `test` branch'inde bulunmamaktadır.
->
-> Algoritma çalışması yapılırken kavramsal referans olarak kullanılabilir; kod kaynağı olarak değil.
+**Son güncelleme:** 2026-08-04 · **Durum:** Arşiv
+
+{% hint style="warning" %}
+Tasarım arşivi — güncel implementasyonun birebir dokümantasyonu değildir. `feature/3D_Packing_Algorithm` branch'inde (2026-05-05) üretildi; `test` branch'teki `CargoPilot.Infrastructure/Services/OptimizationEngine.cs` tarafından geride bırakıldı.
+
+**Bilinen farklar:**
+- Koordinat ekseni adlandırması farklıdır. Güncel sözleşme: **X = genişlik, Y = yükseklik, Z = derinlik**, origin kutunun **sol-alt-arka** köşesi (`apps/frontend/.claude/CLAUDE.md`, `lib/config/scene-config.ts`).
+- MediatR atıfları hâlâ geçerlidir — güncel mimari: `apps/backend/docs/architecture.md`.
+- `Packing/` klasörü ve `PackingEngine` sınıfı `test` branch'inde bulunmamaktadır.
+
+Algoritma çalışması yapılırken kavramsal referans olarak kullanılabilir; kod kaynağı olarak değil.
+{% endhint %}
 
 ---
 

--- a/docs/archive/algoritma-tasarimi/matematiksel-model.md
+++ b/docs/archive/algoritma-tasarimi/matematiksel-model.md
@@ -1,20 +1,17 @@
 # 3D Bin Packing — Matematiksel Model
 
-> **Durum: Tasarım arşivi — güncel implementasyonun birebir dokümantasyonu değildir.**
->
-> Bu doküman `feature/3D_Packing_Algorithm` branch'inde (2026-05-05) üretildi. Branch, `test`'teki
-> `CargoPilot.Infrastructure/Services/OptimizationEngine.cs` implementasyonu tarafından geride
-> bırakıldığı için kapatılmaktadır; tasarım içeriği kaybolmasın diye doküman buraya taşınmıştır.
->
-> Güncel kodla bilinen farklar:
-> - Koordinat ekseni adlandırması burada farklıdır. Güncel sözleşme: **X = genişlik, Y = yükseklik,
->   Z = derinlik**, origin kutunun **sol-alt-arka** köşesi (`apps/frontend/.claude/CLAUDE.md`,
->   `lib/config/scene-config.ts`).
-> - MediatR'a yapılan atıflar geçerli değildir; backend service-based yaklaşım kullanır
->   (`apps/backend/docs/architecture.md`).
-> - `Packing/` klasörü ve `PackingEngine` sınıfı `test` branch'inde bulunmamaktadır.
->
-> Algoritma çalışması yapılırken kavramsal referans olarak kullanılabilir; kod kaynağı olarak değil.
+**Son güncelleme:** 2026-08-04 · **Durum:** Arşiv
+
+{% hint style="warning" %}
+Tasarım arşivi — güncel implementasyonun birebir dokümantasyonu değildir. `feature/3D_Packing_Algorithm` branch'inde (2026-05-05) üretildi; `test` branch'teki `CargoPilot.Infrastructure/Services/OptimizationEngine.cs` tarafından geride bırakıldı.
+
+**Bilinen farklar:**
+- Koordinat ekseni adlandırması farklıdır. Güncel sözleşme: **X = genişlik, Y = yükseklik, Z = derinlik**, origin kutunun **sol-alt-arka** köşesi (`apps/frontend/.claude/CLAUDE.md`, `lib/config/scene-config.ts`).
+- MediatR atıfları hâlâ geçerlidir — güncel mimari: `apps/backend/docs/architecture.md`.
+- `Packing/` klasörü ve `PackingEngine` sınıfı `test` branch'inde bulunmamaktadır.
+
+Algoritma çalışması yapılırken kavramsal referans olarak kullanılabilir; kod kaynağı olarak değil.
+{% endhint %}
 
 ---
 

--- a/docs/archive/algoritma-tasarimi/sistem-mimarisi.md
+++ b/docs/archive/algoritma-tasarimi/sistem-mimarisi.md
@@ -1,20 +1,17 @@
 # 3D Bin Packing — Sistem Mimarisi ve Gereksinim Dokümantasyonu
 
-> **Durum: Tasarım arşivi — güncel implementasyonun birebir dokümantasyonu değildir.**
->
-> Bu doküman `feature/3D_Packing_Algorithm` branch'inde (2026-05-05) üretildi. Branch, `test`'teki
-> `CargoPilot.Infrastructure/Services/OptimizationEngine.cs` implementasyonu tarafından geride
-> bırakıldığı için kapatılmaktadır; tasarım içeriği kaybolmasın diye doküman buraya taşınmıştır.
->
-> Güncel kodla bilinen farklar:
-> - Koordinat ekseni adlandırması burada farklıdır. Güncel sözleşme: **X = genişlik, Y = yükseklik,
->   Z = derinlik**, origin kutunun **sol-alt-arka** köşesi (`apps/frontend/.claude/CLAUDE.md`,
->   `lib/config/scene-config.ts`).
-> - MediatR'a yapılan atıflar geçerli değildir; backend service-based yaklaşım kullanır
->   (`apps/backend/docs/architecture.md`).
-> - `Packing/` klasörü ve `PackingEngine` sınıfı `test` branch'inde bulunmamaktadır.
->
-> Algoritma çalışması yapılırken kavramsal referans olarak kullanılabilir; kod kaynağı olarak değil.
+**Son güncelleme:** 2026-08-04 · **Durum:** Arşiv
+
+{% hint style="warning" %}
+Tasarım arşivi — güncel implementasyonun birebir dokümantasyonu değildir. `feature/3D_Packing_Algorithm` branch'inde (2026-05-05) üretildi; `test` branch'teki `CargoPilot.Infrastructure/Services/OptimizationEngine.cs` tarafından geride bırakıldı.
+
+**Bilinen farklar:**
+- Koordinat ekseni adlandırması farklıdır. Güncel sözleşme: **X = genişlik, Y = yükseklik, Z = derinlik**, origin kutunun **sol-alt-arka** köşesi (`apps/frontend/.claude/CLAUDE.md`, `lib/config/scene-config.ts`).
+- MediatR atıfları hâlâ geçerlidir — güncel mimari: `apps/backend/docs/architecture.md`.
+- `Packing/` klasörü ve `PackingEngine` sınıfı `test` branch'inde bulunmamaktadır.
+
+Algoritma çalışması yapılırken kavramsal referans olarak kullanılabilir; kod kaynağı olarak değil.
+{% endhint %}
 
 ---
 

--- a/docs/archive/audit-test-plani-2026-08.md
+++ b/docs/archive/audit-test-plani-2026-08.md
@@ -1,5 +1,11 @@
 # Cargo Pilot — Denetim Düzeltmeleri Test Planı
 
+**Son güncelleme:** 2026-08-02 · **Durum:** Arşiv
+
+{% hint style="warning" %}
+`chore/AUDIT-test-birlesik` dalının manuel QA planıydı; dal `test` branch'ine merge edildi (PR #914 / #916, 2026-08 başı). Tarihsel kayıt olarak arşivde saklanır.
+{% endhint %}
+
 **Test edilecek dal:** `chore/AUDIT-test-birlesik`
 **Karşılaştırma tabanı:** `dev`
 

--- a/docs/archive/branching-proposal-2026-08.md
+++ b/docs/archive/branching-proposal-2026-08.md
@@ -1,5 +1,7 @@
 # Branch Stratejisi Önerisi — 5 Kişilik Ekip
 
+**Son güncelleme:** 2026-08-03 · **Durum:** Arşiv
+
 **Tarih:** 2026-08-03 · **Durum:** ⛔ **Yürürlükte değil — aynı gün geri alındı**
 **Ekip:** DevOps · Backend · Algoritma · Frontend (4 rol / 5 kişi)
 
@@ -9,8 +11,8 @@
 > **Neden:** §7'de "bu öneriyi reddetmenin makul nedeni" olarak yazılan koşul gerçekte mevcuttu —
 > test ortamı müşteriye gösterilen yüzey ve ayrı bir QA adımı var. Dondurulabilir bir dal gerekiyor.
 >
-> Yürürlükteki kurallar: [`docs/conventions/BRANCHING.md`](../conventions/BRANCHING.md)
-> Karar geçmişi: [branch-audit.md](branch-audit.md) §8–§9
+> Yürürlükteki kurallar: [`docs/conventions/branching.md`](../conventions/branching.md)
+> Karar geçmişi: [branch-audit.md](../context/branch-audit.md) §8–§9
 >
 > §1'deki ölçümler (2 PR/iş, 10/30 kapatılmış PR) hâlâ geçerli ve yeni modelde
 > **terfi PR'ı** düzeniyle giderildi: iş branch'i yalnızca `dev`'e PR açar.
@@ -64,7 +66,7 @@ branch değil. Ortamlar branch'lerle değil, deploy hedefleriyle ayrılır.
 | `chore/` | Doküman, bağımlılık, temizlik | `chore/branch-temizligi` |
 | `infra/` | CI/CD, compose, monitoring (DevOps) | `infra/prod-deploy-pipeline` |
 
-İsimlendirme kuralları `BRANCHING.md`'den aynen korunur: küçük harf, Türkçe karakter yok, boşluk yok,
+İsimlendirme kuralları `branching.md`'den aynen korunur: küçük harf, Türkçe karakter yok, boşluk yok,
 iş kodu büyük harf.
 
 ### Sürüm
@@ -117,7 +119,7 @@ Koruma zaten **repository ruleset** ile yapılıyor (`main-protection`, `test-pr
 | Stale review dismissal | ✅ zaten açık | Değişiklik yok |
 
 **Squash neden:** `feature/lifo-kapi-zekasi-eklendi` branch'inde 12 commit'in 10'u prettier/TS düzeltmesi.
-`COMMITS.md`'nin "atomic commit + PR öncesi temizlik" hedefini squash otomatik olarak sağlıyor.
+`commits.md`'nin "atomic commit + PR öncesi temizlik" hedefini squash otomatik olarak sağlıyor.
 `main` geçmişi PR başına tek, okunabilir commit olur ve `git bisect` daha da iyi çalışır.
 
 ---
@@ -135,7 +137,7 @@ Koruma zaten **repository ruleset** ile yapılıyor (`main-protection`, `test-pr
 | 5 | Production pipeline'ı ekle | `v*` tag → prod image build + `production` environment ile deploy |
 | 6 | Branch temizliğini uygula | `branch-audit.md` §6 |
 | 7 | `test` ve `dev` branch'lerini arşivle | `git tag archive/test origin/test`, sonra branch'leri sil |
-| 8 | `BRANCHING.md`'yi yeni modelle yeniden yaz | `docs/conventions/BRANCHING.md` |
+| 8 | `branching.md`'yi yeni modelle yeniden yaz | `docs/conventions/branching.md` |
 | 9 | Ekibe 15 dk'lık aktarım | — |
 
 **Sıra önemli:** 4. adım (workflow'lar) 2. adımdan (default branch) önce yapılırsa deploy kırılır.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1,24 +1,30 @@
 # Proje Bağlam Kütüphanesi (context)
 
+**Son güncelleme:** 2026-08-08 · **Durum:** Aktif
+
 Bu klasör, repodaki tüm dokümanların **özetlenmiş halini** tutar. Amaç: bir soruya cevap
-vermek için 25 ayrı `.md` dosyasını baştan okumak zorunda kalmamak.
+vermek için 37 ayrı `.md` dosyasını baştan okumak zorunda kalmamak.
+
+---
 
 ## Kullanım Kuralı
 
 1. Önce `project-snapshot.md` okunur — teknik gerçekler, ortamlar, portlar, açık riskler.
 2. Detay gerekiyorsa `doc-map.md`'den **hangi dosyanın** okunacağı bulunur, sadece o dosya açılır.
 3. Branch / PR durumu için `branch-audit.md`.
-4. Branch stratejisi tartışması için `branching-proposal.md`.
+4. Tarihsel öneriler ve yürürlükten kalkmış planlar `docs/archive/` altındadır.
 
 ## İçindekiler
 
 | Dosya | İçerik | Ne zaman okunur |
 |-------|--------|-----------------|
 | [project-snapshot.md](project-snapshot.md) | Stack, ortamlar, portlar, CI/CD, açık riskler — tek sayfa | Her oturum başında |
-| [doc-map.md](doc-map.md) | Repodaki 25 `.md` dosyasının haritası + özeti | "Bu bilgi nerede yazıyor?" sorusunda |
+| [doc-map.md](doc-map.md) | Repodaki 37 `.md` dosyasının haritası + özeti | "Bu bilgi nerede yazıyor?" sorusunda |
 | [kod-taramasi-2026-08.md](kod-taramasi-2026-08.md) | 6 kategoride kod tabanı taraması: gerçek stack, algoritma analizi, doküman-kod çelişkileri, riskler | Kod gerçeği ile doküman iddiası çeliştiğinde; algoritma/test/devops durumu sorulduğunda |
 | [branch-audit.md](branch-audit.md) | 30 remote branch + açık PR analizi, temizlik kararları | Branch/PR temizliği yaparken |
-| [branching-proposal.md](branching-proposal.md) | 5 kişilik ekip için önerilen branch stratejisi | Strateji kararı alınırken |
+
+> Tarihsel öneriler (ör. trunk stratejisi önerisi) `docs/archive/` altında tutulur; bu tablo
+> yalnızca yürürlükteki bağlam dosyalarını listeler.
 
 ## Güncelleme Sorumluluğu
 
@@ -27,7 +33,7 @@ vermek için 25 ayrı `.md` dosyasını baştan okumak zorunda kalmamak.
 | Yeni `.md` eklendi / silindi | `doc-map.md` |
 | Ortam, port, servis, CI değişti | `project-snapshot.md` |
 | Branch temizliği yapıldı | `branch-audit.md` (karar sütunu → uygulandı) |
-| Branch stratejisi değişti | `branching-proposal.md` + `docs/conventions/BRANCHING.md` |
+| Branch stratejisi değişti | `docs/conventions/branching.md` (+ eski karar kaydı: `docs/archive/branching-proposal-2026-08.md`) |
 
 > Bu klasör kaynak değil, **indeks**tir. Çelişki durumunda orijinal doküman geçerlidir;
 > çelişki bulunursa bu klasör düzeltilir.

--- a/docs/context/branch-audit.md
+++ b/docs/context/branch-audit.md
@@ -1,5 +1,11 @@
 # Branch & PR Denetimi
 
+**Son güncelleme:** 2026-08-03 · **Durum:** Aktif
+
+30 remote branch ve açık PR'ların denetimi, temizlik kararları ve uygulanan üç dallı terfi modelinin kaydı.
+
+---
+
 **Tarih:** 2026-08-03 · **Referans:** `origin/test` @ `3c42f65a` (denetim anı)
 **Durum:** ✅ **Tamamlandı ve uygulandı.** Sonuç: **29 branch → 3** (`main`, `test`, `dev`),
 26 `archive/*` tag'i, açık PR yok. Ardından trunk geçişi yapıldı (§8), aynı gün üç dallı
@@ -120,9 +126,9 @@ Eksik: `main`'de required status check tanımlı değil — CI geçmeden merge e
 
 > ⚠️ **Silmeden önce kurtarılacak:** `feature/3D_Packing_Algorithm` branch'i şu üç dosyayı
 > içeriyor ve bunlar `test`'te yok:
-> `apps/backend/docs/matematiksel_model.md` (425 satır),
-> `apps/backend/docs/sistem_mimarisi.md` (330),
-> `apps/backend/docs/bin_packing_implementation_plan.md` (405).
+> `docs/archive/algoritma-tasarimi/matematiksel-model.md` (425 satır),
+> `docs/archive/algoritma-tasarimi/sistem-mimarisi.md` (330),
+> `docs/archive/algoritma-tasarimi/bin-packing-uygulama-plani.md` (405).
 > Toplam 1.160 satır algoritma tasarım dokümanı.
 > ✅ **Kurtarıldı:** PR #888 (`chore/algoritma-tasarim-dokumanlari`). Merge edildikten sonra
 > `feature/3D_Packing_Algorithm` güvenle silinebilir.
@@ -167,7 +173,7 @@ Her adım ayrı ve geri alınabilir tutulmalı.
 | 5 | §5'teki 4 branch için sahipleriyle karar | Yok | ⏳ Ekipte |
 | 6 | §4.3'teki 4 story'yi backlog'a yaz, sonra branch'leri sil | Düşük | ⏳ |
 | 7 | `delete_branch_on_merge` ayarını **açık** hale getir | Yok — birikmeyi kökten keser | ⏳ |
-| 8 | Branch stratejisi kararı → [branching-proposal.md](branching-proposal.md) | — | ⏳ |
+| 8 | Branch stratejisi kararı → [branching-proposal-2026-08.md](../archive/branching-proposal-2026-08.md) | — | ⏳ |
 
 > `dev`'de kurtarılacak iş bulunmadığı için (§3.1) ayrı bir taşıma adımı gerekmiyor.
 
@@ -206,7 +212,7 @@ Kurtarma kararı verilmeden silinen, `test`'te karşılığı olmayan işler —
 
 ## 8. Trunk Geçişi — 2026-08-03
 
-Temizlikten sonra [branching-proposal.md](branching-proposal.md) uygulandı.
+Temizlikten sonra [branching-proposal-2026-08.md](../archive/branching-proposal-2026-08.md) uygulandı.
 
 | Adım | Durum |
 |------|-------|
@@ -216,14 +222,14 @@ Temizlikten sonra [branching-proposal.md](branching-proposal.md) uygulandı.
 | Workflow tetikleyicileri `test`/`dev` → `main` | ✅ |
 | `enforce-test-base` job'u kaldırıldı | ✅ |
 | Sunucu deploy script'i `git checkout main` | ✅ |
-| `BRANCHING.md` trunk modeliyle yeniden yazıldı | ✅ |
+| `branching.md` trunk modeliyle yeniden yazıldı | ✅ |
 | Default branch → `main` | ✅ |
 | `main-protection`'a required status check eklendi | ✅ |
 | Production pipeline (`v*` tag) | ⛔ Yapılmadı — gerekçe aşağıda |
 
 ### Production pipeline neden yapılmadı
 
-`branching-proposal.md` §5 adım 5'te yer alıyor ama şu an inşa edilemez:
+`docs/archive/branching-proposal-2026-08.md` §5 adım 5'te yer alıyor ama şu an inşa edilemez:
 
 1. `PROD_SSH_HOST` / `PROD_SSH_PRIVATE_KEY` secret'ları tanımlı değil.
 2. Production stack sunucuda **hiç kurulmadı** — `.env.prod` yok (`known-issues.md` #2).
@@ -267,7 +273,7 @@ Yeni modelde iş branch'i **yalnızca `dev`'e** PR açar; `dev → test` ve `tes
 | `release-tag.yml` — `main`'e terfide `v0.<n>.0` | ✅ `v0.1.0` oluştu |
 | Ruleset'ler: dal bazında merge yöntemi + required check | ✅ |
 | Bypass modu `always` → `pull_request` (dev/test) | ✅ |
-| `BRANCHING.md` üç dallı modelle yeniden yazıldı | ✅ |
+| `branching.md` üç dallı modelle yeniden yazıldı | ✅ |
 | Production pipeline | ⛔ Hâlâ yok — §8'deki gerekçeler geçerli |
 
 PR zinciri: #898 (→dev) → #899 (→test) → #900 (→main) → #901/#902/#903 (etiket düzeltmesi).
@@ -299,4 +305,4 @@ Bu tablonun 26 iş branch'iyle oluşmasının üç nedeni var; hiçbiri kişi ka
 3. **Uzun ömürlü branch'ler** → 1000+ commit geride kalan branch rebase edilemiyor, kimse silmeye de
    cesaret edemiyor, süresiz duruyor.
 
-Üçünün de yapısal karşılığı [branching-proposal.md](branching-proposal.md)'de.
+Üçünün de yapısal karşılığı [branching-proposal-2026-08.md](../archive/branching-proposal-2026-08.md)'de.

--- a/docs/context/doc-map.md
+++ b/docs/context/doc-map.md
@@ -1,9 +1,22 @@
 # Doküman Haritası
 
+**Son güncelleme:** 2026-08-08 · **Durum:** Aktif
+
 Repodaki tüm `.md` dosyaları, ne içerdikleri ve hangi soruda açılacakları.
-**Toplam 25 dosya / ~4.600 satır.** Tarama: 2026-08-03.
-**Güncelleme 2026-08-04:** `iyilestirme-analizi-2026-08.md`, 3 algoritma tasarım arşivi ve
-`docs/context/kod-taramasi-2026-08.md` haritaya eklendi.
+
+---
+
+**Toplam 37 dosya / ~8.650 satır.** Son tarama: 2026-08-08.
+
+> **Revizyon 2026-08-08:** doküman yapısı yeniden kuruldu (kök sadeleşti, `docs/archive/`
+> açıldı, kebab-case adlandırma, standart şablon). Taşınanlar:
+> `PRODUCTION_DEPLOYMENT_INFO.md` → `docs/devops/deployment.md`,
+> `docs/conventions/{BRANCHING,COMMITS}.md` → `{branching,commits}.md`,
+> `docs/AUDIT-TEST-PLANI.md` → `docs/archive/audit-test-plani-2026-08.md`,
+> `docs/context/branching-proposal.md` → `docs/archive/branching-proposal-2026-08.md`,
+> 3 algoritma tasarım dokümanı `apps/backend/docs/` → `docs/archive/algoritma-tasarimi/`.
+> Yeni: kökte `CONTRIBUTING.md`. Tüm `docs` dokümanlarına standart şablon
+> (H1 → `**Son güncelleme:** … · **Durum:** …` → amaç cümlesi → `---`) uygulandı.
 
 ---
 
@@ -11,70 +24,91 @@ Repodaki tüm `.md` dosyaları, ne içerdikleri ve hangi soruda açılacakları.
 
 | Dosya | Satır | Özet | Şu soruda aç |
 |-------|------:|------|--------------|
-| `README.md` | 93 | Ürün tanıtımı, hızlı başlangıç (3 komut), stack tablosu, repo ağacı, ortam durumu | Projeye ilk bakış |
-| `SUMMARY.md` | 22 | GitBook içindekiler tablosu | Yeni doküman eklerken (buraya da satır eklenmeli) |
-| `PRODUCTION_DEPLOYMENT_INFO.md` | 159 | Test/prod servis adresleri, compose başlat-durdur komutları, sunucudaki env yolları, migration'ı SDK container'ı ile çalıştırma, CI/CD akış tablosu | Deploy / sunucu operasyonu |
-| `CLAUDE.md` | — | **Frontend** geliştirme kuralları (AI asistan talimatı). Kapsam, stack, sınırlar, veri kuralları, 3D invariant'ları, kalite kapıları | Frontend'e kod yazmadan önce |
+| `README.md` | 101 | Ürün tanıtımı, hızlı başlangıç (3 komut), stack tablosu, repo ağacı, ortam durumu, "Katkı Sağlama" bölümü | Projeye ilk bakış |
+| `CONTRIBUTING.md` | 61 | Katkı rehberi: kurulum, üç dallı branch modeli, commit kuralları, kod standartları, PR süreci (1 onay + CI kapıları + UI ekran görüntüsü), yeni doküman eklerken güncellenecek dosyalar | Repoya ilk katkıdan önce |
+| `SUMMARY.md` | 51 | GitBook içindekiler tablosu. Bölümler: Başlangıç, Geliştirme Kuralları, DevOps (8), Backend (7), Proje Bağlamı (5), Arşiv (5) | Yeni doküman eklerken (buraya da satır eklenmeli) |
+| `CLAUDE.md` | 248 | **Frontend** geliştirme kuralları (AI asistan talimatı). Kapsam, stack, sınırlar, veri kuralları, 3D invariant'ları, kalite kapıları; Git konusunda `docs/conventions/`e yönlendirir | Frontend'e kod yazmadan önce |
+
+## .github
+
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `pull_request_template.md` | 32 | Özet / user story / değişiklik tipi / test edildi mi / **Ekran Görüntüleri** / 5 maddelik kontrol listesi | PR açarken |
 
 ## docs/conventions
 
 | Dosya | Satır | Özet | Şu soruda aç |
 |-------|------:|------|--------------|
-| `BRANCHING.md` | 182 | **Mevcut** branch modeli: `test`'ten feature aç → PR `dev` → aynı branch'ten PR `test` → PR `main`. Branch isimlendirme (iş kodu zorunlu, büyük harf/Türkçe karakter/boşluk yasak), PR onay kuralları, branch-ortam ilişkisi, merge commit tercihi | Branch/PR açarken. **Değişiklik önerisi:** `../context/branching-proposal.md` |
-| `COMMITS.md` | 105 | Sade + açıklayıcı mesaj, atomic commit (1 değişiklik = 1 commit), Türkçe tercih, "fix/update/son" gibi mesajlar yasak, PR öncesi geçmiş temizliği | Commit atmadan önce |
+| `branching.md` | 274 | **Yürürlükteki** model: üç dallı terfi `dev` → `test` → `main` (2026-08-03'ten itibaren). İş branch'leri `dev`'den açılır, `test`'e yalnızca `dev`'den PR, `main`'e yalnızca `test`/`hotfix`'ten PR; branch türleri ve ≤3 gün ömür kuralı, doğrudan push yasağı (ruleset), PR onay kuralları | Branch/PR açarken. **Tarihsel öneri:** `../archive/branching-proposal-2026-08.md` |
+| `commits.md` | 107 | Sade + açıklayıcı mesaj, atomic commit (1 değişiklik = 1 commit), Türkçe tercih, "fix/update/son" gibi mesajlar yasak, PR öncesi geçmiş temizliği | Commit atmadan önce |
 
 ## docs/setup
 
 | Dosya | Satır | Özet | Şu soruda aç |
 |-------|------:|------|--------------|
-| `local-setup.md` | 273 | Ön koşullar, `.env.test` hazırlama, iki çalışma modu (tam Docker / Vite+Docker hibrit), migration & seed, default login, sık komutlar, 4 sık sorun çözümü | Yeni geliştirici onboarding |
+| `local-setup.md` | 275 | Ön koşullar, `.env.test` hazırlama, iki çalışma modu (tam Docker / Vite+Docker hibrit), migration & seed, default login, sık komutlar, 4 sık sorun çözümü | Yeni geliştirici onboarding |
 
 ## docs/devops
 
 | Dosya | Satır | Özet | Şu soruda aç |
 |-------|------:|------|--------------|
-| `server-requirements.md` | 97 | Sunucu donanımı (8 vCPU/16 GB/147 GB), bileşen bazlı CPU-RAM-disk gereksinimleri, ortam-port matrisi, aktif servis listesi | Kapasite planlama |
-| `server-access.md` | 239 | SSH erişimi ve yetkili key'ler, UFW port tablosu, fail2ban, nginx reverse proxy path'leri (`/api/`, `/media/`, `/`), ağ diyagramı, monitoring stack başlatma, DIVIZYON ERP DB restore, DB yedekleme cron'ları, GitHub Actions deploy key | Sunucuya bağlanma, ağ/proxy sorunu |
-| `secret-management.md` | 167 | "Repoya secret girmez" kuralı, env dosya tablosu, GHCR public durumu, backend local secret yöntemleri (User Secrets / Local JSON), GitHub Actions secret listesi, Google OAuth + Resend değişkenleri, ihlal prosedürü | Secret ekleme/döndürme |
-| `monitoring-setup.md` | 239 | Prometheus/Loki/Promtail/Grafana mimarisi, ilk kurulum, toplanan metrikler, 3 alert kuralı, sorun giderme (Loki log şişmesi dahil) | Alert/dashboard işleri |
-| `known-issues.md` | 160 | 8 açık sorun + çözülenler tablosu | **Her sprint başında.** Özeti: `project-snapshot.md` §5 |
-| `devops-backlog.md` | 237 | 11 maddelik öncelik matrisi + kategori bazlı detay (uyumsuzluklar, eksikler, güncellenecekler, GHCR, operasyonel). **Not:** 1.2-1.4 maddeleri PR #908 ile kapandı ama hâlâ "Açık" işaretli | DevOps planlaması |
-| `iyilestirme-analizi-2026-08.md` | ~900 | **51 bulguluk** kapsamlı devops analizi (2026-08-03): compose, CI/CD, güvenlik, monitoring, doküman tutarsızlıkları; bazı bulgular "doğrulanmadı" işaretli | DevOps iyileştirme planlarken — en güncel ve en detaylı kaynak |
+| `deployment.md` | 170 | Test/prod servis adresleri, compose başlat-durdur komutları, sunucudaki env yolları, migration'ı SDK container'ı ile çalıştırma, container operasyonları, CI/CD akış tablosu, **Production Durumu** (stack hiç deploy edilmedi, `v*` etiketi tüketilmiyor) | Deploy / sunucu operasyonu |
+| `server-requirements.md` | 99 | Sunucu donanımı (8 vCPU/16 GB/147 GB), bileşen bazlı CPU-RAM-disk gereksinimleri, ortam-port matrisi, aktif servis listesi | Kapasite planlama |
+| `server-access.md` | 241 | SSH erişimi ve yetkili key'ler, UFW port tablosu, fail2ban, nginx reverse proxy path'leri (`/api/`, `/media/`, `/`), ağ diyagramı, monitoring stack başlatma, DIVIZYON ERP DB restore, DB yedekleme cron'ları, GitHub Actions deploy key | Sunucuya bağlanma, ağ/proxy sorunu |
+| `secret-management.md` | 169 | "Repoya secret girmez" kuralı, env dosya tablosu, GHCR public durumu, backend local secret yöntemleri (User Secrets / Local JSON), GitHub Actions secret listesi, Google OAuth + Resend değişkenleri, ihlal prosedürü | Secret ekleme/döndürme |
+| `monitoring-setup.md` | 248 | Prometheus/Loki/Promtail/Grafana mimarisi, ilk kurulum, toplanan metrikler, alert kuralları, sorun giderme (Loki log şişmesi dahil) | Alert/dashboard işleri |
+| `known-issues.md` | 205 | 9 açık sorun (0–8; bayat GHCR kimliği, Resend domain, prod stack, SA parolası, Node 20, prod compose, `dev` gerileme riski, log rotation, image CVE'leri) + çözülenler tablosu | **Her sprint başında.** Özeti: `project-snapshot.md` §5 |
+| `devops-backlog.md` | 234 | 11 maddelik öncelik matrisi + kategori bazlı detay (uyumsuzluklar, eksikler, güncellenecekler, GHCR, operasyonel) | DevOps planlaması |
+| `iyilestirme-analizi-2026-08.md` | 850 | **51 bulguluk** kapsamlı devops analizi (2026-08-03): compose, CI/CD, güvenlik, monitoring, doküman tutarsızlıkları; bazı bulgular "doğrulanmadı" işaretli | DevOps iyileştirme planlarken — en güncel ve en detaylı kaynak |
+
+## docs/archive
+
+Yürürlükte olmayan, tarihsel kayıt niteliğindeki dokümanlar. Karar gerekçesi ararken açılır;
+güncel davranışın kaynağı değildir.
+
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `audit-test-plani-2026-08.md` | 502 | `chore/AUDIT-test-birlesik` dalının (AUDIT-01…07, 09, 10, 11) manuel QA test planı: otomatik kapılar (tsc, eslint, vitest, build, `dotnet build`), 26 rotanın duman testi, düzeltme bazlı senaryolar | AUDIT birleşik dalının kapsamını geriye dönük incelerken |
+| `branching-proposal-2026-08.md` | 173 | 5 kişilik ekip için önerilen trunk stratejisi. **Yürürlükte değil** — aynı gün geri alındı, üç dallı modele dönüldü | Strateji kararının gerekçesi sorulduğunda |
+| `algoritma-tasarimi/matematiksel-model.md` | 440 | **Tasarım arşivi** — bin packing matematiksel modeli (EP, dominance, maliyet fonksiyonu). Kod hem ileride hem geride. Fark listesi: `../kod-taramasi-2026-08.md` §4 | Algoritma tarihçesi |
+| `algoritma-tasarimi/sistem-mimarisi.md` | 345 | **Tasarım arşivi** — planlanan packing mimarisi; `PackingEngine` sınıfı hiç yazılmadı, gerçek motor `OptimizationEngine.cs` | Algoritma tarihçesi |
+| `algoritma-tasarimi/bin-packing-uygulama-plani.md` | 420 | **Tasarım arşivi** — uygulama faz planı; güncel implementasyonla birebir değil | Algoritma tarihçesi |
+
+## docs/context (bu klasör)
+
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `README.md` | 39 | Bağlam kütüphanesinin kullanım kuralı, içindekiler tablosu, güncelleme sorumluluğu matrisi | Bu klasöre ilk girişte |
+| `project-snapshot.md` | 169 | Stack, ortamlar, portlar, CI/CD, açık riskler, branch modeli, squad haritası — tek sayfa teknik anlık görüntü | **Her oturum başında** |
+| `doc-map.md` | bu dosya | Repodaki 37 `.md` dosyasının haritası + özeti + doküman sağlığı tablosu | "Bu bilgi nerede yazıyor?" |
+| `kod-taramasi-2026-08.md` | 96 | 6 kategoride kod tabanı taraması (frontend, backend, algoritma, devops, veritabanı, test/kalite): gerçek stack, algoritma analizi, doküman-kod çelişkileri, riskler | Kod gerçeği ile doküman iddiası çeliştiğinde |
+| `branch-audit.md` | 308 | 30 remote branch + açık PR analizi ve temizlik kararları. **Durum: uygulandı** — 29 branch → 3, 26 `archive/*` tag'i; §9 yürürlükteki üç dallı modeli anlatır | Branch/PR temizliği yaparken |
 
 ## infra
 
-| Dosya | Satır | Özet |
-|-------|------:|------|
-| `infra/env/README.md` | 144 | `.env.*.example` → `.env.*` kopyalama akışı, değişken referansı (genel/DB/MinIO/güvenlik/OAuth/monitoring), güvenlik kuralları, ortam farkları, sunucuda kurulum |
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `infra/env/README.md` | 146 | `.env.*.example` → `.env.*` kopyalama akışı, değişken referansı (genel/DB/MinIO/güvenlik/OAuth/monitoring), güvenlik kuralları, ortam farkları, sunucuda kurulum | Env dosyası hazırlarken |
 
 ## apps/backend/docs
 
 | Dosya | Satır | Özet | Şu soruda aç |
 |-------|------:|------|--------------|
-| `architecture.md` | 188 | Clean Architecture 4 katman + referans yönü, katman içerikleri, **kararlar:** service-based (MediatR yok), aggregate-specific repository, FluentValidation, `Result<T>`, composition root, dev'de InMemory repo. Yeni use-case 8 adımı. Scope dışı: CQRS, domain event, Scrutor, generic repository | Backend'e yeni özellik eklemeden önce |
-| `developer-setup.md` | 74 | Visual Studio workload'ları, `global.json` ile SDK pinleme, doğrulama komutları, CI SDK sabitleme | Backend ortam kurulumu |
-| `environment-variables.md` | 163 | `Section__SubSection__Key` naming standardı ve neden `__`, yapılandırma öncelik sırası, ortam bazlı secret kaynakları, User Secrets kurulumu, prod bağlantı akışı, secret policy, zorunlu/opsiyonel değişken tablosu | Env var eklerken |
-| `database-migrations.md` | 235 | `dotnet-ef` kurulumu, connection string kaynakları, migration üretme/uygulama/geri alma, isimlendirme, ortam bazlı akış, SQL script üretme, 6 yaygın hata | Migration işleri |
-| `user-story-tracker.md` | 528 | 17 story'nin alt iş bazında durum takibi (✅/🟡/⬜) + kanıt dosya listesi. Açık kalanlar: Story 8 "validation hatalarını envelope'a bağla", Story 9 correlation id + exception testleri | Backend ilerleme durumu |
-| `erp-integration/data-model.md` | 53 | `Integration`, `SyncLog`, `ErpUserMapping` entity'leri + `Item`/`Vehicle`'a eklenecek alanlar | ERP entegrasyonu |
-| `erp-integration/erp-schema-divizyon.md` | 455 | Müşteri ERP şeması: `TBLSTSABIT` (stok, 134 kolon), `TBLSIPAMAS` (sipariş başlığı, 106), `TBLSIPATRA` (satırlar, 97), boyut birimi notu, sync ve delta-sync sorguları | ERP alan eşlemesi |
-| `matematiksel_model.md` | 443 | **Tasarım arşivi** — bin packing matematiksel modeli (EP, dominance, maliyet fonksiyonu). Kod hem ileride hem geride; arşiv notundaki "MediatR kullanılmaz" cümlesi hatalı. Fark listesi: `docs/context/kod-taramasi-2026-08.md` §4 | Algoritma tarihçesi |
-| `sistem_mimarisi.md` | 348 | **Tasarım arşivi** — planlanan packing mimarisi; `PackingEngine` sınıfı hiç yazılmadı, gerçek motor `OptimizationEngine.cs` | Algoritma tarihçesi |
-| `bin_packing_implementation_plan.md` | 423 | **Tasarım arşivi** — uygulama planı; güncel implementasyonla birebir değil | Algoritma tarihçesi |
+| `architecture.md` | 203 | Clean Architecture 4 katman + referans yönü, katman içerikleri, **kararlar:** MediatR Command/Query/Handler (2026-08-04'te kod gerçeğine göre düzeltildi), aggregate-specific repository, FluentValidation, `Result<T>`, composition root. Yeni use-case 8 adımı | Backend'e yeni özellik eklemeden önce |
+| `developer-setup.md` | 78 | Visual Studio workload'ları, `global.json` ile SDK pinleme, doğrulama komutları, CI SDK sabitleme | Backend ortam kurulumu |
+| `environment-variables.md` | 165 | `Section__SubSection__Key` naming standardı ve neden `__`, yapılandırma öncelik sırası, ortam bazlı secret kaynakları, User Secrets kurulumu, prod bağlantı akışı, secret policy, zorunlu/opsiyonel değişken tablosu | Env var eklerken |
+| `database-migrations.md` | 237 | `dotnet-ef` kurulumu, connection string kaynakları, migration üretme/uygulama/geri alma, isimlendirme, ortam bazlı akış, SQL script üretme, 6 yaygın hata | Migration işleri |
+| `user-story-tracker.md` | 530 | 17 story'nin alt iş bazında durum takibi (✅/🟡/⬜) + kanıt dosya listesi. Açık kalanlar: Story 8 "validation hatalarını envelope'a bağla", Story 9 correlation id + exception testleri | Backend ilerleme durumu |
+| `erp-integration/data-model.md` | 59 | `Integration`, `SyncLog`, `ErpUserMapping` entity'leri + `Item`/`Vehicle`'a eklenecek alanlar | ERP entegrasyonu |
+| `erp-integration/erp-schema-divizyon.md` | 459 | Müşteri ERP şeması: `TBLSTSABIT` (stok, 134 kolon), `TBLSIPAMAS` (sipariş başlığı, 106), `TBLSIPATRA` (satırlar, 97), boyut birimi notu, sync ve delta-sync sorguları | ERP alan eşlemesi |
 
 ## apps/frontend (AI asistan kuralları)
 
-| Dosya | Satır | Özet |
-|-------|------:|------|
-| `.claude/CLAUDE.md` | 588 | **Frontend standartlarının ana kaynağı.** Klasör yapısı, isimlendirme, TS kuralları (enum yerine `as const`), shadcn kuralları, tasarım token'ları, Zustand slice tablosu, TanStack Query kuralları, form + bağımlı alan tuzağı, 3D standartları (koordinat, `BoxWrapper`, Canvas, `InstancedMesh`, dispose, raycasting, katman), routing/RBAC/JWT, abonelik kilit modal pattern'i, PDF/Excel export, `/share/:token` kuralları |
-| `src/features/data-management/schemas/CLAUDE.md` | 49 | Squad 1 — form şeması, bağımlı alan (fragility ≥ 1 → Z rotasyon kilidi), Figma referansı |
-| `src/features/planning/components/CLAUDE.md` | 141 | Squad 2 — `scene-config.ts`, koordinat & `BoxWrapper`, Canvas, `InstancedMesh` + raycaster, animasyon state machine, `useFrame` kuralları, violation, memory & snapshot |
-
-## .github
-
-| Dosya | Özet |
-|-------|------|
-| `pull_request_template.md` | Özet / user story / değişiklik tipi / test edildi mi / 5 maddelik kontrol listesi. **Not:** ekran görüntüsü alanı yok, CLAUDE.md UI değişikliklerinde görsel istiyor — şablona eklenmesi öneri |
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `.claude/CLAUDE.md` | 598 | **Frontend standartlarının ana kaynağı.** Klasör yapısı, isimlendirme, TS kuralları (enum yerine `as const`), shadcn kuralları, tasarım token'ları, Zustand slice tablosu, TanStack Query kuralları, form + bağımlı alan tuzağı, 3D standartları (koordinat, `BoxWrapper`, Canvas, `InstancedMesh`, dispose, raycasting, katman), routing/RBAC/JWT, abonelik kilit modal pattern'i, PDF/Excel export, `/share/:token` kuralları | Frontend'de herhangi bir dosyaya dokunmadan önce |
+| `src/features/data-management/CLAUDE.md` | 49 | Squad 1 — form şeması, bağımlı alan (fragility ≥ 1 → Z rotasyon kilidi), Figma referansı | Ürün/araç/import ekranlarında |
+| `src/features/planning/scene/CLAUDE.md` | 141 | Squad 2 — `scene-config.ts`, koordinat & `BoxWrapper`, Canvas, `InstancedMesh` + raycaster, animasyon state machine, `useFrame` kuralları, violation, memory & snapshot | 3D sahnede çalışırken |
 
 ---
 
@@ -82,8 +116,8 @@ Repodaki tüm `.md` dosyaları, ne içerdikleri ve hangi soruda açılacakları.
 
 | Bulgu | Etki |
 |-------|------|
-| `SUMMARY.md` (GitBook ToC) backend ve ERP dokümanlarını hiç listelemiyor | Backend dokümanları GitBook'ta görünmüyor |
-| `main` ve production akışını anlatan doküman yok; `BRANCHING.md` "Production pipeline henüz yok" diyor | Prod release süreci yazılı değil |
-| `docs/conventions/BRANCHING.md` iki entegrasyon dalı tarif ediyor, `known-issues.md` #6 bu modelin ayrışma ürettiğini kayıt altına almış | Doküman kendi içinde çelişkiyi kabul ediyor, çözüm yazılı değil |
-| ~~Algoritma tasarım dokümanları sadece `feature/3D_Packing_Algorithm` branch'inde~~ | ✅ Çözüldü — 1.160 satır PR #888 ile `test`'e taşınıyor, her dosyaya "tasarım arşivi" durum notu eklendi |
-| PR şablonunda ekran görüntüsü alanı yok | UI PR'larında görsel kanıt atlanıyor |
+| Production CI/CD pipeline'ı yazılı bir süreç olarak yok | 🟡 **Kısmen çözüldü (2026-08-08)** — `docs/devops/deployment.md` § Production Durumu mevcut gerçeği belgeliyor (stack hiç deploy edilmedi, `v*` etiketi hiçbir workflow'u tetiklemiyor). Pipeline'ın kendisi hâlâ yok → **açık** |
+| ~~Branch konvansiyonu entegrasyon dalı modelini tarif ediyor, `known-issues.md` #6 bu modelin ayrışma ürettiğini kayıt altına almış~~ | ✅ Çözüldü — `branching.md` üç dallı terfi modelini tarif ediyor, `known-issues.md` #6'nın "Uygulanan çözüm" bölümü `Terfi Zinciri Kontrolü` job'unu ve terfi PR'larında squash yasağını belgeliyor; çelişki kalmadı |
+| ~~Algoritma tasarım dokümanları sadece `feature/3D_Packing_Algorithm` branch'inde~~ | ✅ Çözüldü — 1.160 satır PR #888 ile kurtarıldı; 2026-08-08'de `docs/archive/algoritma-tasarimi/` altına taşındı |
+| ~~`SUMMARY.md` (GitBook ToC) backend ve ERP dokümanlarını hiç listelemiyor~~ | ✅ Çözüldü (2026-08-08) — SUMMARY 7 bölümle yeniden üretildi; backend (7), devops (8), arşiv (5) dahil 31 doküman listeleniyor |
+| ~~PR şablonunda ekran görüntüsü alanı yok~~ | ✅ Çözüldü (2026-08-08) — `pull_request_template.md`'ye "Ekran Görüntüleri" bölümü eklendi (UI PR'larında zorunlu) |

--- a/docs/context/kod-taramasi-2026-08.md
+++ b/docs/context/kod-taramasi-2026-08.md
@@ -1,5 +1,11 @@
 # Kod Taraması — Ağustos 2026
 
+**Son güncelleme:** 2026-08-04 · **Durum:** Aktif
+
+Kod tabanının 6 kategoride taranmasından çıkan gerçek durum: stack, algoritma, devops, veritabanı ve test bulguları.
+
+---
+
 **Tarama:** 2026-08-04 · 6 kategori (frontend, backend, algoritma, devops, veritabanı, test/kalite)
 paralel ajanlarla kod tabanı üzerinden tarandı; bulgular burada birleştirildi.
 Yöntem: yalnızca repo dosya içeriği okundu — sunucuya SSH atılmadı, GHCR/Actions geçmişi sorgulanmadı.
@@ -48,7 +54,7 @@ Yöntem: yalnızca repo dosya içeriği okundu — sunucuya SSH atılmadı, GHCR
 - **Çift mantık:** frontend `buildPlacements` (shelf/row) tamamen ayrı bir heuristik — ön izleme/staging için. Manuel drag doğrulaması backend kurallarının **alt kümesi**: %80 destek, MaxStackCount, MaxWeightOnTop, LIFO, drag sonrası ağırlık kontrolü frontend'de yok; tek violation mesajı sınır/çakışma. Yüzey (face) kısıtı ise **sadece** frontend'de var.
 - **Sözleşme:** eksen eşlemesi ve sol-alt-arka pivot backend'de tutarlı ama yazılı değil; cm birimi hiçbir yerde zorlanmıyor (konvansiyon). Pivot offset `scene-config.ts`'te değil, `BoxWrapper`/`CargoMeshInstanced` içine dağılmış (CLAUDE.md kuralının kısmi ihlali). Rotasyon→boyut eşlemesi FE/BE birebir uyumlu doğrulandı; ancak FE `ALLOWED_ROTATIONS.YawOnly=6`'nın backend enum karşılığı yok (latent uyumsuzluk). `allowContamination` FE'den gönderiliyor, BE komutlarında alan yok → sessizce yok sayılıyor.
 - **Performans:** dominance filtresi yok → pratik O(N³); `ImproveBalance` O(N⁴)'e çıkabilir; sıcak döngü `decimal`; `CancellationToken`/timeout yok (HTTP isteğini bloke ediyor); plan başına kutu sayısı sınırsız; hiç benchmark/test yok. FE: `InstancedMesh` eşiği 50, dispose disiplinli, `computeViolations` O(n²) ama sadece `pointerup`'ta.
-- **Tasarım dokümanları arşiv** (`matematiksel_model.md`, `sistem_mimarisi.md`, `bin_packing_implementation_plan.md`): kod hem ileride (AllowedRotations, gruplama, kontaminasyon) hem geride (dominance filtresi, CoG hard constraint + fallback + uyarı üretimi, normalize maliyet fonksiyonu yok). Arşiv notundaki "MediatR kullanılmaz" cümlesi de hatalı.
+- **Tasarım dokümanları arşiv** (`docs/archive/algoritma-tasarimi/matematiksel-model.md`, `sistem-mimarisi.md`, `bin-packing-uygulama-plani.md`): kod hem ileride (AllowedRotations, gruplama, kontaminasyon) hem geride (dominance filtresi, CoG hard constraint + fallback + uyarı üretimi, normalize maliyet fonksiyonu yok). Arşiv notundaki "MediatR kullanılmaz" cümlesi de hatalı.
 
 ## 5. Veritabanı
 

--- a/docs/context/project-snapshot.md
+++ b/docs/context/project-snapshot.md
@@ -1,5 +1,11 @@
 # Proje Anlık Görüntüsü
 
+**Son güncelleme:** 2026-08-04 · **Durum:** Aktif
+
+Stack, ortamlar, portlar, CI/CD ve açık risklerin tek sayfalık teknik anlık görüntüsü.
+
+---
+
 **Kaynak tarama:** 2026-08-03 · `test` @ `3c42f65a` · Repodaki 25 `.md` dosyası okundu.
 **Kod taraması:** 2026-08-04 · 6 kategoride kod tabanı tarandı, §2 kodla doğrulanıp düzeltildi.
 Detaylı bulgular: [kod-taramasi-2026-08.md](kod-taramasi-2026-08.md).
@@ -145,7 +151,7 @@ feat/* ──PR(squash)──► dev ──PR(merge)──► test ──PR(merg
 - `hotfix/*` → `main` tek istisna; ardından `main → test → dev` geri-merge **zorunlu**.
 - `dev` her an çıkılabilir olmalı: erken terfide `dev`'deki her şey birlikte gider.
 - Silinen tüm eski branch'ler `archive/<branch-adı>` tag'i olarak korunuyor (28 tag).
-- Kurallar: [BRANCHING.md](../conventions/BRANCHING.md) · Karar geçmişi: [branching-proposal.md](branching-proposal.md)
+- Kurallar: [branching.md](../conventions/branching.md) · Karar geçmişi: [branching-proposal-2026-08.md](../archive/branching-proposal-2026-08.md)
 
 **Not:** 2026-08-03 sabahı kısa süreliğine trunk modeline (`main` tek dal) geçildi, aynı gün
 üç dallı modele dönüldü. Gerekçe: test ortamı fiilen müşteriye gösterilen yüzey ve ayrı bir

--- a/docs/conventions/branching.md
+++ b/docs/conventions/branching.md
@@ -1,6 +1,8 @@
-# Branching Strategy
+# Branch Stratejisi
 
-Bu doküman, Cargo Pilot projesinde branch yapısını, geliştirme akışını ve PR kurallarını tanımlar.
+**Son güncelleme:** 2026-08-03 · **Durum:** Aktif
+
+Cargo Pilot projesinde branch yapısını, geliştirme akışını ve PR kurallarını tanımlar.
 
 **Model:** Üç dallı terfi (promotion) modeli — `dev` → `test` → `main`.
 **Geçerlilik:** 2026-08-03'ten itibaren.
@@ -267,6 +269,6 @@ git checkout -b feat/US-XXX-devam archive/feature/eski-branch-adi
 
 ## İlgili Dokümanlar
 
-{% content-ref url="COMMITS.md" %}
-[Commit Kuralları](COMMITS.md)
+{% content-ref url="commits.md" %}
+[Commit Kuralları](commits.md)
 {% endcontent-ref %}

--- a/docs/conventions/commits.md
+++ b/docs/conventions/commits.md
@@ -1,5 +1,7 @@
 # Commit Kuralları
 
+**Son güncelleme:** 2026-08-03 · **Durum:** Aktif
+
 Commit geçmişini anlaşılır, okunabilir ve takip edilebilir tutmak için uyulacak kurallar.
 
 ---
@@ -100,6 +102,6 @@ Amaç kusursuz değil, **okunabilir** bir geçmiş oluşturmaktır.
 
 ## İlgili Dokümanlar
 
-{% content-ref url="BRANCHING.md" %}
-[Branching Strategy](BRANCHING.md)
+{% content-ref url="branching.md" %}
+[Branch Stratejisi](branching.md)
 {% endcontent-ref %}

--- a/docs/devops/deployment.md
+++ b/docs/devops/deployment.md
@@ -1,15 +1,12 @@
-# Deployment Bilgileri
+# Deployment
 
-**Sunucu:** `104.247.163.42` / `cargopilot.divizyon.org`\
-**CI/CD:** GitHub Actions → otomatik deploy aktif
+**Son güncelleme:** 2026-08-08 · **Durum:** Aktif
 
-{% hint style="warning" %}
-**Production stack henüz deploy edilmedi.** Test ortamı şu an product demo için kullanılmaktadır. Detaylar için bkz. [Bilinen Sorunlar](docs/devops/known-issues.md).
-{% endhint %}
+Bu doküman test ve production ortamlarının servis adreslerini, stack yönetimini, env dosyalarını, database migration sürecini, container operasyonlarını ve CI/CD akışını açıklar.
 
 ---
 
-## Servis Adresleri
+## Ortamlar ve servis adresleri
 
 {% tabs %}
 {% tab title="🧪 Test" %}
@@ -41,7 +38,7 @@
 
 ---
 
-## Stack Yönetimi
+## Stack yönetimi
 
 {% tabs %}
 {% tab title="🧪 Test" %}
@@ -79,7 +76,7 @@ docker logs -f cargo-pilot-frontend-prod
 
 ---
 
-## Env Dosyaları (Sunucuda)
+## Env Dosyaları
 
 | Ortam | Yol |
 |-------|-----|
@@ -132,7 +129,7 @@ docker exec cargo-pilot-mssql-test /opt/mssql-tools18/bin/sqlcmd \
 
 ---
 
-## Container Durumu
+## Container Operasyonları
 
 ```bash
 # Tüm cargo-pilot container'larını gör
@@ -154,6 +151,20 @@ docker restart cargo-pilot-backend-prod
 | `test` | PR + Push | Image Build → GHCR Push → Deploy (Test) |
 | `main` | Push | _(Production pipeline henüz yok)_ |
 
-{% hint style="info" %}
-SSH erişimi ve sunucu detayları için bkz. [Sunucu Erişim & Ağ](docs/devops/server-access.md).
+---
+
+## Production Durumu
+
+{% hint style="warning" %}
+**Production stack henüz deploy edilmedi.** Test ortamı şu an product demo için kullanılmaktadır. Detaylar için bkz. [Bilinen Sorunlar](known-issues.md).
 {% endhint %}
+
+`main` branch'e push sonrası `release-tag.yml` otomatik olarak `v0.<n>.0` formatında bir sürüm etiketi atar; bu etiketleme herhangi bir deploy tetiklemez. `v*` etiketleri şu an hiçbir workflow tarafından tüketilmiyor — production CI/CD pipeline'ı henüz kurulmadı.
+
+---
+
+## İlgili Dokümanlar
+
+- [Sunucu Erişim & Ağ](server-access.md) — SSH erişimi ve sunucu ağ detayları
+- [Bilinen Sorunlar](known-issues.md) — açık deployment riskleri
+- [Secret Yönetimi](secret-management.md) — env dosyaları ve CI/CD secret'ları

--- a/docs/devops/devops-backlog.md
+++ b/docs/devops/devops-backlog.md
@@ -1,7 +1,8 @@
 # DevOps Backlog
 
-**Oluşturulma:** 2026-05-10 | **Son güncelleme:** 2026-08-04\
-**Sorumlu:** DevOps Chapter Lead
+**Son güncelleme:** 2026-08-04 · **Durum:** Aktif · **Oluşturulma:** 2026-05-10 · **Sorumlu:** DevOps Chapter Lead
+
+Bu doküman DevOps ekibinin açık ve tamamlanmış iyileştirme maddelerini önceliklendirilmiş şekilde takip eder.
 
 ---
 
@@ -17,7 +18,7 @@
 | 6 | Grafana Alert Contact Point | 🟠 Yüksek | ⚠️ Açık |
 | 7 | Resend Domain Doğrulaması | 🟠 Yüksek | ⚠️ Açık |
 | 8 | SSL — self-signed → gerçek sertifika | 🟡 Orta | ⚠️ Açık |
-| 9 | `PRODUCTION_DEPLOYMENT_INFO.md` güncelle | 🟡 Orta | ⚠️ Açık |
+| 9 | `deployment.md` güncelle | 🟡 Orta | ⚠️ Açık |
 | 10 | `monitoring-setup.md` — contact point adımları | 🟡 Orta | ⚠️ Açık |
 | 11 | Node.js 20 → 22 geçişi | 🟢 Düşük | ⚠️ Açık |
 
@@ -186,7 +187,7 @@ Self-signed sertifika kullanılıyor. Cloudflare Full SSL modu ile şimdilik ça
 | `local-setup.md` — Vite dev proxy belgelendi | ✅ | #480 |
 | `.env.test.example` — `VITE_DEV_PROXY_TARGET` eklendi | ✅ | #480 |
 | `secret-management.md` — GHCR public bölümü eklendi | ✅ | #480 |
-| `PRODUCTION_DEPLOYMENT_INFO.md` — Prod deploy checklist eksik | ⚠️ Açık | — |
+| `deployment.md` — Prod deploy checklist eksik | ⚠️ Açık | — |
 | `monitoring-setup.md` — Contact point ekleme adımları eksik | ⚠️ Açık | — |
 | Node.js 20 → 22 geçişi (CI + Dockerfile) | ⚠️ Açık | — |
 

--- a/docs/devops/iyilestirme-analizi-2026-08.md
+++ b/docs/devops/iyilestirme-analizi-2026-08.md
@@ -1,9 +1,11 @@
 # DevOps İyileştirme Analizi — 2026-08-03
 
+**Son güncelleme:** 2026-08-03 · **Durum:** Aktif
+
+Bu doküman dört paralel tarama (CI/CD süresi · Docker image · Altyapı & observability · Sunucu operasyonu) ile tespit edilen 51 maddelik DevOps bulgu listesini, doğrulama durumlarını ve uygulama sırasını içerir.
+
 **Kapsam:** Yalnızca DevOps. Uygulama kodu, iş mantığı ve 3D katmanı kapsam dışı.
-**Yöntem:** Dört paralel tarama (CI/CD süresi · Docker image · Altyapı & observability · Sunucu operasyonu),
-ardından kritik iddiaların elle doğrulanması.
-**Durum:** 📋 Analiz — **hiçbir madde uygulanmadı.** Öncelik kararı bekleniyor.
+**Analiz durumu:** 📋 **Hiçbir madde uygulanmadı.** Öncelik kararı bekleniyor.
 
 > Bu doküman [`known-issues.md`](known-issues.md) ve [`devops-backlog.md`](devops-backlog.md)
 > yerine geçmez; onların **üstüne** gelen bir tarama sonucudur. Zaten kayıtlı olan maddeler

--- a/docs/devops/known-issues.md
+++ b/docs/devops/known-issues.md
@@ -1,6 +1,8 @@
 # Bilinen Sorunlar
 
-**Son güncelleme:** 2026-05-16
+**Son güncelleme:** 2026-08-04 · **Durum:** Aktif
+
+Bu doküman açık ve çözülmüş devops sorunlarını, kök nedenlerini ve uygulanan/uygulanacak çözümlerini listeler.
 
 > Geliştirme backlog'u ve iyileştirme maddeleri için bkz. [DevOps Backlog](devops-backlog.md).
 >
@@ -135,7 +137,7 @@ görülmedi**. İlk deploy'da doğrulanmalı. Bkz. madde 2 ve [devops-backlog.md
 
 **Süreç kuralı:** İş branch'leri yalnızca `dev`'e PR açar. `dev → test` ve `test → main` ayrı terfi PR'larıdır. Test ortamında bulunan bug `test`'te değil, `dev`'den açılan `fix/*` ile düzeltilir.
 
-**Kalan risk:** `hotfix/* → main` sonrası `main → test → dev` geri-merge'ünün unutulması. Bu adım otomatikleştirilmedi — bkz. [BRANCHING.md](../conventions/BRANCHING.md) "Hotfix".
+**Kalan risk:** `hotfix/* → main` sonrası `main → test → dev` geri-merge'ünün unutulması. Bu adım otomatikleştirilmedi — bkz. [branching.md](../conventions/branching.md) "Hotfix".
 
 ---
 

--- a/docs/devops/monitoring-setup.md
+++ b/docs/devops/monitoring-setup.md
@@ -1,7 +1,8 @@
 # Monitoring & Alerting
 
-**Görevler:** US-D19-I, US-D20-I, US-D21-I, US-D28-I, US-D29-I\
-**Son güncelleme:** 2026-05-16
+**Son güncelleme:** 2026-08-04 · **Durum:** Aktif · **Görev:** US-D19-I, US-D20-I, US-D21-I, US-D28-I, US-D29-I
+
+Bu doküman Prometheus, Loki/Promtail ve Grafana ile kurulu monitoring stack'in mimarisini, kurulum adımlarını, alert kurallarını ve sorun giderme yöntemlerini açıklar.
 
 ---
 

--- a/docs/devops/secret-management.md
+++ b/docs/devops/secret-management.md
@@ -1,6 +1,8 @@
 # Secret Yönetimi
 
-**Görev:** US-D23-S | **Tarih:** 2026-04-25
+**Son güncelleme:** 2026-04-25 · **Durum:** Aktif · **Görev:** US-D23-S
+
+Bu doküman repoya girmemesi gereken secret'ları, ortam dosyalarının konumunu, GHCR/CI-CD secret'larını ve bir secret ihlali durumunda izlenecek adımları açıklar.
 
 ---
 

--- a/docs/devops/server-access.md
+++ b/docs/devops/server-access.md
@@ -1,6 +1,8 @@
 # Sunucu Erişim & Ağ Yapılandırması
 
-**Son güncelleme:** 2026-05-16
+**Son güncelleme:** 2026-05-17 · **Durum:** Aktif
+
+Bu doküman sunucuya SSH erişimini, güvenlik duvarı/fail2ban yapılandırmasını, nginx reverse proxy kurallarını ve monitoring stack başlatma adımlarını açıklar.
 
 ---
 

--- a/docs/devops/server-requirements.md
+++ b/docs/devops/server-requirements.md
@@ -1,6 +1,8 @@
 # Sunucu Gereksinimleri
 
-**Görev:** US-D01-I | **Tarih:** 2026-04-23
+**Son güncelleme:** 2026-04-23 · **Durum:** Aktif · **Görev:** US-D01-I
+
+Bu doküman mevcut sunucunun kapasitesini, bileşen bazlı kaynak gereksinimlerini ve prod + test ortamlarının birlikte çalışabilirliğini özetler.
 
 ---
 

--- a/docs/setup/local-setup.md
+++ b/docs/setup/local-setup.md
@@ -1,6 +1,8 @@
 # Local Setup
 
-Bu doküman, Cargo Pilot projesini local geliştirme ortamında ayağa kaldırmak için izlenecek adımları açıklar.
+**Son güncelleme:** 2026-08-03 · **Durum:** Aktif
+
+Cargo Pilot projesini local geliştirme ortamında ayağa kaldırmak için izlenecek adımları açıklar.
 
 ---
 
@@ -146,22 +148,22 @@ Sunucuda nginx `/media/` path'i MinIO S3 API'ye (port 9002) reverse proxy yapıl
 # 1. Remote'u güncelle
 git fetch origin
 
-# 2. test branch'inden yeni branch aç (branching kuralı)
-git checkout -b feature/US-XXX-aciklama origin/test
+# 2. dev branch'inden yeni branch aç (branching kuralı)
+git checkout -b feat/US-XXX-aciklama origin/dev
 
 # 3. Geliştir, test et, commit at
 git add <dosyalar>
 git commit -m "kısa açıklayıcı mesaj"
 
 # 4. Push et
-git push origin feature/US-XXX-aciklama
+git push origin feat/US-XXX-aciklama
 
-# 5. dev'e PR aç, ardından aynı branch'ten test'e PR aç
+# 5. dev'e PR aç
 gh pr create --base dev
 ```
 
 {% hint style="info" %}
-Branch ve commit kuralları için bkz. [Branching Strategy](../conventions/BRANCHING.md) ve [Commit Kuralları](../conventions/COMMITS.md).
+Branch ve commit kuralları için bkz. [Branch Stratejisi](../conventions/branching.md) ve [Commit Kuralları](../conventions/commits.md).
 {% endhint %}
 
 ---
@@ -256,12 +258,12 @@ docker logs cargo-pilot-minio-test --tail=30
 
 ## İlgili Dokümanlar
 
-{% content-ref url="../conventions/BRANCHING.md" %}
-[Branching Strategy](../conventions/BRANCHING.md)
+{% content-ref url="../conventions/branching.md" %}
+[Branch Stratejisi](../conventions/branching.md)
 {% endcontent-ref %}
 
-{% content-ref url="../conventions/COMMITS.md" %}
-[Commit Kuralları](../conventions/COMMITS.md)
+{% content-ref url="../conventions/commits.md" %}
+[Commit Kuralları](../conventions/commits.md)
 {% endcontent-ref %}
 
 {% content-ref url="../devops/secret-management.md" %}

--- a/infra/env/README.md
+++ b/infra/env/README.md
@@ -1,6 +1,8 @@
-# Infra Environment Yapılandırması
+# Infra Ortam Değişkenleri
 
-Bu klasör, Docker Compose ve altyapı servisleri için ortam değişkenlerini içerir.
+**Son güncelleme:** 2026-08-03 · **Durum:** Aktif
+
+Docker Compose ve altyapı servisleri için ortam değişkenlerini ve kurulum adımlarını açıklar.
 
 ## Dosya Yapısı
 


### PR DESCRIPTION
## Özet

Repodaki 37 markdown dokümanının tamamını kapsayan revizyon:

- **Yapı:** `docs/archive/` açıldı (AUDIT test planı, branching-proposal, 3 algoritma tasarım dokümanı taşındı); `PRODUCTION_DEPLOYMENT_INFO.md` kökten `docs/devops/deployment.md`'ye taşınıp yeniden düzenlendi; konvansiyon dosyaları kebab-case oldu (`branching.md`, `commits.md`).
- **Yeni:** `CONTRIBUTING.md` (katkı rehberi); PR şablonuna Ekran Görüntüleri bölümü.
- **Standart şablon:** tüm dokümanlarda H1 + "Son güncelleme · Durum" metadata satırı + amaç cümlesi.
- **Dil:** backend dokümanlarındaki ~1.400 diakritiksiz kelime düzeltildi (kod blokları/tanımlayıcılar korunarak; satır ve backtick sayıları doğrulandı).
- **İçerik düzeltmeleri:** 6 tespit kapatıldı (bayat doc-map, hatalı MediatR arşiv notu, SUMMARY'de eksik backend bölümü, bayat sürümler, çift frontmatter, uyumsuz tarihler); `local-setup.md`'deki eski branch örneği yürürlükteki modele çekildi.
- **İndeksler:** `SUMMARY.md` (7 bölüm / 31 link) ve `docs/context/doc-map.md` yeni yapıya göre baştan üretildi; repo geneli bayat referans taraması temiz.

## İlgili User Story / Issue

Doküman denetimi ve revizyonu (bağımsız chore).

## Değişiklik Tipi

- [x] Dokümantasyon / temizlik (chore)

## Test Edildi mi?

- [x] Manuel doğrulama: dosya envanteri (37), link hedefleri, bayat referans grep taraması, kod bloğu bütünlüğü (fence/backtick sayımları)

## Ek Notlar

Yalnızca `.md` dosyaları ve PR şablonu değişti; kod değişikliği yok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)