### PR TITLE
Branching ve CONTRIBUTING: zorunlu review kuralının kaldırılması

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Detay için bkz. [Commit Kuralları](docs/conventions/commits.md).
 ## PR Süreci
 
 1. PR açarken [PR şablonunu](.github/pull_request_template.md) eksiksiz doldurun (özet, ilgili user story/issue, değişiklik tipi, test durumu, ekran görüntüleri, kontrol listesi).
-2. En az **1 onaylayan review** gerekir; push sonrası eski onaylar düşer, yeniden review istenir. Tüm review thread'leri çözülmüş olmalıdır.
+2. Zorunlu review yoktur; CI kapıları geçen PR merge edilebilir. Riskli veya geniş kapsamlı değişikliklerde bir ekip arkadaşından review istemek önerilir.
 3. CI kapılarının geçmesi zorunludur:
    - **Frontend:** `tsc`, `eslint`, `vitest`, `build`
    - **Backend:** `dotnet build`

--- a/docs/conventions/branching.md
+++ b/docs/conventions/branching.md
@@ -1,6 +1,6 @@
 # Branch Stratejisi
 
-**Son güncelleme:** 2026-08-03 · **Durum:** Aktif
+**Son güncelleme:** 2026-08-08 · **Durum:** Aktif
 
 Cargo Pilot projesinde branch yapısını, geliştirme akışını ve PR kurallarını tanımlar.
 
@@ -204,9 +204,7 @@ Ruleset her dalda yalnızca doğru yöntemi açık bırakır; yanlış seçim ya
 | Kural | Detay |
 |-------|-------|
 | Açıklama | İş kodu + ne yapıldığı |
-| Onay | En az 1 approving review |
-| Push sonrası | Eski onaylar düşer, yeniden review gerekir |
-| Review thread | Tümü çözülmüş olmalı |
+| Onay | Zorunlu review yok (2026-08-08'de kaldırıldı) — CI kapıları geçen PR merge edilebilir; riskli veya geniş kapsamlı işlerde review istemek önerilir |
 | UI değişikliği | Ekran görüntüsü zorunlu |
 | 3D / algoritma değişikliği | Öncesi–sonrası plan karşılaştırması zorunlu |
 


### PR DESCRIPTION
## Özet

Ruleset'lerden zorunlu inceleme şartı kaldırıldığı (2026-08-08) için `docs/conventions/branching.md` PR kuralları tablosu ve `CONTRIBUTING.md` PR süreci maddesi güncel duruma çekildi: CI kapıları geçen PR merge edilebilir; review isteğe bağlı, riskli işlerde önerilir.

## Değişiklik Tipi

- [x] Dokümantasyon (chore)

## Test Edildi mi?

- [x] Manuel — yalnız iki md dosyasında metin değişikliği

🤖 Generated with [Claude Code](https://claude.com/claude-code)