### PR TITLE
Terfi: dev → test (F0-04 kapı yönü enum eşlemesi)

### DIFF
--- a/apps/frontend/src/features/planning/panels/components/AddVehicleModal.tsx
+++ b/apps/frontend/src/features/planning/panels/components/AddVehicleModal.tsx
@@ -79,11 +79,12 @@ const FORM_VEHICLE_TYPE_INT: Record<string, number> = {
   konteyner: 3,
 };
 
+// Backend LoadingType: Rear=0, SideRight=1, SideLeft=2, SideBoth=3, Top=4.
+// Bu modalde sağ/sol kapı seçimi yok; "yan" seçimi varsayılan olarak SideRight'a eşlenir.
 const LOADING_AREA_INT: Record<string, number> = {
   arka: 0,
   yan: 1,
-  ust: 2,
-  'arka-yan': 3,
+  ust: 4,
 };
 
 export function AddVehicleModal({ open, onOpenChange, onCreated }: AddVehicleModalProps) {

--- a/apps/frontend/src/lib/api/loadingPlanMappers.ts
+++ b/apps/frontend/src/lib/api/loadingPlanMappers.ts
@@ -8,7 +8,7 @@ import type {
 import type { Item } from '@/lib/types/item';
 import type { Vehicle } from '@/lib/types/vehicle';
 import { VehicleType, DoorDirection } from '@/lib/types/vehicle';
-import { VEHICLE_TYPE_FROM_INT, LOADING_TYPE_FROM_INT } from './vehicleMappers';
+import { VEHICLE_TYPE_FROM_INT, resolveLoadingType } from './vehicleMappers';
 import { type OrientationIndex } from '@/lib/utils/geometry/boxOrientations';
 import { resolveProductColor, COLOR_FALLBACK } from '@/lib/config/productColors';
 
@@ -419,7 +419,7 @@ export function fromApiPlanListItem(api: PlanListApiItem): LoadingPlanListItem {
     0;
   const rawCreatedAt = api.createdAt ?? api.createdAtUtc ?? new Date(0).toISOString();
   const createdAt = normalizeUtcDatetime(rawCreatedAt);
-  const loadingType = v?.loadingType ?? null;
+  const loadingTypeInfo = resolveLoadingType(v?.loadingType);
   return {
     id: api.id,
     planCode: api.planCode ?? `PLN-${api.id.slice(0, 8).toUpperCase()}`,
@@ -439,8 +439,8 @@ export function fromApiPlanListItem(api: PlanListApiItem): LoadingPlanListItem {
     interiorHeightM: v?.internalHeight ?? 0,
     interiorDepthM: v?.internalLength ?? 0,
     vehicleType: v?.vehicleType != null ? VEHICLE_TYPE_FROM_INT[v.vehicleType] : undefined,
-    doorDirection: loadingType != null ? LOADING_TYPE_FROM_INT[loadingType]?.direction : undefined,
-    doorSide: loadingType != null ? LOADING_TYPE_FROM_INT[loadingType]?.doorSide : undefined,
+    doorDirection: loadingTypeInfo?.direction,
+    doorSide: loadingTypeInfo?.doorSide,
     thumbnailUrl: (() => {
       const raw = ((api as Record<string, unknown>)['thumbnailUrl'] ??
         (api as Record<string, unknown>)['snapshotUrl'] ??
@@ -602,6 +602,7 @@ function apiVehicleToVehicle(
   v: z.infer<typeof planVehicleApiSchema> & { vehicleId?: string },
 ): Vehicle {
   const id = v.vehicleId ?? v.id ?? '';
+  const loadingTypeInfo = resolveLoadingType(v.loadingType);
   return {
     id,
     name: v.vehicleName ?? v.name ?? '—',
@@ -614,11 +615,8 @@ function apiVehicleToVehicle(
       v.vehicleType != null
         ? (VEHICLE_TYPE_FROM_INT[v.vehicleType] ?? VehicleType.Tir)
         : VehicleType.Tir,
-    doorDirection:
-      v.loadingType != null
-        ? (LOADING_TYPE_FROM_INT[v.loadingType]?.direction ?? DoorDirection.Rear)
-        : DoorDirection.Rear,
-    doorSide: v.loadingType != null ? LOADING_TYPE_FROM_INT[v.loadingType]?.doorSide : undefined,
+    doorDirection: loadingTypeInfo?.direction ?? DoorDirection.Rear,
+    doorSide: loadingTypeInfo?.doorSide,
     isFavorite: false,
     isActive: true,
     isDeleted: false,

--- a/apps/frontend/src/lib/api/useVehicles.ts
+++ b/apps/frontend/src/lib/api/useVehicles.ts
@@ -15,7 +15,7 @@ import {
   buildCreateVehiclePayload,
   VEHICLE_TYPE_INT,
   VEHICLE_TYPE_FROM_INT,
-  LOADING_TYPE_FROM_INT,
+  resolveLoadingType,
 } from './vehicleMappers';
 
 // ─── List API response schema ─────────────────────────────────────────────────
@@ -50,7 +50,7 @@ const vehicleListApiItemSchema = z.object({
 type VehicleListApiItem = z.infer<typeof vehicleListApiItemSchema>;
 
 function fromApiVehicleListItem(api: VehicleListApiItem): Vehicle {
-  const loadingTypeInfo = LOADING_TYPE_FROM_INT[api.loadingType ?? 0];
+  const loadingTypeInfo = resolveLoadingType(api.loadingType);
   const kingpin =
     api.kingPinDistanceMm != null && api.kingPinMaxLoadKg != null
       ? {

--- a/apps/frontend/src/lib/api/vehicleMappers.test.ts
+++ b/apps/frontend/src/lib/api/vehicleMappers.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { DoorDirection } from '@/lib/types/vehicle';
+import type { VehicleFormValues } from '@/features/data-management/vehicles/schemas/vehicleSchema';
+import {
+  LOADING_TYPE_FROM_INT,
+  resolveLoadingType,
+  buildCreateVehiclePayload,
+  fromApiVehicle,
+  type VehicleApi,
+} from './vehicleMappers';
+
+function makeApiVehicle(overrides: Partial<VehicleApi> = {}): VehicleApi {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    vehicleName: 'Test Aracı',
+    vehicleType: 0,
+    internalLength: 1000,
+    internalWidth: 240,
+    internalHeight: 260,
+    maxWeightCapacity: 24000,
+    isFavorite: false,
+    isActive: true,
+    isDeleted: false,
+    createdAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+function makeFormValues(overrides: Partial<VehicleFormValues> = {}): VehicleFormValues {
+  return {
+    vehicleType: 'Tir',
+    name: 'Test Aracı',
+    length: 1000,
+    width: 240,
+    height: 260,
+    maxCargoWeight: 24000,
+    doorDirection: 'rear',
+    isActive: true,
+    ...overrides,
+  } as VehicleFormValues;
+}
+
+describe('LOADING_TYPE_FROM_INT — backend LoadingType enum ile hizalama', () => {
+  it('Rear=0 → { direction: rear }', () => {
+    expect(LOADING_TYPE_FROM_INT[0]).toEqual({ direction: DoorDirection.Rear });
+  });
+
+  it('SideRight=1 → { direction: side, doorSide: right }', () => {
+    expect(LOADING_TYPE_FROM_INT[1]).toEqual({
+      direction: DoorDirection.Side,
+      doorSide: 'right',
+    });
+  });
+
+  it('SideLeft=2 → { direction: side, doorSide: left }', () => {
+    expect(LOADING_TYPE_FROM_INT[2]).toEqual({
+      direction: DoorDirection.Side,
+      doorSide: 'left',
+    });
+  });
+
+  it('SideBoth=3 → { direction: side }, doorSide belirsiz bırakılır', () => {
+    expect(LOADING_TYPE_FROM_INT[3]).toEqual({ direction: DoorDirection.Side });
+    expect(LOADING_TYPE_FROM_INT[3].doorSide).toBeUndefined();
+  });
+
+  it('Top=4 → { direction: top }', () => {
+    expect(LOADING_TYPE_FROM_INT[4]).toEqual({ direction: DoorDirection.Top });
+  });
+});
+
+describe('resolveLoadingType', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('null/undefined için undefined döner, uyarı basmaz', () => {
+    expect(resolveLoadingType(null)).toBeUndefined();
+    expect(resolveLoadingType(undefined)).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('bilinmeyen int için undefined döner ve konsola uyarı basar (sessizce yutmaz)', () => {
+    expect(resolveLoadingType(99)).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('99');
+  });
+
+  it('geçerli int için uyarı basmadan doğru eşlemeyi döner', () => {
+    expect(resolveLoadingType(2)).toEqual({ direction: DoorDirection.Side, doorSide: 'left' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('fromApiVehicle — backend loadingType int → Vehicle.doorDirection/doorSide', () => {
+  it.each([
+    [0, DoorDirection.Rear, undefined],
+    [1, DoorDirection.Side, 'right'],
+    [2, DoorDirection.Side, 'left'],
+    [3, DoorDirection.Side, undefined],
+    [4, DoorDirection.Top, undefined],
+  ] as const)('loadingType=%i → direction=%s doorSide=%s', (loadingType, direction, doorSide) => {
+    const vehicle = fromApiVehicle(makeApiVehicle({ loadingType }));
+    expect(vehicle.doorDirection).toBe(direction);
+    expect(vehicle.doorSide).toBe(doorSide);
+  });
+
+  it('bilinmeyen loadingType için Front varsayılanına düşer', () => {
+    const vehicle = fromApiVehicle(makeApiVehicle({ loadingType: 42 }));
+    expect(vehicle.doorDirection).toBe(DoorDirection.Front);
+    expect(vehicle.doorSide).toBeUndefined();
+  });
+
+  it('loadingType null için Front varsayılanına düşer', () => {
+    const vehicle = fromApiVehicle(makeApiVehicle({ loadingType: null }));
+    expect(vehicle.doorDirection).toBe(DoorDirection.Front);
+  });
+});
+
+describe('buildCreateVehiclePayload — frontend DoorDirection → backend loadingType int', () => {
+  it('rear → 0', () => {
+    const payload = buildCreateVehiclePayload(makeFormValues({ doorDirection: 'rear' }));
+    expect(payload.loadingType).toBe(0);
+  });
+
+  it('side + doorSide=right → 1 (SideRight)', () => {
+    const payload = buildCreateVehiclePayload(
+      makeFormValues({ doorDirection: 'side', doorSide: 'right' }),
+    );
+    expect(payload.loadingType).toBe(1);
+  });
+
+  it('side + doorSide=left → 2 (SideLeft)', () => {
+    const payload = buildCreateVehiclePayload(
+      makeFormValues({ doorDirection: 'side', doorSide: 'left' }),
+    );
+    expect(payload.loadingType).toBe(2);
+  });
+
+  it('side + doorSide belirtilmemiş → 1 (SideRight varsayılanı)', () => {
+    const payload = buildCreateVehiclePayload(makeFormValues({ doorDirection: 'side' }));
+    expect(payload.loadingType).toBe(1);
+  });
+
+  it('top → 4', () => {
+    const payload = buildCreateVehiclePayload(makeFormValues({ doorDirection: 'top' }));
+    expect(payload.loadingType).toBe(4);
+  });
+
+  it.each([0, 1, 2, 4] as const)(
+    'round-trip: backend int %i → frontend değerler → tekrar aynı backend int',
+    (loadingType) => {
+      const vehicle = fromApiVehicle(makeApiVehicle({ loadingType }));
+      const payload = buildCreateVehiclePayload(
+        makeFormValues({ doorDirection: vehicle.doorDirection, doorSide: vehicle.doorSide }),
+      );
+      expect(payload.loadingType).toBe(loadingType);
+    },
+  );
+
+  it('SideBoth=3 round-trip: doorSide belirsiz kaldığı için SideRight (1) olarak geri döner (bilinçli basitleştirme)', () => {
+    const vehicle = fromApiVehicle(makeApiVehicle({ loadingType: 3 }));
+    const payload = buildCreateVehiclePayload(
+      makeFormValues({ doorDirection: vehicle.doorDirection, doorSide: vehicle.doorSide }),
+    );
+    expect(payload.loadingType).toBe(1);
+  });
+});

--- a/apps/frontend/src/lib/api/vehicleMappers.ts
+++ b/apps/frontend/src/lib/api/vehicleMappers.ts
@@ -18,7 +18,7 @@ export const VEHICLE_TYPE_INT = {
   Kamposet: 3, // Romork
 } as const;
 
-// Backend: Rear=0, SideRight=1, SideLeft=2, SideBoth=3, Top=4
+// Backend: Trailer=0, Truck=1, Container=2, Romork=3
 export const VEHICLE_TYPE_FROM_INT: Record<number, VehicleType> = {
   0: VehicleType.Tir,
   1: VehicleType.Kamyon,
@@ -27,15 +27,42 @@ export const VEHICLE_TYPE_FROM_INT: Record<number, VehicleType> = {
 };
 
 // loadingType int → { direction, doorSide }
-// Backend: Rear=0, Side=1, Top=2
+// Backend (CargoPilot.Domain.Enums.LoadingType): Rear=0, SideRight=1, SideLeft=2, SideBoth=3, Top=4
 export const LOADING_TYPE_FROM_INT: Record<
   number,
   { direction: DoorDirection; doorSide?: 'right' | 'left' }
 > = {
   0: { direction: DoorDirection.Rear },
-  1: { direction: DoorDirection.Side },
-  2: { direction: DoorDirection.Top },
+  1: { direction: DoorDirection.Side, doorSide: 'right' },
+  2: { direction: DoorDirection.Side, doorSide: 'left' },
+  // SideBoth: hem sağ hem sol kapı var, frontend'de tek bir "her iki taraf" kavramı yok.
+  // En küçük doğru karşılık: side yönü, doorSide belirsiz bırakılır. loadOrder.ts ve
+  // ContainerMesh/VehiclePreview3D, doorSide tanımsızken sağ kapı varsayımına düşer —
+  // yani SideBoth aracı, sağ kapıdan yükleniyormuş gibi gösterilir/sıralanır (yanlış değil,
+  // eksik bilgiyle en güvenli varsayım).
+  3: { direction: DoorDirection.Side },
+  4: { direction: DoorDirection.Top },
 };
+
+/**
+ * Backend loadingType (int) değerini { direction, doorSide } çiftine çevirir.
+ * - null/undefined: veri yok, `undefined` döner — çağıran taraf kendi varsayılanını uygular.
+ * - Eşleşmeyen/bilinmeyen int (tabloda karşılığı olmayan): backend'e yeni bir LoadingType
+ *   değeri eklenmiş ya da veri bozuk olabilir — sessizce yutulmaz, konsola uyarı basılır ve
+ *   `undefined` döner (çağıran taraf kendi varsayılanına bilinçli olarak düşer).
+ */
+export function resolveLoadingType(
+  loadingType: number | null | undefined,
+): { direction: DoorDirection; doorSide?: 'right' | 'left' } | undefined {
+  if (loadingType == null) return undefined;
+  const mapped = LOADING_TYPE_FROM_INT[loadingType];
+  if (!mapped) {
+    console.warn(
+      `[vehicleMappers] Bilinmeyen loadingType değeri: ${loadingType} — eşleme tablosunda karşılığı yok, varsayılana düşülüyor.`,
+    );
+  }
+  return mapped;
+}
 
 // ─── Backend response schema ──────────────────────────────────────────────────
 
@@ -146,6 +173,7 @@ export function fromApiVehicleDetail(api: VehicleDetailApi): Vehicle {
 
   const vehicleType = VEHICLE_TYPE_FROM_INT[api.vehicleType] ?? VehicleType.Tir;
   const isContainer = vehicleType === VehicleType.Konteyner;
+  const loadingTypeInfo = resolveLoadingType(api.loadingType);
   return {
     id: api.id,
     name: api.vehicleName,
@@ -158,8 +186,8 @@ export function fromApiVehicleDetail(api: VehicleDetailApi): Vehicle {
     height: api.internalHeight,
     maxCargoWeight: api.maxWeightCapacity,
     maxLayerCount: api.layerCount ?? undefined,
-    doorDirection: LOADING_TYPE_FROM_INT[api.loadingType ?? -1]?.direction ?? DoorDirection.Front,
-    doorSide: LOADING_TYPE_FROM_INT[api.loadingType ?? -1]?.doorSide,
+    doorDirection: loadingTypeInfo?.direction ?? DoorDirection.Front,
+    doorSide: loadingTypeInfo?.doorSide,
     kingpin,
     axleB,
     axles: additionalAxle ? [additionalAxle] : undefined,
@@ -207,6 +235,7 @@ export function fromApiVehicle(api: VehicleApi): Vehicle {
 
   const vehicleType = VEHICLE_TYPE_FROM_INT[api.vehicleType] ?? VehicleType.Tir;
   const isContainer = vehicleType === VehicleType.Konteyner;
+  const loadingTypeInfo = resolveLoadingType(api.loadingType);
   return {
     id: api.id,
     name: api.vehicleName,
@@ -221,8 +250,8 @@ export function fromApiVehicle(api: VehicleApi): Vehicle {
     grossWeight: api.grossWeight ?? undefined,
     tareWeight: api.tareWeight ?? undefined,
     maxLayerCount: api.layerCount ?? undefined,
-    doorDirection: LOADING_TYPE_FROM_INT[api.loadingType ?? -1]?.direction ?? DoorDirection.Front,
-    doorSide: LOADING_TYPE_FROM_INT[api.loadingType ?? -1]?.doorSide,
+    doorDirection: loadingTypeInfo?.direction ?? DoorDirection.Front,
+    doorSide: loadingTypeInfo?.doorSide,
     kingpin,
     axleB,
     axles: additionalAxle ? [additionalAxle] : undefined,
@@ -316,9 +345,15 @@ export function buildCreateVehiclePayload(values: VehicleFormValues): CreateVehi
       ? toKilograms(values.maxCargoWeight, weightUnit as WeightUnitKey)
       : 0,
     layerCount: Number.isFinite(values.layerCount) ? (values.layerCount ?? 1) : 1,
+    // Backend LoadingType: Rear=0, SideRight=1, SideLeft=2, SideBoth=3, Top=4.
+    // 'front' ve 'rearAndSide' için backend'de birebir karşılık yok — Rear (0) varsayılanına düşülür.
     loadingType: (() => {
-      const map: Record<string, number> = { rear: 0, side: 1, top: 2 };
-      return map[values.doorDirection] ?? 0;
+      if (values.doorDirection === 'rear') return 0;
+      if (values.doorDirection === 'top') return 4;
+      if (values.doorDirection === 'side') {
+        return values.doorSide === 'left' ? 2 : 1; // SideLeft : SideRight (belirtilmemişse sağ)
+      }
+      return 0;
     })(),
     isActive: values.isActive ?? true,
     kingPinDistanceMm: Number.isFinite(values.kingpin?.distance) ? values.kingpin!.distance : null,

--- a/apps/frontend/src/lib/utils/scene/loadOrder.test.ts
+++ b/apps/frontend/src/lib/utils/scene/loadOrder.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { PlacementWithDimensions } from '@/lib/types/loadingPlan';
+import { buildLoadOrder } from './loadOrder';
+
+function makePlacement(overrides: Partial<PlacementWithDimensions> = {}): PlacementWithDimensions {
+  return {
+    itemId: '00000000-0000-0000-0000-000000000001',
+    positionX: 0,
+    positionY: 0,
+    positionZ: 0,
+    orientationIndex: 0,
+    layer: 1,
+    isViolation: false,
+    width: 50,
+    height: 50,
+    depth: 50,
+    weight: 10,
+    ...overrides,
+  };
+}
+
+describe('buildLoadOrder — yan kapı (side) sağ/sol dalı', () => {
+  // Aynı Y ve Z'de, X=0 (sol duvar) ve X=100 (sağ duvar) kutuları.
+  const leftBox = makePlacement({ positionX: 0 });
+  const rightBox = makePlacement({ positionX: 100 });
+  const placements = [rightBox, leftBox]; // index 0 = sağdaki, index 1 = soldaki
+
+  it('doorSide=right → kapı X=width, sol duvar (X küçük) önce girer', () => {
+    const order = buildLoadOrder(placements, 'side', 'right');
+    // leftBox (index 1, X=0) sağ kapıya en uzak → önce girer
+    expect(order).toEqual([1, 0]);
+  });
+
+  it('doorSide=left → kapı X=0, sağ duvar (X büyük) önce girer', () => {
+    const order = buildLoadOrder(placements, 'side', 'left');
+    // rightBox (index 0, X=100) sol kapıya en uzak → önce girer
+    expect(order).toEqual([0, 1]);
+  });
+
+  it('doorSide belirtilmemiş → sağ kapı varsayımına düşer (SideBoth eşlemesiyle tutarlı)', () => {
+    const withoutSide = buildLoadOrder(placements, 'side', undefined);
+    const withRight = buildLoadOrder(placements, 'side', 'right');
+    expect(withoutSide).toEqual(withRight);
+  });
+});
+
+describe('buildLoadOrder — rear ve top dalları (referans, regresyon koruması)', () => {
+  it('rear: Z büyükten küçüğe sıralanır (kapıya en uzak önce)', () => {
+    const near = makePlacement({ positionZ: 0 });
+    const far = makePlacement({ positionZ: 200 });
+    const order = buildLoadOrder([near, far], 'rear');
+    expect(order).toEqual([1, 0]);
+  });
+
+  it('top: Y küçükten büyüğe sıralanır (zemin katı önce)', () => {
+    const bottom = makePlacement({ positionY: 0 });
+    const top = makePlacement({ positionY: 100 });
+    const order = buildLoadOrder([top, bottom], 'top');
+    expect(order).toEqual([1, 0]);
+  });
+});


### PR DESCRIPTION
Faz 0'ın son maddesi: frontend kapı yönü enum eşlemesi backend ile hizalandı.

## İçerik

| Görev | PR | Özet |
|---|---|---|
| F0-04 · Frontend kapı yönü enum eşlemesi | #930 | `LOADING_TYPE_FROM_INT` backend `LoadingType` enum'ı ile hizalandı. |

Eski eşleme `0→Rear, 1→Side, 2→Top` idi; backend ise `Rear=0, SideRight=1, SideLeft=2, SideBoth=3, Top=4`. Sonuç olarak **`SideLeft` araçlar arayüzde "üstten yükleme" görünüyordu** — yanlış kapı yönü, `buildLoadOrder`'ın yanlış dalı ve 3D sahnede yanlış kapı animasyonu. `SideBoth` ve `Top` ise hiç eşleşmiyordu.

## Yeni eşleme

| int | Backend | Frontend |
|---|---|---|
| 0 | Rear | `{ direction: 'rear' }` |
| 1 | SideRight | `{ direction: 'side', doorSide: 'right' }` |
| 2 | SideLeft | `{ direction: 'side', doorSide: 'left' }` |
| 3 | SideBoth | `{ direction: 'side' }` — `doorSide` belirsiz |
| 4 | Top | `{ direction: 'top' }` |

Ters yön (`buildCreateVehiclePayload`, `AddVehicleModal`) da düzeltildi: `ust` artık `2` yerine `4`, `side` ise `doorSide`'a göre `1`/`2` gönderiyor.

**`SideBoth` kararı:** `DoorDirection` tipi genişletilmedi. `loadOrder.ts`, `ContainerMesh.tsx` ve `VehiclePreview3D.tsx` zaten `doorSide` tanımsızken sağ kapı davranışına düşüyor; mevcut desene uyan en küçük çözüm tercih edildi.

**Bilinmeyen değer:** yeni `resolveLoadingType()` fonksiyonu, tabloda karşılığı olmayan int değerlerinde sessiz kalmıyor — konsola uyarı basıp varsayılana düşüyor. `null` için davranış değişmedi.

## Doğrulama

- `npm run lint`, `format:check`, `build`, `test:ci`: **166/166 test geçti** (30'u yeni).
- Frontend CI, Backend CI, Docker Image Build ve Deploy (Test) kontrollerinin tamamı yeşil.
