### PR TITLE
F0-01 · Kapı yönü hatalarının giderilmesi (LIFO bölge yönü)

### DIFF
--- a/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
@@ -4,19 +4,24 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <!-- Test metot adlari xUnit geleneginde alt cizgi icerir (CA1707). -->
-    <NoWarn>$(NoWarn);CA1707</NoWarn>
+
+    <!-- xUnit alt çizgili test adları CA1707'yi tetikler; Directory.Build.props
+         tüm uyarıları hataya yükseltiyor, bu yüzden test projesinde bilinçli olarak kapatılır. -->
+    <NoWarn>CA1707</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <!-- Test metot adlari xUnit geleneginde alt cizgi icerir (CA1707). -->
+    <NoWarn>$(NoWarn);CA1707</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CargoPilot.Infrastructure\CargoPilot.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/apps/backend/CargoPilot.Infrastructure.Tests/GroupZoneTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/GroupZoneTests.cs
@@ -1,0 +1,97 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Services;
+using Xunit;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// LIFO grup bolgelerinin kapi yonune gore dogru eslendigini sabitler.
+/// Sahne sozlesmesi: arka kapi Z=0, arac onu Z=Length.
+/// UnloadingOrder=1 ilk inecek gruptur, bu yuzden kapiya en yakin olmalidir.
+/// </summary>
+public sealed class GroupZoneTests
+{
+    private const decimal VehicleWidth = 100m;
+    private const decimal VehicleHeight = 100m;
+    private const decimal VehicleLength = 300m;
+    private const decimal BoxLength = 50m;
+    private const decimal ZoneSize = VehicleLength / 3m;
+
+    [Fact]
+    public void Lifo_IlkInecekGrup_KapiyaEnYakinBolgeyeYerlesir()
+    {
+        var (result, itemsByOrder) = RunWithThreeGroups();
+
+        var zByOrder = itemsByOrder.ToDictionary(
+            pair => pair.Key,
+            pair => SinglePlacement(result, pair.Value).Z);
+
+        Assert.True(zByOrder[1] < zByOrder[2],
+            $"unloadingOrder=1 kapiya daha yakin olmali. Z: 1={zByOrder[1]}, 2={zByOrder[2]}");
+        Assert.True(zByOrder[2] < zByOrder[3],
+            $"unloadingOrder=2, 3'ten kapiya daha yakin olmali. Z: 2={zByOrder[2]}, 3={zByOrder[3]}");
+    }
+
+    [Fact]
+    public void Lifo_HerGrup_KendiBolgesininSinirlariIcindeKalir()
+    {
+        var (result, itemsByOrder) = RunWithThreeGroups();
+
+        foreach (var (unloadingOrder, itemId) in itemsByOrder)
+        {
+            var zoneStart = (unloadingOrder - 1) * ZoneSize;
+            var zoneEnd = unloadingOrder * ZoneSize;
+            var placement = SinglePlacement(result, itemId);
+
+            Assert.True(placement.Z >= zoneStart && placement.Z + placement.Depth <= zoneEnd,
+                $"unloadingOrder={unloadingOrder} bolgesi [{zoneStart},{zoneEnd}] disinda: " +
+                $"Z={placement.Z}, derinlik={placement.Depth}");
+        }
+    }
+
+    private static (OptimizationResult Result, Dictionary<int, Guid> ItemsByOrder) RunWithThreeGroups()
+    {
+        var itemsByOrder = new Dictionary<int, Guid>();
+        var items = new List<OptimizationItemInput>();
+
+        foreach (var unloadingOrder in new[] { 1, 2, 3 })
+        {
+            var item = CreateItem(unloadingOrder);
+            itemsByOrder[unloadingOrder] = item.ItemId;
+            items.Add(item);
+        }
+
+        var input = new OptimizationInput(
+            VehicleWidth,
+            VehicleHeight,
+            VehicleLength,
+            VehicleMaxWeight: 10_000m,
+            items,
+            LoadingPlanOptimizationCriteria.Lifo,
+            LoadingType.Rear);
+
+        return (new OptimizationEngine().Run(input), itemsByOrder);
+    }
+
+    private static PlacedItemResult SinglePlacement(OptimizationResult result, Guid itemId)
+        => Assert.Single(result.Placements, p => p.ItemId == itemId);
+
+    private static OptimizationItemInput CreateItem(int unloadingOrder)
+        => new(
+            ItemId: Guid.NewGuid(),
+            SKU: $"SKU-{unloadingOrder}",
+            Name: $"Urun {unloadingOrder}",
+            ImageUrl: null,
+            Width: VehicleWidth,
+            Height: VehicleHeight,
+            Length: BoxLength,
+            Weight: 100m,
+            IsStackable: false,
+            MaxStackCount: 1,
+            MaxWeightOnTop: 0m,
+            AllowedRotations: AllowedRotations.Fixed,
+            Quantity: 1,
+            GroupId: Guid.NewGuid(),
+            UnloadingOrder: unloadingOrder);
+}

