### PR TITLE
F0-02: Rotasyon kontrolü regresyon testleri

### DIFF
--- a/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+
+    <!-- xUnit alt çizgili test adları CA1707'yi tetikler; Directory.Build.props
+         tüm uyarıları hataya yükseltiyor, bu yüzden test projesinde bilinçli olarak kapatılır. -->
+    <NoWarn>CA1707</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CargoPilot.Infrastructure\CargoPilot.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineOrientationTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineOrientationTests.cs
@@ -1,0 +1,188 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Services;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// OptimizationEngine.GetOrientations karakterizasyon testleri.
+///
+/// Amaç: Faz 1'de altı yüzey modeli gelmeden önce mevcut altı AllowedRotations
+/// değerinin ürettiği (w, h, d, rotation) permütasyon kümesini testle sabitlemek.
+/// Bu testler davranışı DEĞİŞTİRMEZ; yalnızca mevcut davranışı kayıt altına alır.
+/// F2-06'daki eksen rotasyonu değişikliğinin regresyonu bu testlere göre ölçülür.
+/// </summary>
+public class OptimizationEngineOrientationTests
+{
+    private static OptimizationItemInput CreateItem(
+        decimal width, decimal height, decimal length, AllowedRotations rotations) =>
+        new(
+            ItemId: Guid.NewGuid(),
+            SKU: "SKU-1",
+            Name: "Test Item",
+            ImageUrl: null,
+            Width: width,
+            Height: height,
+            Length: length,
+            Weight: 10m,
+            IsStackable: true,
+            MaxStackCount: 0,
+            MaxWeightOnTop: 0m,
+            AllowedRotations: rotations,
+            Quantity: 1);
+
+    // ── Tam permütasyon kümesi testleri ────────────────────────────────────
+
+    [Fact]
+    public void Fixed_ReturnsOnlyNoRotationOrientation()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.Fixed);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [(100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation)],
+            orientations);
+    }
+
+    [Fact]
+    public void NoVertical_ReturnsNoRotationAndYawOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoVertical);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (30m, 50m, 100m, LoadingPlanPlacementRotation.Yaw)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void NoYaw_ReturnsNoRotationRollAndPitchOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoYaw);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (50m, 100m, 30m, LoadingPlanPlacementRotation.Roll),
+                (100m, 30m, 50m, LoadingPlanPlacementRotation.Pitch)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void PitchOnly_ReturnsNoRotationAndPitchOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.PitchOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (100m, 30m, 50m, LoadingPlanPlacementRotation.Pitch)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void RollOnly_ReturnsNoRotationAndRollOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.RollOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (50m, 100m, 30m, LoadingPlanPlacementRotation.Roll)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void All_ReturnsAllSixOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.All);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (30m, 50m, 100m, LoadingPlanPlacementRotation.Yaw),
+                (50m, 100m, 30m, LoadingPlanPlacementRotation.Roll),
+                (100m, 30m, 50m, LoadingPlanPlacementRotation.Pitch),
+                (50m, 30m, 100m, LoadingPlanPlacementRotation.YawPitch),
+                (30m, 100m, 50m, LoadingPlanPlacementRotation.RollYaw)
+            ],
+            orientations);
+    }
+
+    // ── Eksen kilidi değişmezleri ───────────────────────────────────────────
+
+    [Fact]
+    public void PitchOnly_KeepsWidthLockedOnXAxis()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.PitchOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.All(orientations, o => Assert.Equal(item.Width, o.w));
+    }
+
+    [Fact]
+    public void RollOnly_KeepsLengthLockedOnZAxis()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.RollOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.All(orientations, o => Assert.Equal(item.Length, o.d));
+    }
+
+    [Fact]
+    public void NoVertical_KeepsHeightLockedOnYAxis()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoVertical);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.All(orientations, o => Assert.Equal(item.Height, o.h));
+    }
+
+    // ── Yasak eksen sızıntısı yok ────────────────────────────────────────────
+
+    [Fact]
+    public void NoYaw_DoesNotLeakYawRotations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoYaw);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.DoesNotContain(orientations, o =>
+            o.rotation is LoadingPlanPlacementRotation.Yaw
+                or LoadingPlanPlacementRotation.YawPitch
+                or LoadingPlanPlacementRotation.RollYaw);
+    }
+
+    // ── Simetrik kutu sınır durumu ───────────────────────────────────────────
+
+    [Fact]
+    public void SymmetricBox_AllSixRotationLabelsCollapseToSameDimensions()
+    {
+        var item = CreateItem(40m, 40m, 40m, AllowedRotations.All);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(6, orientations.Length);
+        Assert.Equal(6, orientations.Select(o => o.rotation).Distinct().Count());
+        Assert.All(orientations, o => Assert.Equal((40m, 40m, 40m), (o.w, o.h, o.d)));
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineRotationPlacementTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineRotationPlacementTests.cs
@@ -1,0 +1,144 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Services;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// OptimizationEngine.Run() motor seviyesi rotasyon yerleştirme karakterizasyon testleri.
+///
+/// Amaç: rotasyon kısıtlarının (AllowedRotations) tüm motor akışı içinde (extreme-point
+/// yerleştirme, sınır/çakışma/destek kontrolleri) tutarlı çalıştığını, kilitli eksenlerin
+/// yerleşen sonuçta sabit kaldığını ve rotasyon yüzünden yerleşemeyen kutuların hangi
+/// UnplacedReason ile raporlandığını mevcut davranışa göre sabitlemek.
+/// </summary>
+public class OptimizationEngineRotationPlacementTests
+{
+    private static readonly OptimizationEngine Engine = new();
+
+    private static OptimizationItemInput CreateItem(
+        decimal width, decimal height, decimal length, AllowedRotations rotations) =>
+        new(
+            ItemId: Guid.NewGuid(),
+            SKU: "SKU-1",
+            Name: "Test Item",
+            ImageUrl: null,
+            Width: width,
+            Height: height,
+            Length: length,
+            Weight: 10m,
+            IsStackable: true,
+            MaxStackCount: 0,
+            MaxWeightOnTop: 0m,
+            AllowedRotations: rotations,
+            Quantity: 1);
+
+    private static OptimizationInput CreateInput(
+        decimal vehicleWidth, decimal vehicleHeight, decimal vehicleLength, OptimizationItemInput item) =>
+        new(
+            VehicleWidth: vehicleWidth,
+            VehicleHeight: vehicleHeight,
+            VehicleLength: vehicleLength,
+            VehicleMaxWeight: 1000m,
+            Items: [item]);
+
+    [Fact]
+    public void Fixed_UnplacesBoxThatOnlyFitsWhenRotated()
+    {
+        // Kutu: W=60 sadece Yaw ile Z eksenine (uzunluk=80) sığar; X (genişlik=50) ve
+        // Y (yükseklik=50) eksenlerine hiçbir yönelimde sığmaz.
+        var item = CreateItem(60m, 20m, 20m, AllowedRotations.Fixed);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, item);
+
+        var result = Engine.Run(input);
+
+        Assert.Empty(result.Placements);
+        var unplaced = Assert.Single(result.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+    }
+
+    [Fact]
+    public void All_PlacesBoxViaYawRotationWhenFixedWouldFail()
+    {
+        var item = CreateItem(60m, 20m, 20m, AllowedRotations.All);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, item);
+
+        var result = Engine.Run(input);
+
+        Assert.Empty(result.UnplacedItems);
+        var placed = Assert.Single(result.Placements);
+        Assert.Equal(LoadingPlanPlacementRotation.Yaw, placed.Rotation);
+        // Yaw: (L, H, W) — item'ın W'si (60) Z eksenine (Depth) taşınır.
+        Assert.Equal(20m, placed.Width);
+        Assert.Equal(20m, placed.Height);
+        Assert.Equal(60m, placed.Depth);
+    }
+
+    [Fact]
+    public void RollOnly_VsFixed_RollPlacesWithLengthLockedOnZ_FixedFails()
+    {
+        // Kutu: W=60 sadece Roll ile Y eksenine (yükseklik=80) taşınırsa sığar.
+        var rollItem = CreateItem(60m, 20m, 20m, AllowedRotations.RollOnly);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 80m, vehicleLength: 50m, rollItem);
+
+        var rollResult = Engine.Run(input);
+
+        Assert.Empty(rollResult.UnplacedItems);
+        var placed = Assert.Single(rollResult.Placements);
+        Assert.Equal(LoadingPlanPlacementRotation.Roll, placed.Rotation);
+        // RollOnly değişmezi: L her zaman Z eksenindedir (kilitli).
+        Assert.Equal(rollItem.Length, placed.Depth);
+
+        var fixedItem = rollItem with { AllowedRotations = AllowedRotations.Fixed };
+        var fixedInput = CreateInput(vehicleWidth: 50m, vehicleHeight: 80m, vehicleLength: 50m, fixedItem);
+
+        var fixedResult = Engine.Run(fixedInput);
+
+        Assert.Empty(fixedResult.Placements);
+        var unplaced = Assert.Single(fixedResult.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+    }
+
+    [Fact]
+    public void PitchOnly_VsFixed_PitchPlacesWithWidthLockedOnX_FixedFails()
+    {
+        // Kutu: H=60 sadece Pitch ile Z eksenine (uzunluk=80) taşınırsa sığar.
+        var pitchItem = CreateItem(20m, 60m, 20m, AllowedRotations.PitchOnly);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, pitchItem);
+
+        var pitchResult = Engine.Run(input);
+
+        Assert.Empty(pitchResult.UnplacedItems);
+        var placed = Assert.Single(pitchResult.Placements);
+        Assert.Equal(LoadingPlanPlacementRotation.Pitch, placed.Rotation);
+        // PitchOnly değişmezi: W her zaman X eksenindedir (kilitli).
+        Assert.Equal(pitchItem.Width, placed.Width);
+
+        var fixedItem = pitchItem with { AllowedRotations = AllowedRotations.Fixed };
+        var fixedInput = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, fixedItem);
+
+        var fixedResult = Engine.Run(fixedInput);
+
+        Assert.Empty(fixedResult.Placements);
+        var unplaced = Assert.Single(fixedResult.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+    }
+
+    [Fact]
+    public void RotationConstrainedUnplacedBox_ReportsGenericInsufficientSpaceReason()
+    {
+        // Karakterizasyon notu: motor, rotasyon kısıtı yüzünden yerleşemeyen kutuları
+        // UnplacedReason.RotationOrGeometryConstraint yerine genel InsufficientSpace ile
+        // raporluyor. RotationOrGeometryConstraint şu an motor tarafından hiç atanmıyor.
+        // Bu test mevcut davranışı sabitler; Faz 1'de daha spesifik nedenlendirme
+        // eklenirse bilinçli olarak güncellenmelidir.
+        var item = CreateItem(60m, 20m, 20m, AllowedRotations.Fixed);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, item);
+
+        var result = Engine.Run(input);
+
+        var unplaced = Assert.Single(result.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+        Assert.NotEqual(UnplacedReason.RotationOrGeometryConstraint, unplaced.Reason);
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/AssemblyInfo.cs
+++ b/apps/backend/CargoPilot.Infrastructure/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// Test projesinin internal üyelere (ör. OptimizationEngine.GetOrientations) erişebilmesi için.
+// Üretim davranışını değiştirmez; yalnızca test görünürlüğü sağlar.
+[assembly: InternalsVisibleTo("CargoPilot.Infrastructure.Tests")]

--- a/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
@@ -405,7 +405,7 @@ internal sealed class OptimizationEngine : IOptimizationEngine
         };
     }
 
