### PR TITLE
Terfi: dev → test (Faz 0 hata temizliği)

### DIFF
--- a/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+
+    <!-- xUnit alt çizgili test adları CA1707'yi tetikler; Directory.Build.props
+         tüm uyarıları hataya yükseltiyor, bu yüzden test projesinde bilinçli olarak kapatılır. -->
+    <NoWarn>CA1707</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CargoPilot.Infrastructure\CargoPilot.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/apps/backend/CargoPilot.Infrastructure.Tests/GroupZoneTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/GroupZoneTests.cs
@@ -1,0 +1,96 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Services;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// LIFO grup bolgelerinin kapi yonune gore dogru eslendigini sabitler.
+/// Sahne sozlesmesi: arka kapi Z=0, arac onu Z=Length.
+/// UnloadingOrder=1 ilk inecek gruptur, bu yuzden kapiya en yakin olmalidir.
+/// </summary>
+public sealed class GroupZoneTests
+{
+    private const decimal VehicleWidth = 100m;
+    private const decimal VehicleHeight = 100m;
+    private const decimal VehicleLength = 300m;
+    private const decimal BoxLength = 50m;
+    private const decimal ZoneSize = VehicleLength / 3m;
+
+    [Fact]
+    public void Lifo_IlkInecekGrup_KapiyaEnYakinBolgeyeYerlesir()
+    {
+        var (result, itemsByOrder) = RunWithThreeGroups();
+
+        var zByOrder = itemsByOrder.ToDictionary(
+            pair => pair.Key,
+            pair => SinglePlacement(result, pair.Value).Z);
+
+        Assert.True(zByOrder[1] < zByOrder[2],
+            $"unloadingOrder=1 kapiya daha yakin olmali. Z: 1={zByOrder[1]}, 2={zByOrder[2]}");
+        Assert.True(zByOrder[2] < zByOrder[3],
+            $"unloadingOrder=2, 3'ten kapiya daha yakin olmali. Z: 2={zByOrder[2]}, 3={zByOrder[3]}");
+    }
+
+    [Fact]
+    public void Lifo_HerGrup_KendiBolgesininSinirlariIcindeKalir()
+    {
+        var (result, itemsByOrder) = RunWithThreeGroups();
+
+        foreach (var (unloadingOrder, itemId) in itemsByOrder)
+        {
+            var zoneStart = (unloadingOrder - 1) * ZoneSize;
+            var zoneEnd = unloadingOrder * ZoneSize;
+            var placement = SinglePlacement(result, itemId);
+
+            Assert.True(placement.Z >= zoneStart && placement.Z + placement.Depth <= zoneEnd,
+                $"unloadingOrder={unloadingOrder} bolgesi [{zoneStart},{zoneEnd}] disinda: " +
+                $"Z={placement.Z}, derinlik={placement.Depth}");
+        }
+    }
+
+    private static (OptimizationResult Result, Dictionary<int, Guid> ItemsByOrder) RunWithThreeGroups()
+    {
+        var itemsByOrder = new Dictionary<int, Guid>();
+        var items = new List<OptimizationItemInput>();
+
+        foreach (var unloadingOrder in new[] { 1, 2, 3 })
+        {
+            var item = CreateItem(unloadingOrder);
+            itemsByOrder[unloadingOrder] = item.ItemId;
+            items.Add(item);
+        }
+
+        var input = new OptimizationInput(
+            VehicleWidth,
+            VehicleHeight,
+            VehicleLength,
+            VehicleMaxWeight: 10_000m,
+            items,
+            LoadingPlanOptimizationCriteria.Lifo,
+            LoadingType.Rear);
+
+        return (new OptimizationEngine().Run(input), itemsByOrder);
+    }
+
+    private static PlacedItemResult SinglePlacement(OptimizationResult result, Guid itemId)
+        => Assert.Single(result.Placements, p => p.ItemId == itemId);
+
+    private static OptimizationItemInput CreateItem(int unloadingOrder)
+        => new(
+            ItemId: Guid.NewGuid(),
+            SKU: $"SKU-{unloadingOrder}",
+            Name: $"Urun {unloadingOrder}",
+            ImageUrl: null,
+            Width: VehicleWidth,
+            Height: VehicleHeight,
+            Length: BoxLength,
+            Weight: 100m,
+            IsStackable: false,
+            MaxStackCount: 1,
+            MaxWeightOnTop: 0m,
+            AllowedRotations: AllowedRotations.Fixed,
+            Quantity: 1,
+            GroupId: Guid.NewGuid(),
+            UnloadingOrder: unloadingOrder);
+}

