### PR TITLE
Sürüm: test → main (Faz 0 hata temizliği + terfi otomasyonu)

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,170 @@
+# Terfi otomasyonu (INFRA-01): dev → test ve test → main PR'larını
+# elle `gh pr merge` çalıştırmadan, güvenli şekilde merge eder.
+#
+# Neden `gh pr merge` yerine bu workflow?
+# Merge-commit ile terfi eden PR'larda `test`/`main` dalı `dev`/`test`'te
+# olmayan bir merge commit içerir. Bu nedenle terfi PR'ının
+# `mergeStateStatus` değeri kalıcı olarak BEHIND görünür ve `gh pr merge`
+# istemci tarafı "head branch is not up to date with base branch"
+# kontrolüyle merge'i reddeder. BEHIND durumu bir arıza değildir; sorun
+# yalnızca `gh pr merge`'ün istemci tarafı kontrolündedir. GitHub REST
+# API'sinin merge uç noktası aynı kontrolü yapmaz ve PR'ı sorunsuz
+# merge eder — bu workflow tam olarak bunu otomatikleştirir.
+#
+# Tasarım kararı: bu workflow PR AÇMAZ, yalnızca zaten açık olan terfi
+# PR'ını bulur ve merge eder. PR'ı insan `gh pr create` ile açar.
+# Nedeni: GITHUB_TOKEN ile açılan/işlem gören PR'lar GitHub'ın özyineleme
+# koruması nedeniyle CI'ı (pull_request tetiklenen job'lar) çalıştırmaz;
+# workflow PR açsaydı zorunlu kontroller sonsuza kadar pending kalır ve
+# merge asla gerçekleşmezdi. Repoda bu amaca uygun (repo yazma yetkili)
+# bir PAT secret'ı da yoktu (yalnızca GHCR'a özel TEST_GHCR_PAT var, bu
+# repo/PR işlemleri için kullanılmaz) — bu da PR açan bir tasarımı riskli
+# kılardı.
+#
+# İkinci, daha az bilinen tuzak: merge ADIMININ KENDİSİ de aynı koruma
+# kapsamındadır. GitHub REST API üzerinden GITHUB_TOKEN ile yapılan bir
+# merge, hedef dala "push" edilen merge commit'i GITHUB_TOKEN kaynaklı
+# sayar ve bu commit `test`/`main` üzerindeki push-tetiklemeli
+# workflow'ları (test-deploy.yml → test sunucusuna deploy,
+# release-tag.yml → main'de sürüm etiketi) TETİKLEMEZ. Bunu GITHUB_TOKEN
+# ile yapmak, terfiyi "başarılı" gösterip deploy/sürüm otomasyonunu
+# sessizce kırardı. Bu yüzden merge adımı ayrı bir PAT secret'ı
+# (PROMOTION_PAT) gerektirir; bu secret repoda YOKTUR ve oluşturulması
+# gerekir (bkz. PAT kontrolü adımı ve PR açıklaması).
+
+name: Terfi
+
+on:
+  workflow_dispatch:
+    inputs:
+      hedef:
+        description: "Terfi yönü"
+        required: true
+        type: choice
+        options:
+          - dev-test
+          - test-main
+      pr_numarasi:
+        description: "Terfi PR numarası (boş bırakılırsa base/head dal çiftinden otomatik bulunur)"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: terfi-otomasyonu
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Terfi Et (${{ github.event.inputs.hedef }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: PAT kontrolü
+        run: |
+          if [ -z "${{ secrets.PROMOTION_PAT }}" ]; then
+            echo "::error::PROMOTION_PAT secret'i tanimli degil. Merge adimi GITHUB_TOKEN ile CALISTIRILAMAZ: GITHUB_TOKEN ile yapilan merge, test/main dallarina push tetikli is akislarini (test-deploy.yml, release-tag.yml) tetiklemez ve deploy/surum otomasyonu sessizce kirilir. contents:write + pull-requests:write yetkili bir PAT (classic: repo scope; fine-grained: Contents RW, Pull requests RW) olusturup PROMOTION_PAT adiyla repo secret'i olarak eklemeden bu workflow calismaz."
+            exit 1
+          fi
+
+      - name: Hedef dalları belirle
+        id: hedef
+        run: |
+          case "${{ github.event.inputs.hedef }}" in
+            dev-test)
+              echo "base=test" >> "$GITHUB_OUTPUT"
+              echo "head=dev" >> "$GITHUB_OUTPUT"
+              ;;
+            test-main)
+              echo "base=main" >> "$GITHUB_OUTPUT"
+              echo "head=test" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Bilinmeyen hedef girdisi: ${{ github.event.inputs.hedef }}"
+              exit 1
+              ;;
+          esac
+
+      - name: Terfi PR'ını bul
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BASE="${{ steps.hedef.outputs.base }}"
+          HEAD="${{ steps.hedef.outputs.head }}"
+          INPUT_PR="${{ github.event.inputs.pr_numarasi }}"
+
+          if [ -n "$INPUT_PR" ]; then
+            NUMBER="$INPUT_PR"
+            ACTUAL_BASE=$(gh pr view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName -q .baseRefName)
+            ACTUAL_HEAD=$(gh pr view "$NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName -q .headRefName)
+            if [ "$ACTUAL_BASE" != "$BASE" ] || [ "$ACTUAL_HEAD" != "$HEAD" ]; then
+              echo "::error::PR #$NUMBER, $HEAD -> $BASE terfisine ait degil (bulunan: $ACTUAL_HEAD -> $ACTUAL_BASE)."
+              exit 1
+            fi
+          else
+            NUMBERS=$(gh pr list --repo "$GITHUB_REPOSITORY" --base "$BASE" --head "$HEAD" --state open --json number -q '.[].number')
+            COUNT=$(echo "$NUMBERS" | grep -c . || true)
+            if [ "$COUNT" -eq 0 ]; then
+              echo "::error::$HEAD -> $BASE icin acik terfi PR'i bulunamadi. Once 'gh pr create --base $BASE --head $HEAD' ile PR acin, CI'in calismasini bekleyin, sonra bu workflow'u tekrar tetikleyin."
+              exit 1
+            fi
+            if [ "$COUNT" -gt 1 ]; then
+              JOINED=$(echo "$NUMBERS" | tr '\n' ',' | sed 's/,$//')
+              echo "::error::$HEAD -> $BASE icin birden fazla acik PR var (#$JOINED). pr_numarasi girdisiyle hangisinin merge edilecegini belirtin."
+              exit 1
+            fi
+            NUMBER="$NUMBERS"
+          fi
+
+          echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+          echo "Terfi PR'i: #$NUMBER ($HEAD -> $BASE)"
+
+      - name: Zorunlu kontrollerin geçmesini bekle
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr checks "${{ steps.pr.outputs.number }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --watch \
+            --required \
+            --fail-fast \
+            --interval 20
+
+      - name: PR'ı merge commit ile birleştir
+        env:
+          GH_TOKEN: ${{ secrets.PROMOTION_PAT }}
+        run: |
+          NUMBER="${{ steps.pr.outputs.number }}"
+          ATTEMPT=1
+          MAX_ATTEMPTS=3
+
+          until gh api "repos/$GITHUB_REPOSITORY/pulls/$NUMBER/merge" \
+            -X PUT \
+            -f merge_method=merge \
+            --silent; do
+            if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+              echo "::error::PR #$NUMBER merge edilemedi ($MAX_ATTEMPTS denemeden sonra). Ruleset korumaları --admin veya bypass ile ATLANMAZ; hatanın kök nedenini (ör. gerçek bir çakışma) inceleyin."
+              exit 1
+            fi
+            echo "Merge denemesi $ATTEMPT basarisiz, 10 saniye sonra tekrar denenecek..."
+            ATTEMPT=$((ATTEMPT + 1))
+            sleep 10
+          done
+
+          echo "PR #$NUMBER merge commit ile birlestirildi."
+
+      - name: Özet
+        if: always()
+        run: |
+          {
+            echo "## Terfi Özeti"
+            echo "- **Yön**: ${{ github.event.inputs.hedef }}"
+            echo "- **PR**: #${{ steps.pr.outputs.number }}"
+            echo "- **Tetikleyen**: ${{ github.actor }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+
+    <!-- xUnit alt çizgili test adları CA1707'yi tetikler; Directory.Build.props
+         tüm uyarıları hataya yükseltiyor, bu yüzden test projesinde bilinçli olarak kapatılır. -->
+    <NoWarn>CA1707</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CargoPilot.Infrastructure\CargoPilot.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/apps/backend/CargoPilot.Infrastructure.Tests/GroupZoneTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/GroupZoneTests.cs
@@ -1,0 +1,96 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Services;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// LIFO grup bolgelerinin kapi yonune gore dogru eslendigini sabitler.
+/// Sahne sozlesmesi: arka kapi Z=0, arac onu Z=Length.
+/// UnloadingOrder=1 ilk inecek gruptur, bu yuzden kapiya en yakin olmalidir.
+/// </summary>
+public sealed class GroupZoneTests
+{
+    private const decimal VehicleWidth = 100m;
+    private const decimal VehicleHeight = 100m;
+    private const decimal VehicleLength = 300m;
+    private const decimal BoxLength = 50m;
+    private const decimal ZoneSize = VehicleLength / 3m;
+
+    [Fact]
+    public void Lifo_IlkInecekGrup_KapiyaEnYakinBolgeyeYerlesir()
+    {
+        var (result, itemsByOrder) = RunWithThreeGroups();
+
+        var zByOrder = itemsByOrder.ToDictionary(
+            pair => pair.Key,
+            pair => SinglePlacement(result, pair.Value).Z);
+
+        Assert.True(zByOrder[1] < zByOrder[2],
+            $"unloadingOrder=1 kapiya daha yakin olmali. Z: 1={zByOrder[1]}, 2={zByOrder[2]}");
+        Assert.True(zByOrder[2] < zByOrder[3],
+            $"unloadingOrder=2, 3'ten kapiya daha yakin olmali. Z: 2={zByOrder[2]}, 3={zByOrder[3]}");
+    }
+
+    [Fact]
+    public void Lifo_HerGrup_KendiBolgesininSinirlariIcindeKalir()
+    {
+        var (result, itemsByOrder) = RunWithThreeGroups();
+
+        foreach (var (unloadingOrder, itemId) in itemsByOrder)
+        {
+            var zoneStart = (unloadingOrder - 1) * ZoneSize;
+            var zoneEnd = unloadingOrder * ZoneSize;
+            var placement = SinglePlacement(result, itemId);
+
+            Assert.True(placement.Z >= zoneStart && placement.Z + placement.Depth <= zoneEnd,
+                $"unloadingOrder={unloadingOrder} bolgesi [{zoneStart},{zoneEnd}] disinda: " +
+                $"Z={placement.Z}, derinlik={placement.Depth}");
+        }
+    }
+
+    private static (OptimizationResult Result, Dictionary<int, Guid> ItemsByOrder) RunWithThreeGroups()
+    {
+        var itemsByOrder = new Dictionary<int, Guid>();
+        var items = new List<OptimizationItemInput>();
+
+        foreach (var unloadingOrder in new[] { 1, 2, 3 })
+        {
+            var item = CreateItem(unloadingOrder);
+            itemsByOrder[unloadingOrder] = item.ItemId;
+            items.Add(item);
+        }
+
+        var input = new OptimizationInput(
+            VehicleWidth,
+            VehicleHeight,
+            VehicleLength,
+            VehicleMaxWeight: 10_000m,
+            items,
+            LoadingPlanOptimizationCriteria.Lifo,
+            LoadingType.Rear);
+
+        return (new OptimizationEngine().Run(input), itemsByOrder);
+    }
+
+    private static PlacedItemResult SinglePlacement(OptimizationResult result, Guid itemId)
+        => Assert.Single(result.Placements, p => p.ItemId == itemId);
+
+    private static OptimizationItemInput CreateItem(int unloadingOrder)
+        => new(
+            ItemId: Guid.NewGuid(),
+            SKU: $"SKU-{unloadingOrder}",
+            Name: $"Urun {unloadingOrder}",
+            ImageUrl: null,
+            Width: VehicleWidth,
+            Height: VehicleHeight,
+            Length: BoxLength,
+            Weight: 100m,
+            IsStackable: false,
+            MaxStackCount: 1,
+            MaxWeightOnTop: 0m,
+            AllowedRotations: AllowedRotations.Fixed,
+            Quantity: 1,
+            GroupId: Guid.NewGuid(),
+            UnloadingOrder: unloadingOrder);
+}

--- a/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineOrientationTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineOrientationTests.cs
@@ -1,0 +1,188 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Services;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// OptimizationEngine.GetOrientations karakterizasyon testleri.
+///
+/// Amaç: Faz 1'de altı yüzey modeli gelmeden önce mevcut altı AllowedRotations
+/// değerinin ürettiği (w, h, d, rotation) permütasyon kümesini testle sabitlemek.
+/// Bu testler davranışı DEĞİŞTİRMEZ; yalnızca mevcut davranışı kayıt altına alır.
+/// F2-06'daki eksen rotasyonu değişikliğinin regresyonu bu testlere göre ölçülür.
+/// </summary>
+public class OptimizationEngineOrientationTests
+{
+    private static OptimizationItemInput CreateItem(
+        decimal width, decimal height, decimal length, AllowedRotations rotations) =>
+        new(
+            ItemId: Guid.NewGuid(),
+            SKU: "SKU-1",
+            Name: "Test Item",
+            ImageUrl: null,
+            Width: width,
+            Height: height,
+            Length: length,
+            Weight: 10m,
+            IsStackable: true,
+            MaxStackCount: 0,
+            MaxWeightOnTop: 0m,
+            AllowedRotations: rotations,
+            Quantity: 1);
+
+    // ── Tam permütasyon kümesi testleri ────────────────────────────────────
+
+    [Fact]
+    public void Fixed_ReturnsOnlyNoRotationOrientation()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.Fixed);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [(100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation)],
+            orientations);
+    }
+
+    [Fact]
+    public void NoVertical_ReturnsNoRotationAndYawOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoVertical);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (30m, 50m, 100m, LoadingPlanPlacementRotation.Yaw)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void NoYaw_ReturnsNoRotationRollAndPitchOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoYaw);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (50m, 100m, 30m, LoadingPlanPlacementRotation.Roll),
+                (100m, 30m, 50m, LoadingPlanPlacementRotation.Pitch)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void PitchOnly_ReturnsNoRotationAndPitchOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.PitchOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (100m, 30m, 50m, LoadingPlanPlacementRotation.Pitch)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void RollOnly_ReturnsNoRotationAndRollOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.RollOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (50m, 100m, 30m, LoadingPlanPlacementRotation.Roll)
+            ],
+            orientations);
+    }
+
+    [Fact]
+    public void All_ReturnsAllSixOrientations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.All);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(
+            [
+                (100m, 50m, 30m, LoadingPlanPlacementRotation.NoRotation),
+                (30m, 50m, 100m, LoadingPlanPlacementRotation.Yaw),
+                (50m, 100m, 30m, LoadingPlanPlacementRotation.Roll),
+                (100m, 30m, 50m, LoadingPlanPlacementRotation.Pitch),
+                (50m, 30m, 100m, LoadingPlanPlacementRotation.YawPitch),
+                (30m, 100m, 50m, LoadingPlanPlacementRotation.RollYaw)
+            ],
+            orientations);
+    }
+
+    // ── Eksen kilidi değişmezleri ───────────────────────────────────────────
+
+    [Fact]
+    public void PitchOnly_KeepsWidthLockedOnXAxis()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.PitchOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.All(orientations, o => Assert.Equal(item.Width, o.w));
+    }
+
+    [Fact]
+    public void RollOnly_KeepsLengthLockedOnZAxis()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.RollOnly);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.All(orientations, o => Assert.Equal(item.Length, o.d));
+    }
+
+    [Fact]
+    public void NoVertical_KeepsHeightLockedOnYAxis()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoVertical);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.All(orientations, o => Assert.Equal(item.Height, o.h));
+    }
+
+    // ── Yasak eksen sızıntısı yok ────────────────────────────────────────────
+
+    [Fact]
+    public void NoYaw_DoesNotLeakYawRotations()
+    {
+        var item = CreateItem(100m, 50m, 30m, AllowedRotations.NoYaw);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.DoesNotContain(orientations, o =>
+            o.rotation is LoadingPlanPlacementRotation.Yaw
+                or LoadingPlanPlacementRotation.YawPitch
+                or LoadingPlanPlacementRotation.RollYaw);
+    }
+
+    // ── Simetrik kutu sınır durumu ───────────────────────────────────────────
+
+    [Fact]
+    public void SymmetricBox_AllSixRotationLabelsCollapseToSameDimensions()
+    {
+        var item = CreateItem(40m, 40m, 40m, AllowedRotations.All);
+
+        var orientations = OptimizationEngine.GetOrientations(item);
+
+        Assert.Equal(6, orientations.Length);
+        Assert.Equal(6, orientations.Select(o => o.rotation).Distinct().Count());
+        Assert.All(orientations, o => Assert.Equal((40m, 40m, 40m), (o.w, o.h, o.d)));
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineRotationPlacementTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineRotationPlacementTests.cs
@@ -1,0 +1,144 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Services;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// OptimizationEngine.Run() motor seviyesi rotasyon yerleştirme karakterizasyon testleri.
+///
+/// Amaç: rotasyon kısıtlarının (AllowedRotations) tüm motor akışı içinde (extreme-point
+/// yerleştirme, sınır/çakışma/destek kontrolleri) tutarlı çalıştığını, kilitli eksenlerin
+/// yerleşen sonuçta sabit kaldığını ve rotasyon yüzünden yerleşemeyen kutuların hangi
+/// UnplacedReason ile raporlandığını mevcut davranışa göre sabitlemek.
+/// </summary>
+public class OptimizationEngineRotationPlacementTests
+{
+    private static readonly OptimizationEngine Engine = new();
+
+    private static OptimizationItemInput CreateItem(
+        decimal width, decimal height, decimal length, AllowedRotations rotations) =>
+        new(
+            ItemId: Guid.NewGuid(),
+            SKU: "SKU-1",
+            Name: "Test Item",
+            ImageUrl: null,
+            Width: width,
+            Height: height,
+            Length: length,
+            Weight: 10m,
+            IsStackable: true,
+            MaxStackCount: 0,
+            MaxWeightOnTop: 0m,
+            AllowedRotations: rotations,
+            Quantity: 1);
+
+    private static OptimizationInput CreateInput(
+        decimal vehicleWidth, decimal vehicleHeight, decimal vehicleLength, OptimizationItemInput item) =>
+        new(
+            VehicleWidth: vehicleWidth,
+            VehicleHeight: vehicleHeight,
+            VehicleLength: vehicleLength,
+            VehicleMaxWeight: 1000m,
+            Items: [item]);
+
+    [Fact]
+    public void Fixed_UnplacesBoxThatOnlyFitsWhenRotated()
+    {
+        // Kutu: W=60 sadece Yaw ile Z eksenine (uzunluk=80) sığar; X (genişlik=50) ve
+        // Y (yükseklik=50) eksenlerine hiçbir yönelimde sığmaz.
+        var item = CreateItem(60m, 20m, 20m, AllowedRotations.Fixed);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, item);
+
+        var result = Engine.Run(input);
+
+        Assert.Empty(result.Placements);
+        var unplaced = Assert.Single(result.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+    }
+
+    [Fact]
+    public void All_PlacesBoxViaYawRotationWhenFixedWouldFail()
+    {
+        var item = CreateItem(60m, 20m, 20m, AllowedRotations.All);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, item);
+
+        var result = Engine.Run(input);
+
+        Assert.Empty(result.UnplacedItems);
+        var placed = Assert.Single(result.Placements);
+        Assert.Equal(LoadingPlanPlacementRotation.Yaw, placed.Rotation);
+        // Yaw: (L, H, W) — item'ın W'si (60) Z eksenine (Depth) taşınır.
+        Assert.Equal(20m, placed.Width);
+        Assert.Equal(20m, placed.Height);
+        Assert.Equal(60m, placed.Depth);
+    }
+
+    [Fact]
+    public void RollOnly_VsFixed_RollPlacesWithLengthLockedOnZ_FixedFails()
+    {
+        // Kutu: W=60 sadece Roll ile Y eksenine (yükseklik=80) taşınırsa sığar.
+        var rollItem = CreateItem(60m, 20m, 20m, AllowedRotations.RollOnly);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 80m, vehicleLength: 50m, rollItem);
+
+        var rollResult = Engine.Run(input);
+
+        Assert.Empty(rollResult.UnplacedItems);
+        var placed = Assert.Single(rollResult.Placements);
+        Assert.Equal(LoadingPlanPlacementRotation.Roll, placed.Rotation);
+        // RollOnly değişmezi: L her zaman Z eksenindedir (kilitli).
+        Assert.Equal(rollItem.Length, placed.Depth);
+
+        var fixedItem = rollItem with { AllowedRotations = AllowedRotations.Fixed };
+        var fixedInput = CreateInput(vehicleWidth: 50m, vehicleHeight: 80m, vehicleLength: 50m, fixedItem);
+
+        var fixedResult = Engine.Run(fixedInput);
+
+        Assert.Empty(fixedResult.Placements);
+        var unplaced = Assert.Single(fixedResult.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+    }
+
+    [Fact]
+    public void PitchOnly_VsFixed_PitchPlacesWithWidthLockedOnX_FixedFails()
+    {
+        // Kutu: H=60 sadece Pitch ile Z eksenine (uzunluk=80) taşınırsa sığar.
+        var pitchItem = CreateItem(20m, 60m, 20m, AllowedRotations.PitchOnly);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, pitchItem);
+
+        var pitchResult = Engine.Run(input);
+
+        Assert.Empty(pitchResult.UnplacedItems);
+        var placed = Assert.Single(pitchResult.Placements);
+        Assert.Equal(LoadingPlanPlacementRotation.Pitch, placed.Rotation);
+        // PitchOnly değişmezi: W her zaman X eksenindedir (kilitli).
+        Assert.Equal(pitchItem.Width, placed.Width);
+
+        var fixedItem = pitchItem with { AllowedRotations = AllowedRotations.Fixed };
+        var fixedInput = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, fixedItem);
+
+        var fixedResult = Engine.Run(fixedInput);
+
+        Assert.Empty(fixedResult.Placements);
+        var unplaced = Assert.Single(fixedResult.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+    }
+
+    [Fact]
+    public void RotationConstrainedUnplacedBox_ReportsGenericInsufficientSpaceReason()
+    {
+        // Karakterizasyon notu: motor, rotasyon kısıtı yüzünden yerleşemeyen kutuları
+        // UnplacedReason.RotationOrGeometryConstraint yerine genel InsufficientSpace ile
+        // raporluyor. RotationOrGeometryConstraint şu an motor tarafından hiç atanmıyor.
+        // Bu test mevcut davranışı sabitler; Faz 1'de daha spesifik nedenlendirme
+        // eklenirse bilinçli olarak güncellenmelidir.
+        var item = CreateItem(60m, 20m, 20m, AllowedRotations.Fixed);
+        var input = CreateInput(vehicleWidth: 50m, vehicleHeight: 50m, vehicleLength: 80m, item);
+
+        var result = Engine.Run(input);
+
+        var unplaced = Assert.Single(result.UnplacedItems);
+        Assert.Equal(UnplacedReason.InsufficientSpace, unplaced.Reason);
+        Assert.NotEqual(UnplacedReason.RotationOrGeometryConstraint, unplaced.Reason);
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/OptimizationEngineTests.cs
@@ -1,0 +1,136 @@
+using CargoPilot.Application.Common.Models;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Services;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// OptimizationEngine.cs:52 - bölge eşleşmesi olmayan kutularda fantom ceza
+/// düzeltmesini doğrular. Eşleşme olmadığında (TryGetValue false döndüğünde)
+/// zoneStart/zoneEnd artık null kalır; eskiden default (0,0) struct değeri
+/// kullanılıyordu ve bu, kutuları Z=0'a (kapıya) zorlayan devasa bir ceza
+/// üretiyordu.
+/// </summary>
+public sealed class OptimizationEngineTests
+{
+    /// <summary>
+    /// WeightBalance kriterinde bölge tanımı olmayan (grupsuz) kutularda fantom
+    /// ceza uygulanmadığını doğrular. Düzeltme öncesi zonePenalty = (0 + ez + d) *
+    /// 2000 şeklinde her kutuyu Z=0'a çekiyordu; bu da ağırlık merkezini araç
+    /// uzunluğunun ortasından uzaklaştırıyordu. Düzeltme sonrası dağılım yalnızca
+    /// balancePenalty tarafından belirlenir ve ağırlık merkezi araç ortasına
+    /// (halfL) yakın kalır.
+    /// </summary>
+    [Fact]
+    public void WeightBalance_NoZoneDefinition_NoPhantomPenalty()
+    {
+        var items = new List<OptimizationItemInput>
+        {
+            CreateItem(weight: 200m, unloadingOrder: null, groupId: null)
+        };
+        for (var i = 0; i < 6; i++)
+            items.Add(CreateItem(weight: 50m, unloadingOrder: null, groupId: null));
+
+        var input = new OptimizationInput(
+            VehicleWidth: 200m,
+            VehicleHeight: 200m,
+            VehicleLength: 300m,
+            VehicleMaxWeight: 1000m,
+            items,
+            LoadingPlanOptimizationCriteria.WeightBalance,
+            LoadingType.Rear);
+
+        var result = new OptimizationEngine().Run(input);
+
+        Assert.Equal(items.Count, result.Placements.Count);
+        Assert.Empty(result.UnplacedItems);
+
+        // Ağırlık merkezi araç uzunluğunun (300) ortasına (150) yakın olmalı.
+        // Fantom ceza varken kutular Z=0'a yığılır ve CoG 100'ün altına düşer.
+        Assert.NotNull(result.CenterOfGravityZ);
+        Assert.InRange(result.CenterOfGravityZ!.Value, 100m, 200m);
+    }
+
+    /// <summary>
+    /// Lifo + LoadingType.Rear + birden fazla grup senaryosunda bölge cezasının
+    /// hâlâ uygulandığını doğrular (regresyon testi). Bu, F0-03 düzeltmesinin
+    /// geçerli bölge eşleşmelerini bozmadığını garanti eder.
+    ///
+    /// Kasıtlı olarak yöne bağımsızdır: hangi grubun kapıya (Z=0) yakın bölgeye
+    /// düştüğü F0-01'in sorumluluğudur ve orada (GroupZoneTests) doğrulanır.
+    /// Burada yalnızca her grubun kendi UnloadingOrder'ına ait, zoneSize
+    /// genişliğindeki dilime toplandığı ve iki grubun farklı, çakışmayan
+    /// dilimlere düştüğü doğrulanır.
+    /// </summary>
+    [Fact]
+    public void Lifo_MultipleGroups_ZonePenaltyApplied()
+    {
+        const decimal vehicleLength = 200m;
+        const decimal zoneSize = vehicleLength / 2m;
+
+        var group2Box1 = CreateItem(weight: 50m, unloadingOrder: 2, groupId: Guid.NewGuid());
+        var group2Box2 = CreateItem(weight: 50m, unloadingOrder: 2, groupId: group2Box1.GroupId);
+        var group1Box = CreateItem(weight: 50m, unloadingOrder: 1, groupId: Guid.NewGuid());
+        var ungrouped = CreateItem(weight: 50m, unloadingOrder: null, groupId: null);
+
+        var items = new List<OptimizationItemInput> { group2Box1, group2Box2, group1Box, ungrouped };
+
+        var input = new OptimizationInput(
+            VehicleWidth: 50m,
+            VehicleHeight: 50m,
+            VehicleLength: vehicleLength,
+            VehicleMaxWeight: 500m,
+            items,
+            LoadingPlanOptimizationCriteria.Lifo,
+            LoadingType.Rear);
+
+        var result = new OptimizationEngine().Run(input);
+
+        Assert.Equal(4, result.Placements.Count);
+        Assert.Empty(result.UnplacedItems);
+
+        var group1Placement = Assert.Single(result.Placements, p => p.ItemId == group1Box.ItemId);
+        var group2Placements = new[] { group2Box1, group2Box2 }
+            .Select(item => Assert.Single(result.Placements, p => p.ItemId == item.ItemId))
+            .ToList();
+
+        // Grup 1'in düştüğü bölge dilimi ne olursa olsun (kapıya yakın ya da uzak),
+        // tek kutusu o dilimin dışına taşmamalı.
+        var group1Zone = ZoneIndex(group1Placement.Z, zoneSize);
+        Assert.True(WithinZone(group1Placement, group1Zone, zoneSize),
+            $"Grup 1 kutusu kendi bölge dilimi [{group1Zone * zoneSize},{(group1Zone + 1) * zoneSize}] dışında: Z={group1Placement.Z}, derinlik={group1Placement.Depth}");
+
+        foreach (var placement in group2Placements)
+        {
+            var group2Zone = ZoneIndex(placement.Z, zoneSize);
+            Assert.True(WithinZone(placement, group2Zone, zoneSize),
+                $"Grup 2 kutusu kendi bölge dilimi [{group2Zone * zoneSize},{(group2Zone + 1) * zoneSize}] dışında: Z={placement.Z}, derinlik={placement.Depth}");
+
+            // İki grup, aynı bölge dilimini paylaşmamalı (bölge cezası ayrıştırıyor).
+            Assert.NotEqual(group1Zone, group2Zone);
+        }
+    }
+
+    private static int ZoneIndex(decimal z, decimal zoneSize) => (int)(z / zoneSize);
+
+    private static bool WithinZone(PlacedItemResult placement, int zoneIndex, decimal zoneSize)
+        => placement.Z >= zoneIndex * zoneSize && placement.Z + placement.Depth <= (zoneIndex + 1) * zoneSize;
+
+    private static OptimizationItemInput CreateItem(decimal weight, int? unloadingOrder, Guid? groupId)
+        => new(
+            ItemId: Guid.NewGuid(),
+            SKU: $"SKU-{Guid.NewGuid():N}",
+            Name: "Test Ürünü",
+            ImageUrl: null,
+            Width: 50m,
+            Height: 50m,
+            Length: 50m,
+            Weight: weight,
+            IsStackable: false,
+            MaxStackCount: 1,
+            MaxWeightOnTop: 0m,
+            AllowedRotations: AllowedRotations.Fixed,
+            Quantity: 1,
+            GroupId: groupId,
+            UnloadingOrder: unloadingOrder);
+}

--- a/apps/backend/CargoPilot.Infrastructure/AssemblyInfo.cs
+++ b/apps/backend/CargoPilot.Infrastructure/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// Test projesinin internal üyelere (ör. OptimizationEngine.GetOrientations) erişebilmesi için.
+// Üretim davranışını değiştirmez; yalnızca test görünürlüğü sağlar.
+[assembly: InternalsVisibleTo("CargoPilot.Infrastructure.Tests")]

--- a/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
@@ -56,7 +56,13 @@ internal sealed class OptimizationEngine : IOptimizationEngine
                 continue;
             }
 