-    private static (decimal w, decimal h, decimal d, LoadingPlanPlacementRotation rotation)[]
+    internal static (decimal w, decimal h, decimal d, LoadingPlanPlacementRotation rotation)[]
         GetOrientations(OptimizationItemInput item)
     {
         var (W, H, L) = (item.Width, item.Height, item.Length);

--- a/apps/frontend/src/lib/utils/geometry/boxOrientations.test.ts
+++ b/apps/frontend/src/lib/utils/geometry/boxOrientations.test.ts
@@ -102,6 +102,37 @@ describe('isOrientationAllowed', () => {
       expect(isOrientationAllowed(item, idx as 0 | 1 | 2 | 3 | 4 | 5)).toBe(true);
     }
   });
+
+  it.each([
+    [0, 'allowFaceBottom'],
+    [1, 'allowFaceTop'],
+    [2, 'allowFaceFront'],
+    [3, 'allowFaceBack'],
+    [4, 'allowFaceLeft'],
+    [5, 'allowFaceRight'],
+  ] as const)('idx %i → %s=false o orientation için reddeder', (idx, faceKey) => {
+    const item = makeItem({ [faceKey]: false });
+    expect(isOrientationAllowed(item, idx)).toBe(false);
+  });
+
+  it('allowFace*=false diğer indexleri etkilemez', () => {
+    const item = makeItem({ allowFaceTop: false });
+    expect(isOrientationAllowed(item, 0)).toBe(true);
+    expect(isOrientationAllowed(item, 2)).toBe(true);
+    expect(isOrientationAllowed(item, 3)).toBe(true);
+    expect(isOrientationAllowed(item, 4)).toBe(true);
+    expect(isOrientationAllowed(item, 5)).toBe(true);
+  });
+
+  it('eksen izinli olsa da yüz kısıtı reddederse orientation izinsizdir', () => {
+    const item = makeItem({ allowRotateX: true, allowFaceFront: false });
+    expect(isOrientationAllowed(item, 2)).toBe(false);
+  });
+
+  it('yüz izinli olsa da eksen kısıtı reddederse orientation izinsizdir', () => {
+    const item = makeItem({ allowRotateX: false, allowFaceFront: true });
+    expect(isOrientationAllowed(item, 2)).toBe(false);
+  });
 });
 
 describe('allowedOrientations', () => {
@@ -120,5 +151,15 @@ describe('allowedOrientations', () => {
   it('hepsi kapalı → sadece identity (idx 0)', () => {
     const item = makeItem({ allowRotateX: false, allowRotateZ: false });
     expect(allowedOrientations(item)).toEqual([0]);
+  });
+
+  it('allowFaceTop=false → idx 1 hariç tüm eksen-izinli set döner', () => {
+    const item = makeItem({ allowFaceTop: false });
+    expect(allowedOrientations(item)).toEqual([0, 2, 3, 4, 5]);
+  });
+
+  it('allowRotateX=false + allowFaceLeft=false birlikte → sadece 0, 5', () => {
+    const item = makeItem({ allowRotateX: false, allowFaceLeft: false });
+    expect(allowedOrientations(item)).toEqual([0, 5]);
   });
 });

--- a/cargo-pilot.sln
+++ b/cargo-pilot.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -13,6 +13,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.Infrastructure", "apps\backend\CargoPilot.Infrastructure\CargoPilot.Infrastructure.csproj", "{E77D7D49-8EF0-4E3A-67E8-CA37E299AA5E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.WebAPI", "apps\backend\CargoPilot.WebAPI\CargoPilot.WebAPI.csproj", "{4618B678-DBA1-7394-A174-B0F4FF20BA42}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.Infrastructure.Tests", "apps\backend\CargoPilot.Infrastructure.Tests\CargoPilot.Infrastructure.Tests.csproj", "{CE7ABED3-744E-4A97-8353-C8E57A1DA532}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,6 +38,10 @@ Global
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,6 +52,7 @@ Global
 		{73B7F73A-6F8A-4518-CEF9-C809F44E5ACD} = {270F7A58-C097-D64B-0343-582534E94D4F}
 		{E77D7D49-8EF0-4E3A-67E8-CA37E299AA5E} = {270F7A58-C097-D64B-0343-582534E94D4F}
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42} = {270F7A58-C097-D64B-0343-582534E94D4F}
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532} = {270F7A58-C097-D64B-0343-582534E94D4F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {33884C42-0BAE-4853-8852-85F38E436D95}


### PR DESCRIPTION
## Özet

ClickUp: [F0-02 · Rotasyon kontrolünün her senaryoda tutarlı çalıştığının doğrulanması](https://app.clickup.com/t/86eyjm8c2) — Faz 0 · Hata temizliği · ALG + QA · urgent.

Bu bir **karakterizasyon / regresyon testi** PR'ıdır: mevcut rotasyon davranışı **değiştirilmedi**, yalnızca testle sabitlendi. Faz 1'in altı yüzey modeli gelmeden önce, F2-06'daki eksen rotasyonu değişikliğinin regresyonunun neye göre ölçüleceği bu testlerle netleşiyor.

## Kurulan test altyapısı

- `apps/backend/CargoPilot.Infrastructure.Tests` — yeni xUnit test projesi (`net8.0`), `CargoPilot.Infrastructure`'a proje referansı, kök `cargo-pilot.sln`'e eklendi.
- Test projesinde `<NoWarn>CA1707</NoWarn>` — xUnit'in alt çizgili test adları `Directory.Build.props`'un `TreatWarningsAsErrors` kuralına takılmasın diye.
- **Üretim kodunda tek değişiklik (görünürlük, davranış değil):** `OptimizationEngine.GetOrientations`: `private static` → `internal static`. Yeni `apps/backend/CargoPilot.Infrastructure/AssemblyInfo.cs` içinde `[assembly: InternalsVisibleTo("CargoPilot.Infrastructure.Tests")]`. Metot hâlâ `public` değil; yalnızca test projesine görünür.

**⚠️ Bu PR backend test projesinin sahibidir; F0-01 (#926) ve F0-03 (#925) paralel çalıştığı için `.sln`/`.csproj` çakışmalarını önlemek adına önce bu PR merge edilmelidir.**

## Kapsanan senaryolar (16 backend test)

`OptimizationEngineOrientationTests.cs` (11 test):
- Her `AllowedRotations` değeri (`Fixed`, `NoVertical`, `NoYaw`, `PitchOnly`, `RollOnly`, `All`) için `GetOrientations` çıktısının tam permütasyon kümesi.
- Eksen kilidi değişmezleri: `PitchOnly` → W sabit X'te, `RollOnly` → L sabit Z'de, `NoVertical` → H sabit Y'de.
- `NoYaw` çıktısında Yaw/YawPitch/RollYaw sızıntısı olmadığının doğrulanması.
- Simetrik kutu (W=H=L) sınır durumu: 6 farklı rotasyon etiketi aynı boyutlara çöker.

`OptimizationEngineRotationPlacementTests.cs` (5 test) — motor seviyesi `Run()` davranışı:
- Yalnızca döndürülünce sığan kutu: `Fixed` ile `InsufficientSpace`, `All` ile Yaw rotasyonuyla yerleşir.
- `RollOnly` vs `Fixed` karşıtlığı: RollOnly Roll rotasyonuyla yerleşir (L ekseni Z'de kilitli kalır), aynı kutu/araç Fixed ile yerleşemez.
- `PitchOnly` vs `Fixed` karşıtlığı: PitchOnly Pitch rotasyonuyla yerleşir (W ekseni X'te kilitli kalır), aynı kutu/araç Fixed ile yerleşemez.
- Rotasyon kısıtı yüzünden yerleşemeyen kutunun raporlanan `UnplacedReason`'ının karakterizasyonu (bkz. tutarsızlık notu aşağıda).

Frontend: `apps/frontend/src/lib/utils/geometry/boxOrientations.test.ts` — mevcut 6 face-down preset ve `allowRotateX`/`allowRotateZ` kombinasyonları zaten kapsanıyordu; **`allowFace*` (allowFaceBottom/Top/Front/Back/Left/Right) kısıtları hiç test edilmiyordu**, 13 yeni test eklendi (tekil yüz reddi, eksen+yüz kombinasyonu, `allowedOrientations` filtre sonucu). Kaynak dosyaların davranışı değiştirilmedi.

## Mutation-check sonucu

`GetOrientations`'ın `Fixed` dalına geçici olarak fazladan bir `Yaw` yönelimi sızdırıldı:
- **Kırmızı:** 3 test kırıldı (`Fixed_ReturnsOnlyNoRotationOrientation`, `Fixed_UnplacesBoxThatOnlyFitsWhenRotated`, `RotationConstrainedUnplacedBox_ReportsGenericInsufficientSpaceReason`) — beklenen davranış, testlerin gerçekten dalı kontrol ettiğini kanıtlıyor.
- Değişiklik geri alındı (`git diff` boş — commit edilmedi).
- **Yeşil:** tüm 16 backend test tekrar geçti.

## Tespit edilen tutarsızlıklar (kodla düzeltilmedi, Faz 1 için not)

1. `UnplacedReason` enum'ındaki `RotationOrGeometryConstraint`, `StackingNotAllowed`, `FragilityOrHandlingConstraint`, `Other`, `Unknown` üyeleri `OptimizationEngine` tarafından hiç atanmıyor; motor yalnızca `InsufficientSpace` ve `WeightLimitExceeded` üretiyor (`SegregationOrCompatibility` ise `ContaminationFilter` içinde ayrıca kullanılıyor). Rotasyon kısıtı yüzünden yerleşemeyen bir kutu, spesifik `RotationOrGeometryConstraint` yerine genel `InsufficientSpace` ile raporlanıyor. Bu davranış `RotationConstrainedUnplacedBox_ReportsGenericInsufficientSpaceReason` testiyle sabitlendi.
2. Backend'in 6 eksen-permütasyonu modeli (`AllowedRotations` → `LoadingPlanPlacementRotation`) ile frontend'in 6 yüz-aşağı preset modeli (`BOX_ORIENTATIONS`) farklı soyutlamalar — Faz 1'in "altı yüzey modeli" birleştirme işinin girdisi olabilir.
3. `apps/backend/CargoPilot.slnx` CI tarafından kullanılmıyor (CI kök `cargo-pilot.sln` üzerinden çalışıyor); bu PR de `CargoPilot.slnx`'e dokunmadı.

## Kalite kapıları

- Docker ile `dotnet build cargo-pilot.sln --configuration Release`: **0 Warning, 0 Error**.
- Docker ile `dotnet test cargo-pilot.sln --configuration Release`: **16/16 geçti**.
- `npm run lint`: temiz.
- `npm run format:check`: temiz.
- `npm run test:ci`: **136/136 geçti** (14 test dosyası).

## Test planı

- [x] Backend build (Docker, Release) hatasız.
- [x] Backend testleri (Docker, Release) 16/16 yeşil.
- [x] Mutation-check: kırmızı → geri alma → yeşil doğrulandı.
- [x] Frontend lint / format:check / test:ci temiz.
- [ ] CI'da `Backend CI` ve `Frontend CI` kontrol edilecek (`gh pr checks`).