--- a/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineOrientationTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineOrientationTests.cs
@@ -1,0 +1,188 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Services;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// OptimizationEngine.GetOrientations karakterizasyon testleri.
+///
+/// Amaç: Faz 1'de altı yüzey modeli gelmeden önce mevcut altı AllowedRotations
+/// değerinin ürettiği (w, h, d, rotation) permütasyon kümesini testle sabitlemek.
+/// Bu testler davranışı DEĞİŞTİRMEZ; yalnızca mevcut davranışı kayıt altına alır.
+/// F2-06'daki eksen rotasyonu değişikliğinin regresyonu bu testlere göre ölçülür.
+/// </summary>
+public class OptimizationEngineOrientationTests
+{
+    private static OptimizationItemInput CreateItem(
+        decimal width, decimal height, decimal length, AllowedRotations rotations) =>
+        new(
+            ItemId: Guid.NewGuid(),
+            SKU: "SKU-1",
+            Name: "Test Item",
+            ImageUrl: null,
+            Width: width,
+            Height: height,
+            Length: length,
+            Weight: 10m,
+            IsStackable: true,
+            MaxStackCount: 0,
+            MaxWeightOnTop: 0m,
+            AllowedRotations: rotations,
+            Quantity: 1);
+
+    // ── Tam permütasyon kümesi testleri ────────────────────────────────────
+
+    [Fact]
+    public void Fixed_ReturnsOnlyNoRotationOrientation()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.Fixed);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [(100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation)],
+            orientations);
+    }
+
+    [Fact]
+    public void NoVertical_ReturnsNoRotationAndYawOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoVertical);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (30m, 50m, 100m, LoadingPlanPlacementRotation.Yaw)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void NoYaw_ReturnsNoRotationRollAndPitchOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoYaw);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (50m, 100m, 30m, LoadingPlanPlacementRotation.Roll),
+                (100m, 30m, 50m, LoadingPlanPlacementRotation.Pitch)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void PitchOnly_ReturnsNoRotationAndPitchOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.PitchOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (100m, 30m, 50m, LoadingPlanPlacementRotation.Pitch)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void RollOnly_ReturnsNoRotationAndRollOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.RollOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (50m, 100m, 30m, LoadingPlanPlacementRotation.Roll)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void All_ReturnsAllSixOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.All);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (30m, 50m, 100m, LoadingPlanPlacementRotation.Yaw),
+                (50m, 100m, 30m, LoadingPlanPlacementRotation.Roll),
+                (100m, 30m, 50m, LoadingPlanPlacementRotation.Pitch),
+                (50m, 30m, 100m, LoadingPlanPlacementRotation.YawPitch),
+                (30m, 100m, 50m, LoadingPlanPlacementRotation.RollYaw)
+            ],
+            orientations);
+    }
+
+    // ── Eksen kilidi değişmezleri ───────────────────────────────────────────
+
+    [Fact]
+    public void PitchOnly_KeepsWidthLockedOnXAxis()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.PitchOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.All(orientations, o => Assert.Equal(item.Width, o.w));
+    }
+
+    [Fact]
+    public void RollOnly_KeepsLengthLockedOnZAxis()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.RollOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.All(orientations, o => Assert.Equal(item.Length, o.d));
+    }
+
+    [Fact]
+    public void NoVertical_KeepsHeightLockedOnYAxis()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoVertical);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.All(orientations, o => Assert.Equal(item.Height, o.h));
+    }
+
+    // ── Yasak eksen sızıntısı yok ────────────────────────────────────────────
+
+    [Fact]
+    public void NoYaw_DoesNotLeakYawRotations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoYaw);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.DoesNotContain(orientations, o =>
+            o.rotation is LoadingPlanPlacementRotation.Yaw
+                or LoadingPlanPlacementRotation.YawPitch
+                or LoadingPlanPlacementRotation.RollYaw);
+    }
+
+    // ── Simetrik kutu sınır durumu ───────────────────────────────────────────
+
+    [Fact]
+    public void SymmetricBox_AllSixRotationLabelsCollapseToSameDimensions()
+    {
+        var item = CreateItem(40m, 40m, 40m, AllowedRotations.All);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(6, orientations.Length);
+        Assert.Equal(6, orientations.Select(o => o.rotation).Distinct().Count());
+        Assert.All(orientations, o => Assert.Equal((40m, 40m, 40m), (o.w, o.h, o.d)));
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineRotationPlacementTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineRotationPlacementTests.cs
@@ -1,0 +1,144 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Services;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// OptimizationEngine.Run() motor seviyesi rotasyon yerleştirme karakterizasyon testleri.
+///
+/// Amaç: rotasyon kısıtlarının (AllowedRotations) tüm motor akışı içinde (extreme-point
+/// yerleştirme, sınır/çakışma/destek kontrolleri) tutarlı çalıştığını, kilitli eksenlerin
+/// yerleşen sonuçta sabit kaldığını ve rotasyon yüzünden yerleşemeyen kutuların hangi
+/// UnplacedReason ile raporlandığını mevcut davranışa göre sabitlemek.
+/// </summary>
+public class OptimizationEngineRotationPlacementTests
+{
+    private static readonly OptimizationEngine Engine = new();
+
+    private static OptimizationItemInput CreateItem(
+        decimal width, decimal height, decimal length, AllowedRotations rotations) =>
+        new(
+            ItemId: Guid.NewGuid(),
+            SKU: "SKU-1",
+            Name: "Test Item",
+            ImageUrl: null,
+            Width: width,
+            Height: height,
+            Length: length,
+            Weight: 10m,
+            IsStackable: true,
+            MaxStackCount: 0,
+            MaxWeightOnTop: 0m,
+            AllowedRotations: rotations,
+            Quantity: 1);
+
+    private static OptimizationInput CreateInput(
+        decimal vehicleWidth, decimal vehicleHeight, decimal vehicleLength, OptimizationItemInput item) =>
+        new(
+            VehicleWidth: vehicleWidth,
+            VehicleHeight: vehicleHeight,
+            VehicleLength: vehicleLength,
+            VehicleMaxWeight: 1000m,
+            Items: [item]);
+
+    [Fact]
+    public void Fixed_UnplacesBoxThatOnlyFitsWhenRotated()
+    {
+        // Kutu: W=60 sadece Yaw ile Z eksenine (uzunluk=80) sığar; X (genişlik=50) ve
+        // Y (yükseklik=50) eksenlerine hiçbir yönelimde sığmaz.
+        var item = CreateItem(60m, 20m, 20m, AllowedRotations.Fixed);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, item);
+
+        var result = Engine.Run(input);
+
+        Assert.Empty(result.Placements);
+        var unplaced = Assert.Single(result.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+    }
+
+    [Fact]
+    public void All_PlacesBoxViaYawRotationWhenFixedWouldFail()
+    {
+        var item = CreateItem(60m, 20m, 20m, AllowedRotations.All);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, item);
+
+        var result = Engine.Run(input);
+
+        Assert.Empty(result.UnplacedItems);
+        var placed = Assert.Single(result.Placements);
+        Assert.Equal(LoadingPlanPlacementRotation.Yaw, placed.Rotation);
+        // Yaw: (L, H, W) — item'ın W'si (60) Z eksenine (Depth) taşınır.
+        Assert.Equal(20m, placed.Width);
+        Assert.Equal(20m, placed.Height);
+        Assert.Equal(60m, placed.Depth);
+    }
+
+    [Fact]
+    public void RollOnly_VsFixed_RollPlacesWithLengthLockedOnZ_FixedFails()
+    {
+        // Kutu: W=60 sadece Roll ile Y eksenine (yükseklik=80) taşınırsa sığar.
+        var rollItem = CreateItem(60m, 20m, 20m, AllowedRotations.RollOnly);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 80m, vehicleLength: 50m, rollItem);
+
+        var rollResult = Engine.Run(input);
+
+        Assert.Empty(rollResult.UnplacedItems);
+        var placed = Assert.Single(rollResult.Placements);
+        Assert.Equal(LoadingPlanPlacementRotation.Roll, placed.Rotation);
+        // RollOnly değişmezi: L her zaman Z eksenindedir (kilitli).
+        Assert.Equal(rollItem.Length, placed.Depth);
+
+        var fixedItem = rollItem with { AllowedRotations = AllowedRotations.Fixed };
+        var fixedInput = CreateInput(vehicleWidth: 50m, vehicleHeight: 80m, vehicleLength: 50m, fixedItem);
+
+        var fixedResult = Engine.Run(fixedInput);
+
+        Assert.Empty(fixedResult.Placements);
+        var unplaced = Assert.Single(fixedResult.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+    }
+
+    [Fact]
+    public void PitchOnly_VsFixed_PitchPlacesWithWidthLockedOnX_FixedFails()
+    {
+        // Kutu: H=60 sadece Pitch ile Z eksenine (uzunluk=80) taşınırsa sığar.
+        var pitchItem = CreateItem(20m, 60m, 20m, AllowedRotations.PitchOnly);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, pitchItem);
+
+        var pitchResult = Engine.Run(input);
+
+        Assert.Empty(pitchResult.UnplacedItems);
+        var placed = Assert.Single(pitchResult.Placements);
+        Assert.Equal(LoadingPlanPlacementRotation.Pitch, placed.Rotation);
+        // PitchOnly değişmezi: W her zaman X eksenindedir (kilitli).
+        Assert.Equal(pitchItem.Width, placed.Width);
+
+        var fixedItem = pitchItem with { AllowedRotations = AllowedRotations.Fixed };
+        var fixedInput = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, fixedItem);
+
+        var fixedResult = Engine.Run(fixedInput);
+
+        Assert.Empty(fixedResult.Placements);
+        var unplaced = Assert.Single(fixedResult.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+    }
+
+    [Fact]
+    public void RotationConstrainedUnplacedBox_ReportsGenericInsufficientSpaceReason()
+    {
+        // Karakterizasyon notu: motor, rotasyon kısıtı yüzünden yerleşemeyen kutuları
+        // UnplacedReason.RotationOrGeometryConstraint yerine genel InsufficientSpace ile
+        // raporluyor. RotationOrGeometryConstraint şu an motor tarafından hiç atanmıyor.
+        // Bu test mevcut davranışı sabitler; Faz 1'de daha spesifik nedenlendirme
+        // eklenirse bilinçli olarak güncellenmelidir.
+        var item = CreateItem(60m, 20m, 20m, AllowedRotations.Fixed);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, item);
+
+        var result = Engine.Run(input);
+
+        var unplaced = Assert.Single(result.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+        Assert.NotEqual(UnplacedReason.RotationOrGeometryConstraint, unplaced.Reason);
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineTests.cs
@@ -1,0 +1,136 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Services;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// OptimizationEngine.cs:52 - bölge eşleşmesi olmayan kutularda fantom ceza
+/// düzeltmesini doğrular. Eşleşme olmadığında (TryGetValue false döndüğünde)
+/// zoneStart/zoneEnd artık null kalır; eskiden default (0,0) struct değeri
+/// kullanılıyordu ve bu, kutuları Z=0'a (kapıya) zorlayan devasa bir ceza
+/// üretiyordu.
+/// </summary>
+public sealed class OptimizationEngineTests
+{
+    /// <summary>
+    /// WeightBalance kriterinde bölge tanımı olmayan (grupsuz) kutularda fantom
+    /// ceza uygulanmadığını doğrular. Düzeltme öncesi zonePenalty = (0 + ez + d) *
+    /// 2000 şeklinde her kutuyu Z=0'a çekiyordu; bu da ağırlık merkezini araç
+    /// uzunluğunun ortasından uzaklaştırıyordu. Düzeltme sonrası dağılım yalnızca
+    /// balancePenalty tarafından belirlenir ve ağırlık merkezi araç ortasına
+    /// (halfL) yakın kalır.
+    /// </summary>
+    [Fact]
+    public void WeightBalance_NoZoneDefinition_NoPhantomPenalty()
+    {
+        var items = new List<OptimizationItemInput>
+        {
+            CreateItem(weight: 200m, unloadingOrder: null, groupId: null)
+        };
+        for (var i = 0; i < 6; i++)
+            items.Add(CreateItem(weight: 50m, unloadingOrder: null, groupId: null));
+
+        var input = new OptimizationInput(
+            VehicleWidth: 200m,
+            VehicleHeight: 200m,
+            VehicleLength: 300m,
+            VehicleMaxWeight: 1000m,
+            items,
+            LoadingPlanOptimizationCriteria.WeightBalance,
+            LoadingType.Rear);
+
+        var result = new OptimizationEngine().Run(input);
+
+        Assert.Equal(items.Count, result.Placements.Count);
+        Assert.Empty(result.UnplacedItems);
+
+        // Ağırlık merkezi araç uzunluğunun (300) ortasına (150) yakın olmalı.
+        // Fantom ceza varken kutular Z=0'a yığılır ve CoG 100'ün altına düşer.
+        Assert.NotNull(result.CenterOfGravityZ);
+        Assert.InRange(result.CenterOfGravityZ!.Value, 100m, 200m);
+    }
+
+    /// <summary>
+    /// Lifo + LoadingType.Rear + birden fazla grup senaryosunda bölge cezasının
+    /// hâlâ uygulandığını doğrular (regresyon testi). Bu, F0-03 düzeltmesinin
+    /// geçerli bölge eşleşmelerini bozmadığını garanti eder.
+    ///
+    /// Kasıtlı olarak yöne bağımsızdır: hangi grubun kapıya (Z=0) yakın bölgeye
+    /// düştüğü F0-01'in sorumluluğudur ve orada (GroupZoneTests) doğrulanır.
+    /// Burada yalnızca her grubun kendi UnloadingOrder'ına ait, zoneSize
+    /// genişliğindeki dilime toplandığı ve iki grubun farklı, çakışmayan
+    /// dilimlere düştüğü doğrulanır.
+    /// </summary>
+    [Fact]
+    public void Lifo_MultipleGroups_ZonePenaltyApplied()
+    {
+        const decimal vehicleLength = 200m;
+        const decimal zoneSize = vehicleLength / 2m;
+
+        var group2Box1 = CreateItem(weight: 50m, unloadingOrder: 2, groupId: Guid.NewGuid());
+        var group2Box2 = CreateItem(weight: 50m, unloadingOrder: 2, groupId: group2Box1.GroupId);
+        var group1Box = CreateItem(weight: 50m, unloadingOrder: 1, groupId: Guid.NewGuid());
+        var ungrouped = CreateItem(weight: 50m, unloadingOrder: null, groupId: null);
+
+        var items = new List<OptimizationItemInput> { group2Box1, group2Box2, group1Box, ungrouped };
+
+        var input = new OptimizationInput(
+            VehicleWidth: 50m,
+            VehicleHeight: 50m,
+            VehicleLength: vehicleLength,
+            VehicleMaxWeight: 500m,
+            items,
+            LoadingPlanOptimizationCriteria.Lifo,
+            LoadingType.Rear);
+
+        var result = new OptimizationEngine().Run(input);
+
+        Assert.Equal(4, result.Placements.Count);
+        Assert.Empty(result.UnplacedItems);
+
+        var group1Placement = Assert.Single(result.Placements, p => p.ItemId == group1Box.ItemId);
+        var group2Placements = new[] { group2Box1, group2Box2 }
+            .Select(item => Assert.Single(result.Placements, p => p.ItemId == item.ItemId))
+            .ToList();
+
+        // Grup 1'in düştüğü bölge dilimi ne olursa olsun (kapıya yakın ya da uzak),
+        // tek kutusu o dilimin dışına taşmamalı.
+        var group1Zone = ZoneIndex(group1Placement.Z, zoneSize);
+        Assert.True(WithinZone(group1Placement, group1Zone, zoneSize),
+            $"Grup 1 kutusu kendi bölge dilimi [{group1Zone * zoneSize},{(group1Zone + 1) * zoneSize}] dışında: Z={group1Placement.Z}, derinlik={group1Placement.Depth}");
+
+        foreach (var placement in group2Placements)
+        {
+            var group2Zone = ZoneIndex(placement.Z, zoneSize);
+            Assert.True(WithinZone(placement, group2Zone, zoneSize),
+                $"Grup 2 kutusu kendi bölge dilimi [{group2Zone * zoneSize},{(group2Zone + 1) * zoneSize}] dışında: Z={placement.Z}, derinlik={placement.Depth}");
+
+            // İki grup, aynı bölge dilimini paylaşmamalı (bölge cezası ayrıştırıyor).
+            Assert.NotEqual(group1Zone, group2Zone);
+        }
+    }
+
+    private static int ZoneIndex(decimal z, decimal zoneSize) => (int)(z / zoneSize);
+
+    private static bool WithinZone(PlacedItemResult placement, int zoneIndex, decimal zoneSize)
+        => placement.Z >= zoneIndex * zoneSize && placement.Z + placement.Depth <= (zoneIndex + 1) * zoneSize;
+
+    private static OptimizationItemInput CreateItem(decimal weight, int? unloadingOrder, Guid? groupId)
+        => new(
+            ItemId: Guid.NewGuid(),
+            SKU: $"SKU-{Guid.NewGuid():N}",
+            Name: "Test Ürünü",
+            ImageUrl: null,
+            Width: 50m,
+            Height: 50m,
+            Length: 50m,
+            Weight: weight,
+            IsStackable: false,
+            MaxStackCount: 1,
+            MaxWeightOnTop: 0m,
+            AllowedRotations: AllowedRotations.Fixed,
+            Quantity: 1,
+            GroupId: groupId,
+            UnloadingOrder: unloadingOrder);
+}

--- a/apps/backend/CargoPilot.Infrastructure/AssemblyInfo.cs
+++ b/apps/backend/CargoPilot.Infrastructure/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// Test projesinin internal üyelere (ör. OptimizationEngine.GetOrientations) erişebilmesi için.
+// Üretim davranışını değiştirmez; yalnızca test görünürlüğü sağlar.
+[assembly: InternalsVisibleTo("CargoPilot.Infrastructure.Tests")]

--- a/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
@@ -56,7 +56,13 @@ internal sealed class OptimizationEngine : IOptimizationEngine
                 continue;
             }
 