--- a/apps/backend/CargoPilot.Infrastructure.Tests/GroupZoneTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/GroupZoneTests.cs
@@ -1,7 +1,6 @@
 using CargoPilot.Application.Common.Models;
 using CargoPilot.Domain.Enums;
 using CargoPilot.Infrastructure.Services;
-using Xunit;
 
 namespace CargoPilot.Infrastructure.Tests;
 

--- a/apps/backend/CargoPilot.Infrastructure/AssemblyInfo.cs
+++ b/apps/backend/CargoPilot.Infrastructure/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// Test projesinin internal üyelere (ör. OptimizationEngine.GetOrientations) erişebilmesi için.
+// Üretim davranışını değiştirmez; yalnızca test görünürlüğü sağlar.
+[assembly: InternalsVisibleTo("CargoPilot.Infrastructure.Tests")]

--- a/apps/backend/CargoPilot.Infrastructure/CargoPilot.Infrastructure.csproj
+++ b/apps/backend/CargoPilot.Infrastructure/CargoPilot.Infrastructure.csproj
@@ -44,4 +44,8 @@
     <ProjectReference Include="..\CargoPilot.Application\CargoPilot.Application.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="CargoPilot.Infrastructure.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/apps/backend/CargoPilot.Infrastructure/CargoPilot.Infrastructure.csproj
+++ b/apps/backend/CargoPilot.Infrastructure/CargoPilot.Infrastructure.csproj
@@ -44,8 +44,4 @@
     <ProjectReference Include="..\CargoPilot.Application\CargoPilot.Application.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="CargoPilot.Infrastructure.Tests" />
-  </ItemGroup>
-
 </Project>

--- a/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
@@ -37,6 +37,13 @@ internal sealed class OptimizationEngine : IOptimizationEngine
 
         var groupZones = ComputeGroupZones(instances, input.VehicleLength, input.LoadingType, input.Criteria);
 
+        // LIFO bölgeleri de aynı nedenle tohumlanır: aday noktalar yalnızca
+        // yerleştirilmiş kutulara komşu doğduğu için ilk yüklenen grup her zaman
+        // Z=0'a, yani kapının önüne düşüyordu. Her bölgenin başlangıcı aday
+        // yapılınca grup kendi bölgesinden başlayarak dolar.
+        foreach (var zoneStart in groupZones.Values.Select(z => z.ZStart).Where(z => z > 0m))
+            extremePoints.Add((0m, 0m, zoneStart));
+
         foreach (var item in instances)
         {
             // Her kutu için aday pozisyon taraması pahalıdır; iptal edilen istekte

--- a/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
@@ -147,8 +147,11 @@ internal sealed class OptimizationEngine : IOptimizationEngine
     }
 
     // ── Grup zone hesaplama ───────────────────────────────────────────────────