-            groupZones.TryGetValue(item.UnloadingOrder ?? -1, out var zone);
+            decimal? zoneStart = null;
+            decimal? zoneEnd = null;
+            if (groupZones.TryGetValue(item.UnloadingOrder ?? -1, out var zone))
+            {
+                zoneStart = zone.ZStart;
+                zoneEnd = zone.ZEnd;
+            }
 
             PlacedBox? best = null;
             var bestScore = decimal.MaxValue;
@@ -82,7 +88,7 @@ internal sealed class OptimizationEngine : IOptimizationEngine
                         item.Weight, totalWeight,
                         momentX, momentZ,
                         halfW, halfL,
-                        zone.ZStart, zone.ZEnd);
+                        zoneStart, zoneEnd);
 
                     if (score < bestScore)
                     {

--- a/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
@@ -37,6 +37,13 @@ internal sealed class OptimizationEngine : IOptimizationEngine
 
         var groupZones = ComputeGroupZones(instances, input.VehicleLength, input.LoadingType, input.Criteria);
 
+        // LIFO bölgeleri de aynı nedenle tohumlanır: aday noktalar yalnızca
+        // yerleştirilmiş kutulara komşu doğduğu için ilk yüklenen grup her zaman
+        // Z=0'a, yani kapının önüne düşüyordu. Her bölgenin başlangıcı aday
+        // yapılınca grup kendi bölgesinden başlayarak dolar.
+        foreach (var zoneStart in groupZones.Values.Select(z => z.ZStart).Where(z => z > 0m))
+            extremePoints.Add((0m, 0m, zoneStart));
+
         foreach (var item in instances)
         {
             // Her kutu için aday pozisyon taraması pahalıdır; iptal edilen istekte
@@ -147,8 +154,11 @@ internal sealed class OptimizationEngine : IOptimizationEngine
     }
 
     // ── Grup zone hesaplama ───────────────────────────────────────────────────
-    // Gruplara ait distinct UnloadingOrder değerlerini DESC sıralar ve kamyon
-    // uzunluğunu eşit bölümlere ayırır. 0-1 grup varsa zone uygulanmaz.
+    // Arka kapı Z=0'dadır. UnloadingOrder=1 ilk inecek gruptur, bu yüzden kapıya
+    // en yakın (en küçük Z) bölgeye düşer. Distinct UnloadingOrder değerleri ASC
+    // sıralanır ve kamyon uzunluğu eşit bölümlere ayrılır; sıradaki her grup bir
+    // sonraki bölgeye, yani kapıdan daha uzağa yerleşir. 0-1 grup varsa zone
+    // uygulanmaz.
     private static Dictionary<int, (decimal ZStart, decimal ZEnd)> ComputeGroupZones(
         IReadOnlyList<OptimizationItemInput> items,
         decimal vehicleLength,
@@ -163,7 +173,7 @@ internal sealed class OptimizationEngine : IOptimizationEngine
             .Where(i => i.GroupId.HasValue && i.UnloadingOrder.HasValue)
             .Select(i => i.UnloadingOrder!.Value)
             .Distinct()
-            .OrderByDescending(o => o)
+            .OrderBy(o => o)
             .ToList();
 
         if (orders.Count <= 1)
@@ -180,7 +190,8 @@ internal sealed class OptimizationEngine : IOptimizationEngine
 
     // ── Grup-bilinçli sıralama ────────────────────────────────────────────────
     // GroupId'si olan items yükleme sırasına göre sıralanır:
-    // yüksek UnloadingOrder = araç arkası = önce yüklenir (DESC sıra).
+    // yüksek UnloadingOrder = en son inecek grup = kapıdan en uzak bölge
+    // (arka kapıda Z=length tarafı) = önce yüklenir (DESC sıra).
     // GroupId'si olmayan items en sona eklenir.
     // Grup yoksa mevcut criteria-based sıralama uygulanır.
     private static List<OptimizationItemInput> SortForGroupPlacement(

--- a/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs
@@ -405,7 +405,7 @@ internal sealed class OptimizationEngine : IOptimizationEngine
         };
     }
 
-    private static (decimal w, decimal h, decimal d, LoadingPlanPlacementRotation rotation)[]
+    internal static (decimal w, decimal h, decimal d, LoadingPlanPlacementRotation rotation)[]
         GetOrientations(OptimizationItemInput item)
     {
         var (W, H, L) = (item.Width, item.Height, item.Length);

--- a/apps/backend/CargoPilot.slnx
+++ b/apps/backend/CargoPilot.slnx
@@ -7,6 +7,7 @@
   </Folder>
   <Folder Name="/Infrastructure/">
     <Project Path="CargoPilot.Infrastructure/CargoPilot.Infrastructure.csproj" Id="84e3f1c2-5401-4196-8309-a9815dd1c50d" />
+    <Project Path="CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj" Id="a2b8c7d3-6e9f-4b1a-c3d5-e8f9a0b1c2d3" />
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />

--- a/apps/frontend/src/features/planning/panels/components/AddVehicleModal.tsx
+++ b/apps/frontend/src/features/planning/panels/components/AddVehicleModal.tsx
@@ -79,11 +79,12 @@ const FORM_VEHICLE_TYPE_INT: Record<string, number> = {
   konteyner: 3,
 };
 
+// Backend LoadingType: Rear=0, SideRight=1, SideLeft=2, SideBoth=3, Top=4.
+// Bu modalde sağ/sol kapı seçimi yok; "yan" seçimi varsayılan olarak SideRight'a eşlenir.
 const LOADING_AREA_INT: Record<string, number> = {
   arka: 0,
   yan: 1,
-  ust: 2,
-  'arka-yan': 3,
+  ust: 4,
 };
 
 export function AddVehicleModal({ open, onOpenChange, onCreated }: AddVehicleModalProps) {

--- a/apps/frontend/src/lib/api/loadingPlanMappers.ts
+++ b/apps/frontend/src/lib/api/loadingPlanMappers.ts
@@ -8,7 +8,7 @@ import type {
 import type { Item } from '@/lib/types/item';
 import type { Vehicle } from '@/lib/types/vehicle';
 import { VehicleType, DoorDirection } from '@/lib/types/vehicle';
-import { VEHICLE_TYPE_FROM_INT, LOADING_TYPE_FROM_INT } from './vehicleMappers';
+import { VEHICLE_TYPE_FROM_INT, resolveLoadingType } from './vehicleMappers';
 import { type OrientationIndex } from '@/lib/utils/geometry/boxOrientations';
 import { resolveProductColor, COLOR_FALLBACK } from '@/lib/config/productColors';
 
@@ -419,7 +419,7 @@ export function fromApiPlanListItem(api: PlanListApiItem): LoadingPlanListItem {
     0;
   const rawCreatedAt = api.createdAt ?? api.createdAtUtc ?? new Date(0).toISOString();
   const createdAt = normalizeUtcDatetime(rawCreatedAt);
-  const loadingType = v?.loadingType ?? null;
+  const loadingTypeInfo = resolveLoadingType(v?.loadingType);
   return {
     id: api.id,
     planCode: api.planCode ?? `PLN-${api.id.slice(0, 8).toUpperCase()}`,
@@ -439,8 +439,8 @@ export function fromApiPlanListItem(api: PlanListApiItem): LoadingPlanListItem {
     interiorHeightM: v?.internalHeight ?? 0,
     interiorDepthM: v?.internalLength ?? 0,
     vehicleType: v?.vehicleType != null ? VEHICLE_TYPE_FROM_INT[v.vehicleType] : undefined,
-    doorDirection: loadingType != null ? LOADING_TYPE_FROM_INT[loadingType]?.direction : undefined,
-    doorSide: loadingType != null ? LOADING_TYPE_FROM_INT[loadingType]?.doorSide : undefined,
+    doorDirection: loadingTypeInfo?.direction,
+    doorSide: loadingTypeInfo?.doorSide,
     thumbnailUrl: (() => {
       const raw = ((api as Record<string, unknown>)['thumbnailUrl'] ??
         (api as Record<string, unknown>)['snapshotUrl'] ??
@@ -602,6 +602,7 @@ function apiVehicleToVehicle(
   v: z.infer<typeof planVehicleApiSchema> & { vehicleId?: string },
 ): Vehicle {
   const id = v.vehicleId ?? v.id ?? '';
+  const loadingTypeInfo = resolveLoadingType(v.loadingType);
   return {
     id,
     name: v.vehicleName ?? v.name ?? '—',
@@ -614,11 +615,8 @@ function apiVehicleToVehicle(
       v.vehicleType != null
         ? (VEHICLE_TYPE_FROM_INT[v.vehicleType] ?? VehicleType.Tir)
         : VehicleType.Tir,
-    doorDirection:
-      v.loadingType != null
-        ? (LOADING_TYPE_FROM_INT[v.loadingType]?.direction ?? DoorDirection.Rear)
-        : DoorDirection.Rear,
-    doorSide: v.loadingType != null ? LOADING_TYPE_FROM_INT[v.loadingType]?.doorSide : undefined,
+    doorDirection: loadingTypeInfo?.direction ?? DoorDirection.Rear,
+    doorSide: loadingTypeInfo?.doorSide,
     isFavorite: false,
     isActive: true,
     isDeleted: false,

--- a/apps/frontend/src/lib/api/useVehicles.ts
+++ b/apps/frontend/src/lib/api/useVehicles.ts
@@ -15,7 +15,7 @@ import {
   buildCreateVehiclePayload,
   VEHICLE_TYPE_INT,
   VEHICLE_TYPE_FROM_INT,
-  LOADING_TYPE_FROM_INT,
+  resolveLoadingType,
 } from './vehicleMappers';
 
 // ─── List API response schema ─────────────────────────────────────────────────
@@ -50,7 +50,7 @@ const vehicleListApiItemSchema = z.object({
 type VehicleListApiItem = z.infer<typeof vehicleListApiItemSchema>;
 
 function fromApiVehicleListItem(api: VehicleListApiItem): Vehicle {
-  const loadingTypeInfo = LOADING_TYPE_FROM_INT[api.loadingType ?? 0];
+  const loadingTypeInfo = resolveLoadingType(api.loadingType);
   const kingpin =
     api.kingPinDistanceMm != null && api.kingPinMaxLoadKg != null
       ? {

--- a/apps/frontend/src/lib/api/vehicleMappers.test.ts
+++ b/apps/frontend/src/lib/api/vehicleMappers.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { DoorDirection } from '@/lib/types/vehicle';
+import type { VehicleFormValues } from '@/features/data-management/vehicles/schemas/vehicleSchema';
+import {
+  LOADING_TYPE_FROM_INT,
+  resolveLoadingType,
+  buildCreateVehiclePayload,
+  fromApiVehicle,
+  type VehicleApi,
+} from './vehicleMappers';
+
+function makeApiVehicle(overrides: Partial<VehicleApi> = {}): VehicleApi {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    vehicleName: 'Test Aracı',
+    vehicleType: 0,
+    internalLength: 1000,
+    internalWidth: 240,
+    internalHeight: 260,
+    maxWeightCapacity: 24000,
+    isFavorite: false,
+    isActive: true,
+    isDeleted: false,
+    createdAt: new Date(0).toISOString(),
+    ...overrides,
+  };
+}
+
+function makeFormValues(overrides: Partial<VehicleFormValues> = {}): VehicleFormValues {
+  return {
+    vehicleType: 'Tir',
+    name: 'Test Aracı',
+    length: 1000,
+    width: 240,
+    height: 260,
+    maxCargoWeight: 24000,
+    doorDirection: 'rear',
+    isActive: true,
+    ...overrides,
+  } as VehicleFormValues;
+}
+
+describe('LOADING_TYPE_FROM_INT — backend LoadingType enum ile hizalama', () => {
+  it('Rear=0 → { direction: rear }', () => {
+    expect(LOADING_TYPE_FROM_INT[0]).toEqual({ direction: DoorDirection.Rear });
+  });
+
+  it('SideRight=1 → { direction: side, doorSide: right }', () => {
+    expect(LOADING_TYPE_FROM_INT[1]).toEqual({
+      direction: DoorDirection.Side,
+      doorSide: 'right',
+    });
+  });
+
+  it('SideLeft=2 → { direction: side, doorSide: left }', () => {
+    expect(LOADING_TYPE_FROM_INT[2]).toEqual({
+      direction: DoorDirection.Side,
+      doorSide: 'left',
+    });
+  });
+
+  it('SideBoth=3 → { direction: side }, doorSide belirsiz bırakılır', () => {
+    expect(LOADING_TYPE_FROM_INT[3]).toEqual({ direction: DoorDirection.Side });
+    expect(LOADING_TYPE_FROM_INT[3].doorSide).toBeUndefined();
+  });
+
+  it('Top=4 → { direction: top }', () => {
+    expect(LOADING_TYPE_FROM_INT[4]).toEqual({ direction: DoorDirection.Top });
+  });
+});
+
+describe('resolveLoadingType', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('null/undefined için undefined döner, uyarı basmaz', () => {
+    expect(resolveLoadingType(null)).toBeUndefined();
+    expect(resolveLoadingType(undefined)).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('bilinmeyen int için undefined döner ve konsola uyarı basar (sessizce yutmaz)', () => {
+    expect(resolveLoadingType(99)).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('99');
+  });
+
+  it('geçerli int için uyarı basmadan doğru eşlemeyi döner', () => {
+    expect(resolveLoadingType(2)).toEqual({ direction: DoorDirection.Side, doorSide: 'left' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('fromApiVehicle — backend loadingType int → Vehicle.doorDirection/doorSide', () => {
+  it.each([
+    [0, DoorDirection.Rear, undefined],
+    [1, DoorDirection.Side, 'right'],
+    [2, DoorDirection.Side, 'left'],
+    [3, DoorDirection.Side, undefined],
+    [4, DoorDirection.Top, undefined],
+  ] as const)('loadingType=%i → direction=%s doorSide=%s', (loadingType, direction, doorSide) => {
+    const vehicle = fromApiVehicle(makeApiVehicle({ loadingType }));
+    expect(vehicle.doorDirection).toBe(direction);
+    expect(vehicle.doorSide).toBe(doorSide);
+  });
+
+  it('bilinmeyen loadingType için Front varsayılanına düşer', () => {
+    const vehicle = fromApiVehicle(makeApiVehicle({ loadingType: 42 }));
+    expect(vehicle.doorDirection).toBe(DoorDirection.Front);
+    expect(vehicle.doorSide).toBeUndefined();
+  });
+
+  it('loadingType null için Front varsayılanına düşer', () => {
+    const vehicle = fromApiVehicle(makeApiVehicle({ loadingType: null }));
+    expect(vehicle.doorDirection).toBe(DoorDirection.Front);
+  });
+});
+
+describe('buildCreateVehiclePayload — frontend DoorDirection → backend loadingType int', () => {
+  it('rear → 0', () => {
+    const payload = buildCreateVehiclePayload(makeFormValues({ doorDirection: 'rear' }));
+    expect(payload.loadingType).toBe(0);
+  });
+
+  it('side + doorSide=right → 1 (SideRight)', () => {
+    const payload = buildCreateVehiclePayload(
+      makeFormValues({ doorDirection: 'side', doorSide: 'right' }),
+    );
+    expect(payload.loadingType).toBe(1);
+  });
+
+  it('side + doorSide=left → 2 (SideLeft)', () => {
+    const payload = buildCreateVehiclePayload(
+      makeFormValues({ doorDirection: 'side', doorSide: 'left' }),
+    );
+    expect(payload.loadingType).toBe(2);
+  });
+
+  it('side + doorSide belirtilmemiş → 1 (SideRight varsayılanı)', () => {
+    const payload = buildCreateVehiclePayload(makeFormValues({ doorDirection: 'side' }));
+    expect(payload.loadingType).toBe(1);
+  });
+
+  it('top → 4', () => {
+    const payload = buildCreateVehiclePayload(makeFormValues({ doorDirection: 'top' }));
+    expect(payload.loadingType).toBe(4);
+  });
+
+  it.each([0, 1, 2, 4] as const)(
+    'round-trip: backend int %i → frontend değerler → tekrar aynı backend int',
+    (loadingType) => {
+      const vehicle = fromApiVehicle(makeApiVehicle({ loadingType }));
+      const payload = buildCreateVehiclePayload(
+        makeFormValues({ doorDirection: vehicle.doorDirection, doorSide: vehicle.doorSide }),
+      );
+      expect(payload.loadingType).toBe(loadingType);
+    },
+  );
+
+  it('SideBoth=3 round-trip: doorSide belirsiz kaldığı için SideRight (1) olarak geri döner (bilinçli basitleştirme)', () => {
+    const vehicle = fromApiVehicle(makeApiVehicle({ loadingType: 3 }));
+    const payload = buildCreateVehiclePayload(
+      makeFormValues({ doorDirection: vehicle.doorDirection, doorSide: vehicle.doorSide }),
+    );
+    expect(payload.loadingType).toBe(1);
+  });
+});

--- a/apps/frontend/src/lib/api/vehicleMappers.ts
+++ b/apps/frontend/src/lib/api/vehicleMappers.ts
@@ -18,7 +18,7 @@ export const VEHICLE_TYPE_INT = {
   Kamposet: 3, // Romork
 } as const;
 
-// Backend: Rear=0, SideRight=1, SideLeft=2, SideBoth=3, Top=4
+// Backend: Trailer=0, Truck=1, Container=2, Romork=3
 export const VEHICLE_TYPE_FROM_INT: Record<number, VehicleType> = {
   0: VehicleType.Tir,
   1: VehicleType.Kamyon,
@@ -27,15 +27,42 @@ export const VEHICLE_TYPE_FROM_INT: Record<number, VehicleType> = {
 };
 
 // loadingType int → { direction, doorSide }
-// Backend: Rear=0, Side=1, Top=2
+// Backend (CargoPilot.Domain.Enums.LoadingType): Rear=0, SideRight=1, SideLeft=2, SideBoth=3, Top=4
 export const LOADING_TYPE_FROM_INT: Record<
   number,
   { direction: DoorDirection; doorSide?: 'right' | 'left' }
 > = {
   0: { direction: DoorDirection.Rear },
-  1: { direction: DoorDirection.Side },
-  2: { direction: DoorDirection.Top },
+  1: { direction: DoorDirection.Side, doorSide: 'right' },
+  2: { direction: DoorDirection.Side, doorSide: 'left' },
+  // SideBoth: hem sağ hem sol kapı var, frontend'de tek bir "her iki taraf" kavramı yok.
+  // En küçük doğru karşılık: side yönü, doorSide belirsiz bırakılır. loadOrder.ts ve
+  // ContainerMesh/VehiclePreview3D, doorSide tanımsızken sağ kapı varsayımına düşer —
+  // yani SideBoth aracı, sağ kapıdan yükleniyormuş gibi gösterilir/sıralanır (yanlış değil,
+  // eksik bilgiyle en güvenli varsayım).
+  3: { direction: DoorDirection.Side },
+  4: { direction: DoorDirection.Top },
 };
+
+/**
+ * Backend loadingType (int) değerini { direction, doorSide } çiftine çevirir.
+ * - null/undefined: veri yok, `undefined` döner — çağıran taraf kendi varsayılanını uygular.
+ * - Eşleşmeyen/bilinmeyen int (tabloda karşılığı olmayan): backend'e yeni bir LoadingType
+ *   değeri eklenmiş ya da veri bozuk olabilir — sessizce yutulmaz, konsola uyarı basılır ve
+ *   `undefined` döner (çağıran taraf kendi varsayılanına bilinçli olarak düşer).
+ */
+export function resolveLoadingType(
+  loadingType: number | null | undefined,
+): { direction: DoorDirection; doorSide?: 'right' | 'left' } | undefined {
+  if (loadingType == null) return undefined;
+  const mapped = LOADING_TYPE_FROM_INT[loadingType];
+  if (!mapped) {
+    console.warn(
+      `[vehicleMappers] Bilinmeyen loadingType değeri: ${loadingType} — eşleme tablosunda karşılığı yok, varsayılana düşülüyor.`,
+    );
+  }
+  return mapped;
+}
 
 // ─── Backend response schema ──────────────────────────────────────────────────
 
@@ -146,6 +173,7 @@ export function fromApiVehicleDetail(api: VehicleDetailApi): Vehicle {
 
   const vehicleType = VEHICLE_TYPE_FROM_INT[api.vehicleType] ?? VehicleType.Tir;
   const isContainer = vehicleType === VehicleType.Konteyner;
+  const loadingTypeInfo = resolveLoadingType(api.loadingType);
   return {
     id: api.id,
     name: api.vehicleName,
@@ -158,8 +186,8 @@ export function fromApiVehicleDetail(api: VehicleDetailApi): Vehicle {
     height: api.internalHeight,
     maxCargoWeight: api.maxWeightCapacity,
     maxLayerCount: api.layerCount ?? undefined,
-    doorDirection: LOADING_TYPE_FROM_INT[api.loadingType ?? -1]?.direction ?? DoorDirection.Front,
-    doorSide: LOADING_TYPE_FROM_INT[api.loadingType ?? -1]?.doorSide,
+    doorDirection: loadingTypeInfo?.direction ?? DoorDirection.Front,
+    doorSide: loadingTypeInfo?.doorSide,
     kingpin,
     axleB,
     axles: additionalAxle ? [additionalAxle] : undefined,
@@ -207,6 +235,7 @@ export function fromApiVehicle(api: VehicleApi): Vehicle {
 
   const vehicleType = VEHICLE_TYPE_FROM_INT[api.vehicleType] ?? VehicleType.Tir;
   const isContainer = vehicleType === VehicleType.Konteyner;
+  const loadingTypeInfo = resolveLoadingType(api.loadingType);
   return {
     id: api.id,
     name: api.vehicleName,
@@ -221,8 +250,8 @@ export function fromApiVehicle(api: VehicleApi): Vehicle {
     grossWeight: api.grossWeight ?? undefined,
     tareWeight: api.tareWeight ?? undefined,
     maxLayerCount: api.layerCount ?? undefined,
-    doorDirection: LOADING_TYPE_FROM_INT[api.loadingType ?? -1]?.direction ?? DoorDirection.Front,
-    doorSide: LOADING_TYPE_FROM_INT[api.loadingType ?? -1]?.doorSide,
+    doorDirection: loadingTypeInfo?.direction ?? DoorDirection.Front,
+    doorSide: loadingTypeInfo?.doorSide,
     kingpin,
     axleB,
     axles: additionalAxle ? [additionalAxle] : undefined,
@@ -316,9 +345,15 @@ export function buildCreateVehiclePayload(values: VehicleFormValues): CreateVehi
       ? toKilograms(values.maxCargoWeight, weightUnit as WeightUnitKey)
       : 0,
     layerCount: Number.isFinite(values.layerCount) ? (values.layerCount ?? 1) : 1,
+    // Backend LoadingType: Rear=0, SideRight=1, SideLeft=2, SideBoth=3, Top=4.
+    // 'front' ve 'rearAndSide' için backend'de birebir karşılık yok — Rear (0) varsayılanına düşülür.
     loadingType: (() => {
-      const map: Record<string, number> = { rear: 0, side: 1, top: 2 };
-      return map[values.doorDirection] ?? 0;
+      if (values.doorDirection === 'rear') return 0;
+      if (values.doorDirection === 'top') return 4;
+      if (values.doorDirection === 'side') {
+        return values.doorSide === 'left' ? 2 : 1; // SideLeft : SideRight (belirtilmemişse sağ)
+      }
+      return 0;
     })(),
     isActive: values.isActive ?? true,
     kingPinDistanceMm: Number.isFinite(values.kingpin?.distance) ? values.kingpin!.distance : null,

--- a/apps/frontend/src/lib/utils/geometry/boxOrientations.test.ts
+++ b/apps/frontend/src/lib/utils/geometry/boxOrientations.test.ts
@@ -102,6 +102,37 @@ describe('isOrientationAllowed', () => {
       expect(isOrientationAllowed(item, idx as 0 | 1 | 2 | 3 | 4 | 5)).toBe(true);
     }
   });
+
+  it.each([
+    [0, 'allowFaceBottom'],
+    [1, 'allowFaceTop'],
+    [2, 'allowFaceFront'],
+    [3, 'allowFaceBack'],
+    [4, 'allowFaceLeft'],
+    [5, 'allowFaceRight'],
+  ] as const)('idx %i → %s=false o orientation için reddeder', (idx, faceKey) => {
+    const item = makeItem({ [faceKey]: false });
+    expect(isOrientationAllowed(item, idx)).toBe(false);
+  });
+
+  it('allowFace*=false diğer indexleri etkilemez', () => {
+    const item = makeItem({ allowFaceTop: false });
+    expect(isOrientationAllowed(item, 0)).toBe(true);
+    expect(isOrientationAllowed(item, 2)).toBe(true);
+    expect(isOrientationAllowed(item, 3)).toBe(true);
+    expect(isOrientationAllowed(item, 4)).toBe(true);
+    expect(isOrientationAllowed(item, 5)).toBe(true);
+  });
+
+  it('eksen izinli olsa da yüz kısıtı reddederse orientation izinsizdir', () => {
+    const item = makeItem({ allowRotateX: true, allowFaceFront: false });
+    expect(isOrientationAllowed(item, 2)).toBe(false);
+  });
+
+  it('yüz izinli olsa da eksen kısıtı reddederse orientation izinsizdir', () => {
+    const item = makeItem({ allowRotateX: false, allowFaceFront: true });
+    expect(isOrientationAllowed(item, 2)).toBe(false);
+  });
 });
 
 describe('allowedOrientations', () => {
@@ -120,5 +151,15 @@ describe('allowedOrientations', () => {
   it('hepsi kapalı → sadece identity (idx 0)', () => {
     const item = makeItem({ allowRotateX: false, allowRotateZ: false });
     expect(allowedOrientations(item)).toEqual([0]);
+  });
+
+  it('allowFaceTop=false → idx 1 hariç tüm eksen-izinli set döner', () => {
+    const item = makeItem({ allowFaceTop: false });
+    expect(allowedOrientations(item)).toEqual([0, 2, 3, 4, 5]);
+  });
+
+  it('allowRotateX=false + allowFaceLeft=false birlikte → sadece 0, 5', () => {
+    const item = makeItem({ allowRotateX: false, allowFaceLeft: false });
+    expect(allowedOrientations(item)).toEqual([0, 5]);
   });
 });

--- a/apps/frontend/src/lib/utils/scene/loadOrder.test.ts
+++ b/apps/frontend/src/lib/utils/scene/loadOrder.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { PlacementWithDimensions } from '@/lib/types/loadingPlan';
+import { buildLoadOrder } from './loadOrder';
+
+function makePlacement(overrides: Partial<PlacementWithDimensions> = {}): PlacementWithDimensions {
+  return {
+    itemId: '00000000-0000-0000-0000-000000000001',
+    positionX: 0,
+    positionY: 0,
+    positionZ: 0,
+    orientationIndex: 0,
+    layer: 1,
+    isViolation: false,
+    width: 50,
+    height: 50,
+    depth: 50,
+    weight: 10,
+    ...overrides,
+  };
+}
+
+describe('buildLoadOrder — yan kapı (side) sağ/sol dalı', () => {
+  // Aynı Y ve Z'de, X=0 (sol duvar) ve X=100 (sağ duvar) kutuları.
+  const leftBox = makePlacement({ positionX: 0 });
+  const rightBox = makePlacement({ positionX: 100 });
+  const placements = [rightBox, leftBox]; // index 0 = sağdaki, index 1 = soldaki
+
+  it('doorSide=right → kapı X=width, sol duvar (X küçük) önce girer', () => {
+    const order = buildLoadOrder(placements, 'side', 'right');
+    // leftBox (index 1, X=0) sağ kapıya en uzak → önce girer
+    expect(order).toEqual([1, 0]);
+  });
+
+  it('doorSide=left → kapı X=0, sağ duvar (X büyük) önce girer', () => {
+    const order = buildLoadOrder(placements, 'side', 'left');
+    // rightBox (index 0, X=100) sol kapıya en uzak → önce girer
+    expect(order).toEqual([0, 1]);
+  });
+
+  it('doorSide belirtilmemiş → sağ kapı varsayımına düşer (SideBoth eşlemesiyle tutarlı)', () => {
+    const withoutSide = buildLoadOrder(placements, 'side', undefined);
+    const withRight = buildLoadOrder(placements, 'side', 'right');
+    expect(withoutSide).toEqual(withRight);
+  });
+});
+
+describe('buildLoadOrder — rear ve top dalları (referans, regresyon koruması)', () => {
+  it('rear: Z büyükten küçüğe sıralanır (kapıya en uzak önce)', () => {
+    const near = makePlacement({ positionZ: 0 });
+    const far = makePlacement({ positionZ: 200 });
+    const order = buildLoadOrder([near, far], 'rear');
+    expect(order).toEqual([1, 0]);
+  });
+
+  it('top: Y küçükten büyüğe sıralanır (zemin katı önce)', () => {
+    const bottom = makePlacement({ positionY: 0 });
+    const top = makePlacement({ positionY: 100 });
+    const order = buildLoadOrder([top, bottom], 'top');
+    expect(order).toEqual([1, 0]);
+  });
+});

--- a/cargo-pilot.sln
+++ b/cargo-pilot.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -13,6 +13,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.Infrastructure", "apps\backend\CargoPilot.Infrastructure\CargoPilot.Infrastructure.csproj", "{E77D7D49-8EF0-4E3A-67E8-CA37E299AA5E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.WebAPI", "apps\backend\CargoPilot.WebAPI\CargoPilot.WebAPI.csproj", "{4618B678-DBA1-7394-A174-B0F4FF20BA42}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CargoPilot.Infrastructure.Tests", "apps\backend\CargoPilot.Infrastructure.Tests\CargoPilot.Infrastructure.Tests.csproj", "{CE7ABED3-744E-4A97-8353-C8E57A1DA532}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,6 +38,10 @@ Global
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -46,6 +52,7 @@ Global
 		{73B7F73A-6F8A-4518-CEF9-C809F44E5ACD} = {270F7A58-C097-D64B-0343-582534E94D4F}
 		{E77D7D49-8EF0-4E3A-67E8-CA37E299AA5E} = {270F7A58-C097-D64B-0343-582534E94D4F}
 		{4618B678-DBA1-7394-A174-B0F4FF20BA42} = {270F7A58-C097-D64B-0343-582534E94D4F}
+		{CE7ABED3-744E-4A97-8353-C8E57A1DA532} = {270F7A58-C097-D64B-0343-582534E94D4F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {33884C42-0BAE-4853-8852-85F38E436D95}

--- a/docs/conventions/branching.md
+++ b/docs/conventions/branching.md
@@ -133,6 +133,10 @@ gh pr create --base dev --head feat/US-142-login-form
 gh pr create --base test --head dev --title "Terfi: dev → test"
 ```
 
+PR açıldıktan ve CI (zorunlu kontroller) çalışmaya başladıktan sonra **Terfi** workflow'unu
+tetikleyin (Actions → Terfi → Run workflow, hedef: `dev-test`). Workflow kontrollerin
+yeşile dönmesini bekler ve PR'ı merge commit ile birleştirir.
+
 **Merge yöntemi: merge commit.** Squash yapılırsa `test`, `dev`'de olmayan yeni bir commit alır
 ve dallar kalıcı olarak ayrışır.
 
@@ -144,7 +148,29 @@ Merge sonrası test sunucusuna otomatik deploy olur — geliştiriciler ve QA bu
 gh pr create --base main --head test --title "Sürüm: test → main"
 ```
 
+PR açıldıktan sonra **Terfi** workflow'unu tetikleyin (Actions → Terfi → Run workflow,
+hedef: `test-main`).
+
 Merge sonrası CI otomatik `v0.<n>.0` sürüm etiketi atar.
+
+{% hint style="warning" %}
+**Bu PR'ları elle `gh pr merge` ile merge ETMEYİN.** Merge-commit ile terfi modelinde
+`test`/`main` dalı `dev`/`test`'te olmayan bir merge commit içerir; bu yüzden terfi PR'ının
+`mergeStateStatus` değeri kalıcı olarak `BEHIND` görünür ve `gh pr merge`'ün istemci tarafı
+kontrolü merge'i şu hatayla reddeder:
+
+```
+X Pull request #928 is not mergeable: the head branch is not up to date with the base branch.
+```
+
+Bu bir ruleset arızası değildir (üç ruleset'te de `strict_required_status_checks_policy`
+kapalıdır) — `BEHIND` durumu, merge-commit ile terfi modelinin doğal ve zararsız sonucudur.
+Doğru yol yukarıdaki **Terfi** workflow'udur (`.github/workflows/promote.yml`). Workflow
+kullanılamıyorsa GitHub REST API (`gh api repos/<org>/<repo>/pulls/<PR>/merge -X PUT -f
+merge_method=merge`) veya GitHub arayüzündeki **"Merge pull request"** düğmesi kullanılabilir
+— ikisi de `gh pr merge`'ün istemci tarafı kontrolünü uygulamaz. Korumaları atlamak için
+**`--admin` veya bypass kullanılmaz.**
+{% endhint %}
 
 ---
 


### PR DESCRIPTION
Faz 0 hata temizliğinin tamamı ve terfi otomasyonu `main`'e çıkıyor.

## İçerik

| Görev | PR | Özet |
|---|---|---|
| F0-02 · Rotasyon kontrolünün doğrulanması | #927 | Backend birim test projesi (`CargoPilot.Infrastructure.Tests`) kuruldu; 16 rotasyon karakterizasyon testi + frontend'e 13 `allowFace*` senaryosu. Üretim davranışı değişmedi. |
| F0-01 · Kapı yönü hatalarının giderilmesi | #926 | LIFO bölge → Z eşlemesi tersti; `unloadingOrder=1` (ilk inecek) artık kapıya en yakın bölgeye düşüyor. Ayrıca bölge başlangıçları extreme point olarak tohumlandı — aksi hâlde hiçbir grup kendi bölgesine ulaşamıyordu. |
| F0-03 · Fantom bölge cezasının kaldırılması | #925 | `TryGetValue` dönüşü yok sayıldığı için bölgesiz her kutu sabit ceza alıyor, ağırlık dengesi kriteri işlevsiz kalıyordu. Eşleşme yoksa artık ceza uygulanmıyor. |
| F0-04 · Frontend kapı yönü enum eşlemesi | #930 | `LOADING_TYPE_FROM_INT` backend `LoadingType` enum'ı ile hizalandı; `SideLeft` araçlar arayüzde "üstten yükleme" görünmüyor artık. Ters yön eşlemesi de düzeltildi. |
| INFRA-01 · Terfi otomasyonu | #932 | `workflow_dispatch` ile çalışan `promote.yml`; açık terfi PR'ını bulur, zorunlu kontrolleri bekler, REST API ile merge commit yapar. |

## Doğrulama

- Birleşik ağaçta `dotnet test cargo-pilot.sln -c Release`: **20/20 backend testi** geçiyor.
- Frontend: **166/166 Vitest testi** (30'u yeni).
- Beş PR'ın da Frontend CI, Backend CI, Image Build ve Deploy (Test) kontrolleri yeşil geçti; test sunucusuna iki ayrı deploy başarıyla tamamlandı.
- Her algoritma düzeltmesi mutation-check ile sınandı: düzeltme geri alındığında ilgili testler kırmızıya döndü.

## Bu terfiyle birlikte devreye giren

`promote.yml` varsayılan dala (`main`) ulaştığı için bundan sonra Actions arayüzünden **Terfi** workflow'u tetiklenebilir hâle gelir. `PROMOTION_PAT` secret'ı eklendi; ilk gerçek koşuda token kapsamlarının doğruluğu görülecek.

## Takip gerektiren, kapsam dışı bırakılan bulgular

- `LoadingType.Rear` dışındaki kapı yönleri için bölge desteği yok; `ComputeGroupZones` yan/üst kapıda erken dönüyor.
- `UnplacedReason` içindeki `RotationOrGeometryConstraint` ve diğer üyeler motor tarafından hiç atanmıyor; rotasyon kısıtı yüzünden yerleşemeyen kutu genel `InsufficientSpace` ile raporlanıyor.
- Backend'in 6 eksen-permütasyonu modeli ile frontend'in 6 yüz-aşağı preset modeli farklı soyutlamalar — Faz 1'in birleştirme işinin girdisi.
- `apps/backend/CargoPilot.slnx` CI tarafından kullanılmıyor.