-            groupZones.TryGetValue(item.UnloadingOrder ?? -1, out var zone);
+            decimal? zoneStart = null;
+            decimal? zoneEnd = null;
+            if (groupZones.TryGetValue(item.UnloadingOrder ?? -1, out var zone))
+            {
+                zoneStart = zone.ZStart;
+                zoneEnd = zone.ZEnd;
+            }
 
             PlacedBox? best = null;
             var bestScore = decimal.MaxValue;
@@ -82,7 +88,7 @@ internal sealed class OptimizationEngine : IOptimizationEngine
                         item.Weight, totalWeight,
                         momentX, momentZ,
                         halfW, halfL,
-                        zone.ZStart, zone.ZEnd);
+                        zoneStart, zoneEnd);
 
                     if (score < bestScore)
                     {

--- a/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
@@ -37,6 +37,13 @@ internal sealed class OptimizationEngine : IOptimizationEngine
 
         var groupZones = ComputeGroupZones(instances, input.VehicleLength, input.LoadingType, input.Criteria);
 
+        // LIFO bölgeleri de aynı nedenle tohumlanır: aday noktalar yalnızca
+        // yerleştirilmiş kutulara komşu doğduğu için ilk yüklenen grup her zaman
+        // Z=0'a, yani kapının önüne düşüyordu. Her bölgenin başlangıcı aday
+        // yapılınca grup kendi bölgesinden başlayarak dolar.
+        foreach (var zoneStart in groupZones.Values.Select(z => z.ZStart).Where(z => z > 0m))
+            extremePoints.Add((0m, 0m, zoneStart));
+
         foreach (var item in instances)
         {
             // Her kutu için aday pozisyon taraması pahalıdır; iptal edilen istekte
@@ -147,8 +154,11 @@ internal sealed class OptimizationEngine : IOptimizationEngine
     }
 
     // ── Grup zone hesaplama ───────────────────────────────────────────────────
-    // Gruplara ait distinct UnloadingOrder değerlerini DESC sıralar ve kamyon
-    // uzunluğunu eşit bölümlere ayırır. 0-1 grup varsa zone uygulanmaz.
+    // Arka kapı Z=0'dadır. UnloadingOrder=1 ilk inecek gruptur, bu yüzden kapıya
+    // en yakın (en küçük Z) bölgeye düşer. Distinct UnloadingOrder değerleri ASC
+    // sıralanır ve kamyon uzunluğu eşit bölümlere ayrılır; sıradaki her grup bir
+    // sonraki bölgeye, yani kapıdan daha uzağa yerleşir. 0-1 grup varsa zone
+    // uygulanmaz.
     private static Dictionary<int, (decimal ZStart, decimal ZEnd)> ComputeGroupZones(
         IReadOnlyList<OptimizationItemInput> items,
         decimal vehicleLength,
@@ -163,7 +173,7 @@ internal sealed class OptimizationEngine : IOptimizationEngine
             .Where(i => i.GroupId.HasValue && i.UnloadingOrder.HasValue)
             .Select(i => i.UnloadingOrder!.Value)
             .Distinct()
-            .OrderByDescending(o => o)
+            .OrderBy(o => o)
             .ToList();
 
         if (orders.Count <= 1)
@@ -180,7 +190,8 @@ internal sealed class OptimizationEngine : IOptimizationEngine
 
     // ── Grup-bilinçli sıralama ────────────────────────────────────────────────
     // GroupId'si olan items yükleme sırasına göre sıralanır:
-    // yüksek UnloadingOrder = araç arkası = önce yüklenir (DESC sıra).
+    // yüksek UnloadingOrder = en son inecek grup = kapıdan en uzak bölge
+    // (arka kapıda Z=length tarafı) = önce yüklenir (DESC sıra).
     // GroupId'si olmayan items en sona eklenir.
     // Grup yoksa mevcut criteria-based sıralama uygulanır.
     private static List<OptimizationItemInput> SortForGroupPlacement(

--- a/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
@@ -405,7 +405,7 @@ internal sealed class OptimizationEngine : IOptimizationEngine
         };
     }
 
-    private static (decimal w, decimal h, decimal d, LoadingPlanPlacementRotation rotation)[]
+    internal static (decimal w, decimal h, decimal d, LoadingPlanPlacementRotation rotation)[]
         GetOrientations(OptimizationItemInput item)
     {
         var (W, H, L) = (item.Width, item.Height, item.Length);

--- a/apps/backend/CargoPilot.slnx
+++ b/apps/backend/CargoPilot.slnx
@@ -7,6 +7,7 @@
   </Folder>
   <Folder Name="/Infrastructure/">
     <Project Path="CargoPilot.Infrastructure/CargoPilot.Infrastructure.csproj" Id="84e3f1c2-5401-4196-8309-a9815dd1c50d" />
+    <Project Path="CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj" Id="a2b8c7d3-6e9f-4b1a-c3d5-e8f9a0b1c2d3" />
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />

--- a/apps/frontend/src/lib/utils/geometry/boxOrientations.test.ts
+++ b/apps/frontend/src/lib/utils/geometry/boxOrientations.test.ts
@@ -102,6 +102,37 @@ describe('isOrientationAllowed', () => {
       expect(isOrientationAllowed(item, idx as 0 | 1 | 2 | 3 | 4 | 5)).toBe(true);
     }
   });
+
+  it.each([
+    [0, 'allowFaceBottom'],
+    [1, 'allowFaceTop'],
+    [2, 'allowFaceFront'],
+    [3, 'allowFaceBack'],
+    [4, 'allowFaceLeft'],
+    [5, 'allowFaceRight'],
+  ] as const)('idx %i → %s=false o orientation için reddeder', (idx, faceKey) => {
+    const item = makeItem({ [faceKey]: false });
+    expect(isOrientationAllowed(item, idx)).toBe(false);
+  });
+
+  it('allowFace*=false diğer indexleri etkilemez', () => {
+    const item = makeItem({ allowFaceTop: false });
+    expect(isOrientationAllowed(item, 0)).toBe(true);
+    expect(isOrientationAllowed(item, 2)).toBe(true);
+    expect(isOrientationAllowed(item, 3)).toBe(true);
+    expect(isOrientationAllowed(item, 4)).toBe(true);
+    expect(isOrientationAllowed(item, 5)).toBe(true);
+  });
+
+  it('eksen izinli olsa da yüz kısıtı reddederse orientation izinsizdir', () => {
+    const item = makeItem({ allowRotateX: true, allowFaceFront: false });
+    expect(isOrientationAllowed(item, 2)).toBe(false);
+  });
+
+  it('yüz izinli olsa da eksen kısıtı reddederse orientation izinsizdir', () => {
+    const item = makeItem({ allowRotateX: false, allowFaceFront: true });
+    expect(isOrientationAllowed(item, 2)).toBe(false);
+  });
 });
 
 describe('allowedOrientations', () => {
@@ -120,5 +151,15 @@ describe('allowedOrientations', () => {
   it('hepsi kapalı → sadece identity (idx 0)', () => {
     const item = makeItem({ allowRotateX: false, allowRotateZ: false });
     expect(allowedOrientations(item)).toEqual([0]);
+  });
+
+  it('allowFaceTop=false → idx 1 hariç tüm eksen-izinli set döner', () => {
+    const item = makeItem({ allowFaceTop: false });
+    expect(allowedOrientations(item)).toEqual([0, 2, 3, 4, 5]);
+  });
+
+  it('allowRotateX=false + allowFaceLeft=false birlikte → sadece 0, 5', () => {
+    const item = makeItem({ allowRotateX: false, allowFaceLeft: false });
+    expect(allowedOrientations(item)).toEqual([0, 5]);
   });
 });

--- a/cargo-pilot.sln
+++ b/cargo-pilot.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -13,6 +13,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.Infrastructure", "apps\backend\CargoPilot.Infrastructure\CargoPilot.Infrastructure.csproj", "{E77D7D49-8EF0-4E3A-67E8-CA37E299AA5E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.WebAPI", "apps\backend\CargoPilot.WebAPI\CargoPilot.WebAPI.csproj", "{4618B678-DBA1-7394-A174-B0F4FF20BA42}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.Infrastructure.Tests", "apps\backend\CargoPilot.Infrastructure.Tests\CargoPilot.Infrastructure.Tests.csproj", "{CE7ABED3-744E-4A97-8353-C8E57A1DA532}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,6 +38,10 @@ Global
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,6 +52,7 @@ Global
 		{73B7F73A-6F8A-4518-CEF9-C809F44E5ACD} = {270F7A58-C097-D64B-0343-582534E94D4F}
 		{E77D7D49-8EF0-4E3A-67E8-CA37E299AA5E} = {270F7A58-C097-D64B-0343-582534E94D4F}
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42} = {270F7A58-C097-D64B-0343-582534E94D4F}
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532} = {270F7A58-C097-D64B-0343-582534E94D4F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {33884C42-0BAE-4853-8852-85F38E436D95}


### PR DESCRIPTION
Faz 0 hata temizliği tamamlandı; üç görev `dev`'e alındı ve test ortamına terfi ediyor.

## İçerik

| Görev | PR | Özet |
|---|---|---|
| F0-02 · Rotasyon kontrolünün doğrulanması | #927 | Backend birim test projesi (`CargoPilot.Infrastructure.Tests`) kuruldu; 16 rotasyon karakterizasyon testi + frontend'e 13 `allowFace*` senaryosu eklendi. Üretim davranışı değişmedi. |
| F0-01 · Kapı yönü hatalarının giderilmesi | #926 | LIFO bölge → Z eşlemesi ters çalışıyordu; `ComputeGroupZones` artık `UnloadingOrder` değerlerini artan sıralıyor, `unloadingOrder=1` (ilk inecek) kapıya en yakın bölgeye düşüyor. Ayrıca bölge başlangıçları extreme point olarak tohumlandı — aksi hâlde hiçbir grup kendi bölgesine ulaşamıyordu. |
| F0-03 · Fantom bölge cezasının kaldırılması | #925 | `TryGetValue` dönüş değeri yok sayıldığı için bölgesi olmayan her kutu `(ez + d) * 2000` sabit cezası alıyordu; bu her kriterde geçerliydi ve ağırlık dengesi kriterini işlevsiz bırakıyordu. Eşleşme yoksa artık `null` bölge geçiliyor, ceza 0 kalıyor. |

## Doğrulama

- Birleşik `dev` ağacında `dotnet test cargo-pilot.sln -c Release`: **20/20 test geçiyor** (16 rotasyon + 2 bölge yönü + 2 fantom ceza).
- Üç PR'ın Backend CI job log'larında testlerin gerçekten koştuğu doğrulandı.
- Her düzeltme mutation-check ile sınandı: düzeltme geri alındığında ilgili testler kırmızıya döndü.

## Kapsam dışı bırakılan, takip gerektiren bulgular

- `LoadingType.Rear` dışındaki kapı yönleri için bölge desteği yok; `ComputeGroupZones` yan/üst kapıda erken dönüyor.
- Frontend `LOADING_TYPE_FROM_INT` eşlemesi backend `LoadingType` enum'ı ile uyumsuz (`SideLeft` → `Top` görünüyor). ClickUp'ta F0-04 olarak açıldı.
- `UnplacedReason` içindeki `RotationOrGeometryConstraint` ve diğer üyeler motor tarafından hiç atanmıyor; rotasyon kısıtı yüzünden yerleşemeyen kutu genel `InsufficientSpace` ile raporlanıyor.
- `apps/backend/CargoPilot.slnx` CI tarafından kullanılmıyor; kayıtlar kök `cargo-pilot.sln` üzerinden yürüyor.