-    // Gruplara ait distinct UnloadingOrder değerlerini DESC sıralar ve kamyon
-    // uzunluğunu eşit bölümlere ayırır. 0-1 grup varsa zone uygulanmaz.
+    // Arka kapı Z=0'dadır. UnloadingOrder=1 ilk inecek gruptur, bu yüzden kapıya
+    // en yakın (en küçük Z) bölgeye düşer. Distinct UnloadingOrder değerleri ASC
+    // sıralanır ve kamyon uzunluğu eşit bölümlere ayrılır; sıradaki her grup bir
+    // sonraki bölgeye, yani kapıdan daha uzağa yerleşir. 0-1 grup varsa zone
+    // uygulanmaz.
     private static Dictionary<int, (decimal ZStart, decimal ZEnd)> ComputeGroupZones(
         IReadOnlyList<OptimizationItemInput> items,
         decimal vehicleLength,
@@ -163,7 +166,7 @@ internal sealed class OptimizationEngine : IOptimizationEngine
             .Where(i => i.GroupId.HasValue && i.UnloadingOrder.HasValue)
             .Select(i => i.UnloadingOrder!.Value)
             .Distinct()
-            .OrderByDescending(o => o)
+            .OrderBy(o => o)
             .ToList();
 
         if (orders.Count <= 1)
@@ -180,7 +183,8 @@ internal sealed class OptimizationEngine : IOptimizationEngine
 
     // ── Grup-bilinçli sıralama ────────────────────────────────────────────────
     // GroupId'si olan items yükleme sırasına göre sıralanır:
-    // yüksek UnloadingOrder = araç arkası = önce yüklenir (DESC sıra).
+    // yüksek UnloadingOrder = en son inecek grup = kapıdan en uzak bölge
+    // (arka kapıda Z=length tarafı) = önce yüklenir (DESC sıra).
     // GroupId'si olmayan items en sona eklenir.
     // Grup yoksa mevcut criteria-based sıralama uygulanır.
     private static List<OptimizationItemInput> SortForGroupPlacement(

--- a/cargo-pilot.sln
+++ b/cargo-pilot.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -14,7 +14,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.Infrastructure",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.WebAPI", "apps\backend\CargoPilot.WebAPI\CargoPilot.WebAPI.csproj", "{4618B678-DBA1-7394-A174-B0F4FF20BA42}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.Infrastructure.Tests", "apps\backend\CargoPilot.Infrastructure.Tests\CargoPilot.Infrastructure.Tests.csproj", "{86670B4B-5BF8-4363-BAC7-D3901CD571F6}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.Infrastructure.Tests", "apps\backend\CargoPilot.Infrastructure.Tests\CargoPilot.Infrastructure.Tests.csproj", "{CE7ABED3-744E-4A97-8353-C8E57A1DA532}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -38,10 +38,10 @@ Global
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Release|Any CPU.Build.0 = Release|Any CPU
-		{86670B4B-5BF8-4363-BAC7-D3901CD571F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{86670B4B-5BF8-4363-BAC7-D3901CD571F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{86670B4B-5BF8-4363-BAC7-D3901CD571F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{86670B4B-5BF8-4363-BAC7-D3901CD571F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -52,7 +52,7 @@ Global
 		{73B7F73A-6F8A-4518-CEF9-C809F44E5ACD} = {270F7A58-C097-D64B-0343-582534E94D4F}
 		{E77D7D49-8EF0-4E3A-67E8-CA37E299AA5E} = {270F7A58-C097-D64B-0343-582534E94D4F}
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42} = {270F7A58-C097-D64B-0343-582534E94D4F}
-		{86670B4B-5BF8-4363-BAC7-D3901CD571F6} = {270F7A58-C097-D64B-0343-582534E94D4F}
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532} = {270F7A58-C097-D64B-0343-582534E94D4F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {33884C42-0BAE-4853-8852-85F38E436D95}

--- a/cargo-pilot.sln
+++ b/cargo-pilot.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.Infrastructure",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.WebAPI", "apps\backend\CargoPilot.WebAPI\CargoPilot.WebAPI.csproj", "{4618B678-DBA1-7394-A174-B0F4FF20BA42}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.Infrastructure.Tests", "apps\backend\CargoPilot.Infrastructure.Tests\CargoPilot.Infrastructure.Tests.csproj", "{86670B4B-5BF8-4363-BAC7-D3901CD571F6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,6 +38,10 @@ Global
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{86670B4B-5BF8-4363-BAC7-D3901CD571F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{86670B4B-5BF8-4363-BAC7-D3901CD571F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{86670B4B-5BF8-4363-BAC7-D3901CD571F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{86670B4B-5BF8-4363-BAC7-D3901CD571F6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,6 +52,7 @@ Global
 		{73B7F73A-6F8A-4518-CEF9-C809F44E5ACD} = {270F7A58-C097-D64B-0343-582534E94D4F}
 		{E77D7D49-8EF0-4E3A-67E8-CA37E299AA5E} = {270F7A58-C097-D64B-0343-582534E94D4F}
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42} = {270F7A58-C097-D64B-0343-582534E94D4F}
+		{86670B4B-5BF8-4363-BAC7-D3901CD571F6} = {270F7A58-C097-D64B-0343-582534E94D4F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {33884C42-0BAE-4853-8852-85F38E436D95}


### PR DESCRIPTION
## Kök Neden

LIFO grup bölgeleri kapı yönünün tersine eşleniyordu ve bölge mekanizması pratikte hiç uygulanamıyordu. İki ayrı kusur var:

**1. Bölge → Z eşlemesi ters (`ComputeGroupZones`, satır ~162)**

```csharp
.OrderByDescending(o => o)   // en büyük UnloadingOrder önce
...
zones[orders[i]] = (i * zoneSize, (i + 1) * zoneSize);   // orders[0] → Z≈0
```

Sonuç: **en büyük** `UnloadingOrder` (en son inecek grup) kapıya en yakın bölgeye düşüyordu.

Sözleşme ise tersini söylüyor:

- `apps/frontend/src/lib/utils/scene/loadOrder.ts` → `rear` kapı **Z=0**'dadır.
- `ContainerMesh.tsx` → arka kanadın menteşesi `position={[0, 0, 0]}`.
- `OptimizationModal.tsx:207` → "Kapıdan **ilk inecek grubu en üste** sürükleyin", `NewPlanPage.tsx:238` → `unloadingOrder: idx + 1`.

Yani `unloadingOrder = 1` = ilk inecek = kapıya en yakın = **en küçük Z**. Referans doğru olan sahne sözleşmesidir; düzeltilen taraf backend'dir.

**2. Bölge başlangıçları aday nokta olarak tohumlanmıyordu**

Sadece sıralamayı çevirmek davranışı düzeltmiyor. Aday (extreme point) kümesi `(0,0,0)` ile başlıyor ve yalnızca yerleştirilmiş kutulara komşu noktalarla büyüyor. Bu yüzden **ilk yerleştirilen kutu her zaman Z=0'a**, yani kapının önüne düşüyor; hiçbir grup kendi bölgesine ulaşamıyordu. `SortForGroupPlacement` yüksek `UnloadingOrder`'ı önce yerleştirdiği için (bu sıralama doğru: en son inecek grup en derine, önce yüklenir) en son inecek grup ısrarla kapının önüne yığılıyordu.

Aynı sorun `WeightBalance` için zaten tespit edilmiş ve dört köşe tohumlanarak çözülmüştü (satır 26-36); LIFO bölgeleri için aynı desen uygulandı.

## Çözüm

1. `ComputeGroupZones` distinct `UnloadingOrder` değerlerini **artan** sıralar → `unloadingOrder=1` bölgesi `[0, zoneSize)`, yani kapının dibi.
2. Her bölgenin başlangıcı `(0, 0, ZStart)` olarak extreme point kümesine tohumlanır; grup kendi bölgesinden başlayarak dolar.
3. `SortForGroupPlacement` üzerindeki belirsiz yorum netleştirildi ("araç arkası" ifadesi hangi ucu kastettiği belirsizdi) — **sıralamanın kendisi doğru olduğu için kod değişmedi.**

Kapasite, ağırlık dengesi, ağırlık merkezi, istiflenebilirlik, kırılganlık, rotasyon limitleri, katman sayısı ve destek kısıtlarına dokunulmadı; skor katsayıları (`2_000m`, `900_000m`, `1_000_000m`) aynen korundu.

## Doğrulama

Sahne: 300×100×100 cm araç, üç grup (`unloadingOrder` 1/2/3), her biri 1 kutu (100×100×50), `Fixed` rotasyon, LIFO + `LoadingType.Rear`. Bölge boyu 100 cm.

| Grup | Öncesi (Z) | Sonrası (Z) | Beklenen bölge |
|------|-----------|-------------|----------------|
| `unloadingOrder=1` (ilk inecek) | **100** | **0** | `[0, 100)` — kapı dibi |
| `unloadingOrder=2` | 50 | 100 | `[100, 200)` |
| `unloadingOrder=3` (son inecek) | **0** (kapının önü) | **200** | `[200, 300)` |

Düzeltme öncesi kodda testlerin kırmızı olduğu doğrulandı:

```
Failed GroupZoneTests.Lifo_IlkInecekGrup_KapiyaEnYakinBolgeyeYerlesir
   unloadingOrder=1 kapiya daha yakin olmali. Z: 1=100, 2=50
Failed GroupZoneTests.Lifo_HerGrup_KendiBolgesininSinirlariIcindeKalir
   unloadingOrder=1 bolgesi [0,100] disinda: Z=100, derinlik=50
```

Düzeltme sonrası:

```
Build succeeded. 0 Error(s)
Passed GroupZoneTests.Lifo_IlkInecekGrup_KapiyaEnYakinBolgeyeYerlesir
Passed GroupZoneTests.Lifo_HerGrup_KendiBolgesininSinirlariIcindeKalir
Test Run Successful. Total tests: 2, Passed: 2
```

`dotnet build cargo-pilot.sln -c Release` ve `dotnet test cargo-pilot.sln -c Release` komutları geliştirici makinesinde .NET SDK kurulu olmadığı için `mcr.microsoft.com/dotnet/sdk:8.0` konteynerinde (SDK 8.0.423, `global.json` ile uyumlu) çalıştırıldı. Nihai doğrulama CI'daki **Backend CI** işidir.

**Frontend'e dokunulmadı.** Tutarlılık okuma ile doğrulandı: `buildLoadOrder` `rear` durumunda Z'yi büyükten küçüğe sıralar (kapıdan uzak önce yüklenir), grup listesi `unloadingOrder` ASC gösterilir. Düzeltilen yönle tutarlı, değişiklik gerekmedi.

## Test Projesi Notu

Test projesi F0-02 ve F0-03 ile paralel oluşturuluyor; `.sln` ve `.csproj` dosyalarında çakışma beklenir. **Merge sırası F0-02 → F0-03 → F0-01 olmalıdır.**

Çakışma yüzeyini küçültmek için:

- Testler `OptimizationEngineTests.cs` yerine ayrı bir dosyaya (`GroupZoneTests.cs`) yazıldı.
- F0-03 yalnızca `apps/backend/CargoPilot.slnx`'e ekleme yapmış; bu PR ise projeyi **`cargo-pilot.sln`**'e ekliyor. CI `dotnet test cargo-pilot.sln` çalıştırdığı için testlerin koşması bu kaydı gerektiriyor.
- `OptimizationEngine` `internal` olduğundan `CargoPilot.Infrastructure.csproj`'a `InternalsVisibleTo` eklendi.

## Kapsam Dışı Bırakılanlar

- **`LoadingType.Rear` dışındaki kapı yönleri için bölge desteği yok.** `ComputeGroupZones` yan/üst kapıda erken dönüyor; LIFO gruplama bu araçlarda bölgesiz çalışmaya devam ediyor. Ayrı görev gerektirir.
- **Fantom bölge cezası** (`TryGetValue` dönüş değerinin yok sayılması) bu dalda **kasıtlı olarak düzeltilmedi** — F0-03 / PR #925 aynı satırı düzeltiyor, mükerrer düzeltmeyi önlemek için geri alındı.
- **Kapsam dışı bulgu:** `apps/frontend/src/lib/api/vehicleMappers.ts:29-38` içindeki `LOADING_TYPE_FROM_INT` tablosu backend `LoadingType` enum'ı ile uyumsuz. Backend `Rear=0, SideRight=1, SideLeft=2, SideBoth=3, Top=4`; frontend `2`'yi `Top` olarak okuyor. `SideLeft` araçları frontend'de "üstten yükleme" görünüyor. Ayrı bir kapı yönü hatası, bu görevin kapsamında değil.

## İlgili Görev

ClickUp: https://app.clickup.com/t/86eyjm8c3 (F0-01 · Kapı yönü hatalarının giderilmesi)
