### PR TITLE
Terfi: test → main

### DIFF
--- a/docs/COORDINATE_AUDIT.md
+++ b/docs/COORDINATE_AUDIT.md
@@ -1,0 +1,736 @@
+# Koordinat Sistemi Denetimi (Coordinate Audit)
+
+**Referans standart:** [`COORDINATE_STANDARD.md`](./COORDINATE_STANDARD.md) ·
+[`coordinate-standard.html`](./coordinate-standard.html)
+**Tarih:** 2026-08-12 · **Sürüm:** 2 (yeni standarda göre baştan yazıldı)
+**Kapsam:** `apps/frontend/src`, `apps/backend`, repo kökündeki prototip HTML,
+`.claude` doküman dosyaları
+**Kapsam dışı:** `node_modules`, `bin`/`obj`, EF Core migration snapshot'ları,
+`.claude/worktrees` kopyaları
+
+> Bu denetim **yalnızca rapordur** — hiçbir kaynak dosya değiştirilmemiştir.
+
+> **Sürüm 1'e göre ne değişti:** origin sağ-alt yerine **sol-alt**, `depth` yerine
+> **`length`**, kapılar front/rear/sağ/sol yerine **small/big**. Bunun sonucunda önceki
+> denetimde ihlal sayılan bazı maddeler **artık uyumludur** — bkz. bölüm 4
+> ("Artık uyumlu — dokunulmayacak"). O bölümü okumadan düzeltmeye başlamayın; aksi
+> hâlde doğru olan kodu bozarsınız.
+
+---
+
+## 1. Özet
+
+### 1.1 Severity dağılımı
+
+| Severity   | Adet |
+| ---------- | ---- |
+| **High**   | 9    |
+| **Medium** | 15   |
+| **Low**    | 8    |
+| **Toplam** | **32** |
+
+### 1.2 Dosya bazında dağılım
+
+| Dosya | High | Med | Low | Bulgular |
+| ----- | ---- | --- | --- | -------- |
+| `apps/backend/…/Optimization/LifoPlacement.cs` | 1 | – | – | H-01 |
+| `apps/backend/…/Optimization/OptimizationEngine.cs` | 1 | – | – | H-09 |
+| `apps/backend/…/Optimization/VolumeScoring.cs` | – | 1 | – | M-11 |
+| `apps/backend/CargoPilot.Domain/Enums/LoadingType.cs` | 1 | – | – | H-07 |
+| `apps/backend/…/Models/OptimizationResult.cs` | – | 1 | – | M-11 |
+| `apps/backend/…/Shares/GetSharePlanByToken/SharePlanDto.cs` | – | 1 | – | M-11 |
+| `…/planning/scene/components/ContainerMesh.tsx` | 1 | 1 | – | H-02, M-02 |
+| `…/planning/scene/hooks/useLoadingAnimation.ts` | 1 | – | – | H-03 |
+| `…/lib/utils/scene/loadOrder.ts` | 1 | – | – | H-04 |
+| `…/lib/utils/geometry/calcCenterOfGravity.ts` | 1 | 1 | – | H-05, M-13 |
+| `…/data-management/vehicles/components/VehiclePreview3D.tsx` | 1 | 1 | – | H-06, M-02 |
+| `…/lib/types/vehicle.ts` | 1 | – | – | H-07 |
+| `…/data-management/vehicles/components/VehicleDimensionsFields.tsx` | 1 | – | – | H-10 |
+| `…/lib/types/loadingPlan.ts` | – | 1 | 1 | M-00, L-05 |
+| `…/lib/types/share.ts` | – | 1 | – | M-00 |
+| `…/lib/store/usePlanStore.ts` | – | 2 | 1 | M-00, M-12, L-03 |
+| `…/lib/api/loadingPlanMappers.ts` | – | 2 | – | M-00, M-12 |
+| `…/lib/api/vehicleMappers.ts` | – | 1 | – | M-01 |
+| `…/lib/config/scene-config.ts` | – | 1 | – | M-03 |
+| `…/lib/utils/scene/sceneFilter.ts` | – | 2 | – | M-00, M-04 |
+| `…/planning/scene/components/CameraPresetButtons.tsx` | – | 1 | – | M-05 |
+| `…/planning/scene/components/CargoMeshInstanced.tsx` | – | 1 | – | M-06 |
+| `…/planning/scene/components/BoxWrapper.tsx` | – | 1 | – | M-07 |
+| `…/planning/scene/CLAUDE.md` · `apps/frontend/.claude/CLAUDE.md` | – | 1 | – | M-08 |
+| `…/products/components/ProductTable.tsx` | – | 1 | – | M-09 |
+| `…/imports/components/ERPItemsTable.tsx` | – | 1 | – | M-09 |
+| `…/imports/components/BulkImportDialog.tsx` | – | 1 | 1 | M-09, L-07 |
+| `…/products/components/ProductForm.tsx` | – | 1 | – | M-10 |
+| `…/lib/utils/geometry/geometry.ts` | – | 1 | – | M-13 |
+| `…/lib/utils/geometry/checkOrientationFit.ts` | – | 1 | 1 | M-13, L-08 |
+| `tip1_animasyonlu_planlayici (1).html` (repo kökü) | – | 1 | – | M-14 |
+| `…/lib/utils/export/export-utils.ts` | – | – | 1 | L-01 |
+| `…/planning/scene/components/SelectedBoxCoords.tsx` | – | – | 1 | L-02 |
+| `…/lib/utils/geometry/boxOrientations.ts` | – | – | 1 | L-04 |
+| `…/lib/utils/geometry/calcVolume.ts` | – | – | 1 | L-06 |
+| `…/imports/components/VehicleBulkImportDialog.tsx` | – | – | 1 | L-07 |
+
+### 1.3 Üç kök neden
+
+**KÖK-1 — `z` ekseni yönü ters.**
+Kod genelinde `z = 0` **kapı**, `z = length` **kabin/uzak uç** kabul edilir. Standartta tam
+tersi: `z = 0` uzak yüz, `z = length` referans kapı. Tek başına bu fark 6 dosyayı doğrudan
+bozuyor (H-01…H-06) ve 2 dosyayı dolaylı etkiliyor (M-04, M-05).
+
+**KÖK-2 — Kapı modeli eski.**
+Kapılar hâlâ `front / rear / side / top` yön enum'u olarak tutuluyor; standart
+`small / big` tipi + yüz (`z=length`, `x=0`, `x=width`) çifti ve **liste** istiyor. Bir
+araçta aynı anda birden fazla kapı olabildiği için tekil enum bilgi kaybediyor (H-07,
+M-01, M-02).
+
+**KÖK-3 — `depth` terimi.**
+`z` boyutu frontend'de `depth`, backend DTO'larında `Depth` olarak taşınıyor; standart
+terim artık **`length`**. Frontend'de 23 dosya, 117 kullanım (M-00, M-11, M-12).
+
+---
+
+## 2. Bulgular
+
+### H-01 · `z = 0` kapı kabul ediliyor (motor) — **HIGH**
+
+**Dosya:** `apps/backend/CargoPilot.Application/Common/Optimization/LifoPlacement.cs:36-40`
+
+```csharp
+// Arka kapı Z=0'dadır. UnloadingOrder=1 ilk inecek gruptur, bu yüzden kapıya
+// en yakın (en küçük Z) bölgeye düşer.
+```
+
+**Kullanılan konvansiyon:** `z = 0` → kapı; `z = VehicleLength` → uzak uç.
+**İhlal:** Standartta `z = 0` uzak yüz, `z = length` referans kapıdır. LIFO bölgeleri ters
+uçtan başlıyor; ilk inecek grup fiilen kapının en uzağına yerleşiyor.
+**Fix:** Bölge indekslemesini tersine çevir (`ZStart = length − (i+1)·zoneSize`) ya da tek
+noktada `z' = length − z − d` dönüşümü uygula.
+
+---
+
+### H-02 · Kapı meshleri ters uçlarda — **HIGH**
+
+**Dosya:** `apps/frontend/src/features/planning/scene/components/ContainerMesh.tsx:302-348`
+
+```tsx
+case 'rear':
+  // Arka kapı: Z=0 yüzü
+  return (<group position={[0, 0, 0]}><RearDoors .../></group>);
+...
+default:
+  // 'front' veya undefined — ön yüz (Z=length)
+  return (<group position={[0, 0, length]}><RearDoors .../></group>);
+```
+
+**Kullanılan konvansiyon:** kapı `z = 0`, "ön yüz" `z = length`.
+**İhlal:** Standartta referans kapı `z = length`, uzak yüz `z = 0`. Ayrıca **"front door"
+diye bir kapı yok** — default dalı geçersiz bir kapıyı çiziyor. Dosya içindeki
+`SideDoor` / `TopDoor` yorumları (satır 198-201, 240, 253, 314) da `Z=0`'ı "arka" olarak
+adlandırıyor.
+**Fix:** Referans kapıyı `position={[0,0,length]}`'e taşı, `front` dalını kaldır, kapı
+seçimini `doors` listesine göre yap.
+
+---
+
+### H-03 · Yükleme animasyonu yanlış uçtan giriyor — **HIGH**
+
+**Dosya:** `apps/frontend/src/features/planning/scene/hooks/useLoadingAnimation.ts:110-139`
+
+```ts
+case 'rear':
+  // Arka kapı: Z=0 önünden girer
+  fromZ = -OFFSET;
+  break;
+...
+default:
+  // 'front' veya undefined — Z=depth önünden girer
+  fromZ = depth + OFFSET;
+```
+
+**İhlal:** Referans kapı `z = length`'te olduğu için kutular kapıdan değil, uzak duvarın
+(TIR'da kabinin) içinden geçerek giriyor. Ayrıca parametre adı `vehicleDepth` (satır 63-64)
+— standart terim `length`.
+**Fix:** Referans kapı için `fromZ = length + OFFSET`; big door için `fromX = −OFFSET`
+(x = 0 yüzü) veya `width + OFFSET` (x = width yüzü).
+
+---
+
+### H-04 · Yükleme sırası ters yönde — **HIGH**
+
+**Dosya:** `apps/frontend/src/lib/utils/scene/loadOrder.ts:5-18, 31-66`
+
+```ts
+ * rear  (Z=0):       Z büyük→küçük, sonra Y küçük→büyük (alt kat önce), X küçük→büyük
+ * front (Z=length):  Z küçük→büyük, sonra Y küçük→büyük, X küçük→büyük
+```
+
+**İhlal:** Standarda göre yükleme her zaman `z = 0`'dan (uzak yüz) `z = length`'e (kapı)
+doğru ilerler. `rear` dalındaki `z` azalan sıralama tam tersi. `front` dalı ise artık
+karşılığı olmayan bir kapı tipini temsil ediyor.
+**Fix:** Referans kapı yüklemesinde `z` **artan**; big door yüklemesinde kapının olduğu
+yüzden uzağa doğru `x` sıralaması.
+
+---
+
+### H-05 · Dingil yükü payları ters — **HIGH**
+
+**Dosya:** `apps/frontend/src/lib/utils/geometry/calcCenterOfGravity.ts:38, 105, 122-124`
+
+```ts
+/** Front axle load share (0..1) — Z=0 is rear, Z=containerLength is front */
+...
+// Moment-based axle shares: rear axle at Z=0, front axle at Z=containerLength
+const frontAxleShare = containerLength > 0 ? cog.z / containerLength : 0.5;
+```
+
+**Kullanılan konvansiyon:** `z = 0` → arka aks, `z = length` → ön aks (kabin).
+**İhlal:** Standartta `z = 0` uzak yüz = **kabin ucu**, `z = length` back door. Yani
+`frontAxleShare` fiilen **arka** aksın payını veriyor. Ağırlık merkezi kabine yakınken
+arayüz "arka aks yüklü" diyor — güvenlik/mevzuat açısından en riskli bulgu.
+**Fix:** `frontAxleShare = 1 − cog.z / length`; yorumları ve `containerLength` parametre
+adını (`length`) standarda göre düzelt.
+
+---
+
+### H-06 · Çekici kabini yanlış uçta modellenmiş — **HIGH**
+
+**Dosya:** `apps/frontend/src/features/data-management/vehicles/components/VehiclePreview3D.tsx:283, 354-366`
+
+```tsx
+<group position={[0, 0, cargoLength + gapLength]}>   {/* kabin */}
+...
+{/* Ön kapı — Z=length yüzü */}   {isFront && <mesh position={[width/2, height/2, length + …]}>}
+{/* Arka kapı — Z=0 yüzü */}      {isRear  && <mesh position={[width/2, height/2, -…]}>}
+```
+
+**İhlal:** Standartta kabin (uzak yüz) `z = 0`'dadır ve **front door yoktur**. Önizleme,
+kabini `z = length` ucuna koyup back door'u `z = 0`'a alarak ekseni tersine çeviriyor.
+**Fix:** Kabini `z < 0` tarafına al, back door'u `z = length` yüzüne taşı, `isFront`
+dalını kaldır.
+
+---
+
+### H-07 · Kapı modeli standarda uymuyor — **HIGH**
+
+**Dosyalar:** `apps/frontend/src/lib/types/vehicle.ts:11-18` ·
+`apps/backend/CargoPilot.Domain/Enums/LoadingType.cs:3-9`
+
+```ts
+export const DoorDirection = {
+  Front: 'front', Rear: 'rear', Side: 'side', Top: 'top', RearAndSide: 'rearAndSide',
+} as const;
+```
+
+```csharp
+public enum LoadingType { Rear = 0, SideRight = 1, SideLeft = 2, SideBoth = 3, Top = 4 }
+```
+
+**Kullanılan konvansiyon:** Kapı = tekil yön enum'u (front/rear/side/top).
+**İhlal:** Üç ayrı ihlal bir arada:
+1. Standart kapıları **boyuta** göre sınıflar (`small` / `big`), yöne göre değil.
+2. **`Front` diye bir kapı yoktur** — frontend bu değeri tanımlıyor ve `ContainerMesh`
+   default dalında kullanıyor (H-02).
+3. Kapı bilgisi **liste** olmalı; bir araçta small door + iki big door aynı anda
+   bulunabilir. Tekil enum bunu ifade edemiyor (`SideBoth` bilgi kaybıyla tek tarafa
+   düşüyor — M-01).
+
+**Fix:** `doors: Array<{ type: 'small' | 'big'; face: 'z=0' | 'z=length' | 'x=0' | 'x=width' }>`
+modeline geç; backend enum'unu bu listeye eşleyen bir migration + uyumluluk katmanı yaz.
+`top` kapının karşılığı sektör araştırmasına bağlı (bkz. bölüm 5).
+
+---
+
+### H-09 · Big door açıklık payı (`x₀`) hiçbir yerde uygulanmıyor — **HIGH** 🔒
+
+**Dosya:** `apps/backend/CargoPilot.Application/Common/Optimization/OptimizationEngine.cs:39, 86-92`
+
+```csharp
+var extremePoints = new HashSet<(decimal x, decimal y, decimal z)> { (0m, 0m, 0m) };
+...
+if (ex + w > input.VehicleWidth)  continue;
+```
+
+**Kullanılan konvansiyon:** Yerleştirme her zaman `x = 0`'dan başlar, `x` üst sınırı
+`VehicleWidth`.
+**İhlal:** Standart, big door `x = 0` yüzündeyse yüklemenin `(x₀, 0, 0)`'dan başlamasını
+istiyor. Motorda ne `x₀` kavramı ne de big door'un hangi yüzde olduğu bilgisi var.
+**Fix:** `OptimizationInput`'a `xMin` (ve gerekirse `xMax`) ekle; tohum noktasını ve sınır
+kontrolünü buna göre kur.
+🔒 **Bloke:** `x₀` değeri henüz tanımlı değil (bkz. bölüm 5). Değer netleşmeden
+uygulanamaz.
+
+---
+
+### H-10 · Araç formunda eksen etiketleri takas — **HIGH**
+
+**Dosya:** `apps/frontend/src/features/data-management/vehicles/components/VehicleDimensionsFields.tsx:37-43, 107-113`
+
+```tsx
+{/* X — Uzunluk */}
+<FormField name="length" ... <FormLabel>Uzunluk/Çap (X)</FormLabel>   // placeholder 1350
+{/* Z — Derinlik */}
+<FormField name="width"  ... <FormLabel>Derinlik (Z)</FormLabel>      // placeholder 240
+```
+
+**Kullanılan konvansiyon:** `length → x`, `width → z`.
+**İhlal:** Sahne bunun tam tersini yapıyor — `ContainerMesh` `boxGeometry args={[width,
+height, length]}` ile `width → x`, `length → z` eşliyor. Standarda göre de doğru olan
+sahnedeki eşleme. Form etiketleri hem eksen hem terim olarak yanlış: `length` alanı "(X)"
+diyor, `width` alanı "Derinlik (Z)" diyor. Değerler tesadüfen fiziksel olarak doğru yere
+düştüğü için hata sessiz.
+**Fix:** `length` → `Uzunluk (Z)`, `width` → `Genişlik (X)`, `height` → `Yükseklik (Y)`.
+
+---
+
+### M-00 · `depth` terimi tip sözleşmesinde — **MEDIUM**
+
+**Dosyalar:** `lib/types/loadingPlan.ts:36` · `lib/types/share.ts:60` ·
+`lib/utils/geometry/calcCenterOfGravity.ts:9,64,91` · `lib/utils/geometry/geometry.ts:15-16` ·
+`lib/utils/geometry/checkOrientationFit.ts:6,29` · `lib/utils/geometry/boxOrientations.ts:66,80-86` ·
+`lib/utils/scene/sceneFilter.ts:5` · `lib/store/usePlanStore.ts:53,66,164,216,248,708-717` ·
+`lib/api/loadingPlanMappers.ts:386` — toplam **23 dosya, 117 kullanım**
+
+```ts
+export const placementWithDimensionsSchema = placementSchema.extend({
+  width: z.number().positive(),
+  height: z.number().positive(),
+  depth: z.number().positive(),
+```
+
+**İhlal:** Standart terim **`length`**; `depth` açıkça yasak. Bugün geometriyi bozmuyor —
+değer doğru eksende — ancak aynı fiziksel büyüklük sistemde iki adla dolaşıyor
+(`item.length` ↔ `placement.depth`) ve bu, standardın yasakladığı belirsizliğin ta
+kendisi.
+**Fix:** `depth` → `length` yeniden adlandırması; `placementWithDimensionsSchema` bu
+zincirin başı olduğu için önce orası. Rename mekanik ama 23 dosyaya dokunduğu için tek bir
+PR'da, davranış değişikliği olmadan yapılmalı.
+
+---
+
+### M-01 · `LOADING_TYPE_FROM_INT` eşlemesi bilgi kaybediyor — **MEDIUM**
+
+**Dosya:** `apps/frontend/src/lib/api/vehicleMappers.ts:29-45` ·
+test: `vehicleMappers.test.ts:114`
+
+```ts
+// SideBoth: hem sağ hem sol kapı var, frontend'de tek bir "her iki taraf" kavramı yok.
+3: { direction: DoorDirection.Side },
+```
+
+**İhlal:** Standart, iki big door'u ayrı ayrı modelliyor; `SideBoth` tek bir belirsiz
+`side` değerine düşürülüyor ve `doorSide` tanımsız kalıp "sağ kapı" varsayımına iniyor.
+Ayrıca bilinmeyen `loadingType` değeri testte `Front` varsayılanına düşüyor — `Front`
+artık geçersiz bir kapı.
+**Fix:** Eşlemeyi `doors` listesine çevir: `3 → [{type:'big',face:'x=0'},{type:'big',face:'x=width'}]`.
+
+---
+
+### M-02 · "sağ / sol kapı" adlandırması — **MEDIUM**
+
+**Dosyalar:** `ContainerMesh.tsx:295-311` · `VehiclePreview3D.tsx:349-350, 368` ·
+`vehicleSchema.ts:69` · `loadOrder.ts:38-45`
+
+```tsx
+// doorSide: 'right' → X=width yüzü (+X), 'left' veya undefined → X=0 yüzü (-X)
+const sideX = doorSide === 'right' ? width + DOOR_PANEL_T / 2 : -DOOR_PANEL_T / 2;
+```
+
+**Durum:** Eşlemenin **yönü doğru** — standartta da kapı görünümünde sağ = `x = width`
+(bkz. bölüm 4, "Artık uyumlu"). İhlal edilen, adlandırma kuralı: standart "sağ kapı" /
+"sol kapı" kavramını kaldırıp `big door` + yüz çiftini koyuyor.
+**Fix:** `doorSide: 'right' | 'left'` → `face: 'x=0' | 'x=width'`. Yön mantığına
+dokunulmaz, yalnızca ad ve tip değişir.
+
+---
+
+### M-03 · Kamera preset adları standartla uyuşmuyor — **MEDIUM**
+
+**Dosya:** `apps/frontend/src/lib/config/scene-config.ts:105-112`
+
+```ts
+CAMERA_PRESETS: {
+  TOP:        { dir: [0, 1, 0.001],    label: 'Üstten' },
+  FRONT:      { dir: [0, 0.25, -1],    label: 'Önden' },
+  BACK:       { dir: [0, 0.25, 1],     label: 'Arkadan' },
+  SIDE_RIGHT: { dir: [1, 0.25, 0],     label: 'Sağ Yan' },
+  SIDE_LEFT:  { dir: [-1, 0.25, 0],    label: 'Sol Yan' },
+  ISO:        { dir: [0.55, 0.5, 0.9], label: 'İzometrik' },
+},
+```
+
+**İhlal:** Standart bakış adları: kapı görünümü / karşı görünüm / sağ / sol / üst /
+izometrik. `FRONT` ve `BACK` adları, "ön kapı" kavramı kaldırıldığı için yanıltıcı.
+**Önemli not:** `dir` vektörlerinin **hepsi standartla uyumlu** — `ISO [0.55, 0.5, 0.9]`
+tam olarak yeni referans kamera (`+z, +x, +y`), `BACK [0, 0.25, 1]` ise kapı görünümü.
+Yalnızca adlar değişecek; H-02'deki `z` düzeltmesinden sonra anlamları da kendiliğinden
+doğru olur.
+**Fix:** `FRONT → OPPOSITE` ("Karşıdan"), `BACK → DOOR` ("Kapıdan"); `dir` değerlerine
+dokunma.
+
+---
+
+### M-04 · X-Ray derinlik filtresi yanlış uçtan soyuyor — **MEDIUM**
+
+**Dosya:** `apps/frontend/src/lib/utils/scene/sceneFilter.ts:13, 26` ·
+tetikleyici: `CameraPresetButtons.tsx:58, 120-137`
+
+```ts
+ * 2. Layer filtresi: activeLayer > 0 ise, positionZ < activeLayer olan kutular ghost olur.
+return box.positionZ < activeLayer;
+```
+
+**İhlal:** Küçük `z` = kapıya yakın varsayılıyor; standartta küçük `z` uzak yüzdür. Filtre
+yükü ters uçtan soyuyor. Ayrıca arayüz etiketi "Derinlik Filtresi" — terim `length`
+olmalı.
+**Fix:** `positionZ > length − activeLayer`; etiketi "Uzunluk Filtresi" yap.
+
+---
+
+### M-05 · CoG panelinde yanlış eksen etiketi — **MEDIUM**
+
+**Dosya:** `apps/frontend/src/features/planning/scene/components/CameraPresetButtons.tsx:214-221`
+
+```tsx
+<span>Sağ-Sol Yük Dağılımı</span>  {(balance.frontAxleShare * 100).toFixed(1)}%
+<span>Ön-Arka Yük Dağılımı</span>  {(balance.rearAxleShare * 100).toFixed(1)}%
+```
+
+**İhlal:** `frontAxleShare` ve `rearAxleShare` **ikisi de `z` ekseni** paylarıdır ve
+toplamları 1'dir. "Sağ-Sol" satırı `lateralBias`'i (x ekseni) göstermeli. Kullanıcı lateral
+dengeyi hiç görmüyor; iki satır aynı büyüklüğün tümleyenini gösteriyor.
+**Fix:** Sağ-Sol satırına `lateralBias`, Ön-Arka satırına `longitudinalBias` bağla. H-05
+düzeltilmeden bu satırların yönü de ters kalır.
+
+---
+
+### M-06 · `+Z (kapı/ön)` adlandırması — **MEDIUM**
+
+**Dosya:** `apps/frontend/src/features/planning/scene/components/CargoMeshInstanced.tsx:59-63`
+
+```ts
+const FACE_CONFIGS = [
+  // +Z (kapı/ön)
+  { ox: 0, oy: 0, oz: 1, rx: 0, ry: 0 },
+  // -Z (arka)
+  { ox: 0, oy: 0, oz: -1, rx: 0, ry: Math.PI },
+```
+
+**Durum:** `+Z = kapı` kısmı standarda **uygun**; `/ön` eki ve `-Z = arka` adlandırması
+yanlış — standartta "ön/arka" kapı kavramı yok, `−Z` uzak yüzdür.
+**Fix:** Yorumları `+Z → referans kapı (z = length)`, `−Z → uzak yüz (z = 0)` olarak yaz.
+
+---
+
+### M-07 · Etiket yüzü yorumu kod ile çelişiyor — **MEDIUM**
+
+**Dosya:** `apps/frontend/src/features/planning/scene/components/BoxWrapper.tsx:24, 279`
+
+```tsx
+/** +Z yüzüne (kapıya bakan) uygulanacak etiket texture'ı */
+// 6-material array: +X, -X, +Y, -Y, +Z(kapıya bakan), -Z(arka)
+```
+
+**Durum:** Standarda göre **doğru** (`z = length` referans kapıdır). Ancak aynı kod
+tabanındaki `ContainerMesh` kapıyı `Z = 0`'a koyduğu için ürün etiketleri fiilen ters yüze
+bakıyor.
+**Fix:** H-02 düzeltilince bu dosya kendiliğinden doğru olur; yalnızca `-Z(arka)` ifadesi
+`-Z (uzak yüz)` olarak güncellenir.
+
+---
+
+### M-08 · Squad dokümanları eski koordinat tablosunu taşıyor — **MEDIUM**
+
+**Dosyalar:** `apps/frontend/src/features/planning/scene/CLAUDE.md:33` ·
+`apps/frontend/.claude/CLAUDE.md` (3D Sahne → Koordinat Sistemi tablosu)
+
+```
+X=Genişlik · Y=Yükseklik · Z=Derinlik · Origin=Sol-Alt-Arka · Rotasyon=Derece
+```
+
+**İhlal:** `Z=Derinlik` → `length` olmalı; `Origin=Sol-Alt-Arka` → origin **uzak**-sol-alt
+köşedir ("arka" ifadesi kapı ucunu çağrıştırıyor); `Depth / Length` eşanlamlı kullanımı
+kaldırılmalı. ("Sol" kısmı artık **doğru**.)
+**Fix:** Her iki dokümandaki tabloyu sil, `COORDINATE_STANDARD.md`'ye referans ver.
+
+---
+
+### M-09 · Tablolarda eksen/terim adları yanlış — **MEDIUM**
+
+**Dosyalar:** `products/components/ProductTable.tsx:747, 753` (hücreler 273-289) ·
+`imports/components/ERPItemsTable.tsx:468, 474` (hücreler 558-572) ·
+`imports/components/BulkImportDialog.tsx:647, 649`
+
+```tsx
+<TableHead>Uzunluk/Çap (X)</TableHead>   // hücre: item.width
+<TableHead>Derinlik (Z)</TableHead>      // hücre: item.length
+```
+
+**Durum:** Eksen eşlemesi **doğru** (`width → x`, `length → z`), adlandırma yanlış:
+`width` "Uzunluk", `length` "Derinlik" diye gösteriliyor. Yeni terminolojide `x` =
+**Genişlik/width**, `z` = **Uzunluk/length** — yani iki kolon adı da takas edilmiş.
+**Fix:** `Genişlik (X)` / `Yükseklik (Y)` / `Uzunluk (Z)`.
+
+---
+
+### M-10 · Ürün formunda `depth` terimi — **MEDIUM**
+
+**Dosya:** `apps/frontend/src/features/data-management/products/components/ProductForm.tsx:790-815`
+
+```tsx
+<DimensionField name="width"  label={`${t('forms.product.width')} (X)`} />
+<DimensionField name="length" label={`${t('forms.product.depth')} (Z)`} />
+```
+
+**Durum:** Eksen eşlemesi **doğru** — bu dosya H-10'daki araç formunun aksine doğru
+çalışıyor ve düzeltme için referans alınmalı. Tek sorun i18n anahtarı:
+`forms.product.depth` → `forms.product.length`.
+**Fix:** i18n anahtarını ve `tr.json` / `en.json` karşılıklarını değiştir.
+
+---
+
+### M-11 · Backend DTO'larında `Depth` — **MEDIUM**
+
+**Dosyalar:** `…/Common/Models/OptimizationResult.cs:24` (`PlacedItemResult.Depth`) ·
+`…/Shares/GetSharePlanByToken/SharePlanDto.cs:17` (`SharePlacementDetailDto.Depth`) ·
+`…/Common/Optimization/VolumeScoring.cs:19-23` (`DepthCoefficient`, `DepthTerm`)
+
+```csharp
+public sealed record PlacedItemResult(
+    Guid PlacementId, Guid ItemId,
+    decimal X, decimal Y, decimal Z,
+    decimal Width, decimal Height, decimal Depth, …);
+```
+
+**İhlal:** Standart terim `Length`. Dikkat: aynı dosyalarda `ShareVehicleDataDto.Length`
+(SharePlanDto.cs:6) zaten `Length` kullanıyor — yani **tek API yanıtında araç için
+`Length`, kutu için `Depth`** dolaşıyor.
+**Fix:** `Depth → Length`; API sözleşmesi değiştiği için frontend tarafıyla (M-00) aynı
+PR'da yapılmalı.
+
+---
+
+### M-12 · Gereksizleşen `length → depth` dönüşümü — **MEDIUM**
+
+**Dosyalar:** `lib/api/loadingPlanMappers.ts:322-342, 367, 386, 687-706` ·
+`lib/store/usePlanStore.ts:799`
+
+```ts
+function placedDimensions(w: number, h: number, l: number, rotation: number)
+  : { pw: number; ph: number; pd: number } { … }
+```
+
+```ts
+depth: item.length,
+```
+
+**İhlal:** M-00 + M-11 uygulandığında bu dönüşüm anlamsız kalır (`length → length`).
+Ayrıca `w/h/l` ve `pw/ph/pd` kısaltmaları standardın yasakladığı biçimde.
+**Fix:** İmzayı `placedDimensions(width, height, length, rotation) → { width, height, length }`
+yap; `depth: item.length` satırı doğrudan `length: item.length`'e iner.
+
+---
+
+### M-13 · `bottom-left-rear` origin yorumları — **MEDIUM**
+
+**Dosyalar:** `lib/utils/geometry/geometry.ts:6` ·
+`lib/utils/geometry/calcCenterOfGravity.ts:49` ·
+`lib/utils/geometry/checkOrientationFit.ts:27`
+
+```ts
+ * Positions are bottom-left-rear corners in centimeters (scene contract).
+// Sol-alt-arka origin: kutunun bounds'u positionX..positionX+width gibi.
+```
+
+**Durum:** `bottom` ve **`left` artık doğru** (origin `x = 0`, yani kapı görünümünde sol).
+Yanlış olan `rear`: köşe kapı ucunda değil, **uzak yüzdedir** (`z = 0`).
+**Fix:** `bottom-left-far corner (min x, min y, min z)` — hesaplama mantığı doğru, yalnızca
+adlandırma yanıltıcı.
+
+---
+
+### M-14 · Prototip HTML tamamen farklı bir konvansiyon kullanıyor — **MEDIUM**
+
+**Dosya:** `tip1_animasyonlu_planlayici (1).html:425, 435, 464-470, 586, 643-646` (repo kökü)
+
+```js
+return { x: algX - CL/2, y: algZ - CH/2, z: CW/2 - algY };   // toScene()
+const onLbl = makeTextSprite('ÖN (KAPI)', …); onLbl.position.set(CL/2 + 40, 0, 0);
+```
+
+**Kullanılan konvansiyon:** `U(zunluk) → x`, `G(enişlik) → −z`, `Y → y`; origin konteyner
+**merkezinde**; kapı `+X` ucunda ve **"ÖN (KAPI)"** etiketli.
+**İhlal:** Merkezi origin, eksen eşlemesinin tamamen farklı olması ve "ön = kapı"
+adlandırması. Üretimde kullanılmıyor; ancak veri giriş formlarındaki `Uzunluk (X)`
+etiketleri (H-10, M-09) buradan miras alınmış görünüyor.
+**Fix:** `docs/archive/` altına taşı, başına "prototip — koordinat konvansiyonu geçersiz"
+uyarısı ekle.
+
+---
+
+### L-01 · Excel çıktısında eksen/origin açıklaması yok — **LOW**
+
+**Dosya:** `lib/utils/export/export-utils.ts:214-244`
+
+```ts
+'Derinlik (cm)': p.depth,
+'Konum X': p.positionX, 'Konum Y': p.positionY, 'Konum Z': p.positionZ,
+```
+
+**İhlal:** `Derinlik` → `Uzunluk`; ayrıca hangi köşe / hangi yön olduğu yazmıyor. Depo
+operatörü `Konum Z = 0` değerini kapı sanabilir.
+**Fix:** Başlıkları düzelt ve sayfaya açıklama satırı ekle: `X = width (kapıdan bakışta
+sağa), Y = height, Z = length (uzak yüz → kapı), köşe = origin'e en yakın köşe, cm`.
+
+---
+
+### L-02 · Sahne HUD'unda eksen bağlamı yok — **LOW**
+
+**Dosya:** `features/planning/scene/components/SelectedBoxCoords.tsx:20-33`
+**İhlal:** Yalnızca `X / Y / Z` harfleri; boyut adı ve referans köşe gösterilmiyor.
+**Fix:** `X width · Y height · Z length — kutunun origin'e en yakın köşesi` alt satırı.
+
+---
+
+### L-03 · Staging alanı yönü belgelenmemiş — **LOW**
+
+**Dosya:** `lib/store/usePlanStore.ts:189-191`
+
+```ts
+const originX = vehicleWidth + SCENE.STAGING_GAP_CM;
+```
+
+**İhlal:** Doğrudan ihlal değil; `+x` yönü standartta kapı görünümünde **sağ** taraftır ama
+kod bunu yalnızca "yan" diye anıyor.
+**Fix:** Sabitlerin yanına yön yorumu: `staging alanı sağ tarafta, x > width`.
+
+---
+
+### L-04 · Orientation etiketleri ve `RotatedDimensions.depth` — **LOW**
+
+**Dosya:** `lib/utils/geometry/boxOrientations.ts:18-23, 63-88`
+
+```ts
+{ idx: 2, label: 'Ön yüz altta', … }, { idx: 4, label: 'Sol yüz altta', … },
+export interface RotatedDimensions { width: number; height: number; depth: number; }
+```
+
+**İhlal:** `depth` → `length` (M-00 kapsamı). Ayrıca `Ön/Arka/Sol/Sağ yüz` etiketleri
+konteyner yüz adlarıyla karışıyor; standart bu kelimeleri kapı/kamera için ayırıyor.
+**Fix:** Etiketleri eksene bağla (`+z yüzü altta` …).
+
+---
+
+### L-05 · Placement orientation yorumu — **LOW**
+
+**Dosya:** `lib/types/loadingPlan.ts:4-5`
+
+```ts
+// 0: alt yüz · 1: üst yüz · 2: ön yüz · 3: arka yüz · 4: sol yüz · 5: sağ yüz altta.
+```
+
+**İhlal:** L-04 ile aynı; ayrıca tip dosyası API sözleşmesi olduğu için İngilizce olmalı.
+**Fix:** `bottom / top / +z / −z / −x / +x face down`.
+
+---
+
+### L-06 · `calcVolume` parametre adları — **LOW**
+
+**Dosya:** `lib/utils/geometry/calcVolume.ts:7-9`
+
+```ts
+export function calcVolume(lengthCm: number, widthCm: number, heightCm: number): number
+```
+
+**İhlal:** Çağrı yerlerinde sıra tutarsız (`ProductTable.tsx:235` `(length, width, height)`,
+`VehicleDimensionsFields.tsx:31` `(length, width, height)`). Çarpım sırası sonucu
+değiştirmediği için hata üretmiyor, isimlendirme yine de standarda aykırı.
+**Fix:** `calcVolume(widthCm, heightCm, lengthCm)`.
+
+---
+
+### L-07 · Toplu içe aktarma başlıkları — **LOW**
+
+**Dosyalar:** `imports/components/VehicleBulkImportDialog.tsx:135, 379` ·
+`imports/components/BulkImportDialog.tsx:189, 647-649`
+
+```ts
+length: String(r['Uzunluk (cm)'] ?? ''),
+```
+
+**İhlal:** Şablon başlıkları eksen bilgisi taşımıyor ve M-09'daki takas aynı burada da var.
+**Fix:** `Uzunluk (Z, cm)` / `Genişlik (X, cm)` / `Yükseklik (Y, cm)`; eski başlıkları
+geriye dönük kabul etmeye devam et.
+
+---
+
+### L-08 · `w/h/d` kısaltmaları — **LOW**
+
+**Dosya:** `lib/utils/geometry/checkOrientationFit.ts:8-25`
+
+```ts
+export function fitsInVehicle(posX, posY, posZ, w: number, h: number, d: number, vehicle: Vehicle)
+```
+
+**İhlal:** Standart açık eşleme olmadan `w/h/d/l` kısaltmalarını yasaklıyor.
+**Fix:** `width, height, length` tam adları.
+
+---
+
+## 3. Standarda uygun dosyalar
+
+| Dosya | Not |
+| ----- | --- |
+| `lib/utils/geometry/geometry.ts` (`boxesIntersect`, `computeViolations`) | AABB testi eksen-agnostik ve doğru; yalnızca origin yorumu (M-13). |
+| `features/planning/scene/components/BoxWrapper.tsx` (pivot offset, 100-175) | `+boyut/2` köşe→merkez dönüşümü doğru ve tek noktada. |
+| `features/planning/scene/components/CargoMeshInstanced.tsx` (matris kurulumu 186-190, 497-505) | Offset kuralı `InstancedMesh` yolunda da tutarlı. |
+| `features/data-management/products/components/ProductForm.tsx:790-815` | Eksen eşlemesi doğru — H-10 düzeltmesinin referansı (yalnızca i18n anahtarı, M-10). |
+| `features/planning/scene/utils/cameraUtils.ts` · `ResourceTracker.ts` | Konvansiyondan bağımsız. |
+| `lib/utils/scene/buildBoxLabel.ts` · `buildAtlasTexture.ts` | Eksen varsayımı yok. |
+| `features/planning/scene/components/ContainerBody.tsx:45` | `[width/2, height/2, length/2]` merkezleme doğru; terim de artık doğru. |
+| `apps/backend/…/Optimization/PlacementValidator.cs:22-28` (`Intersects`) | AABB mantığı doğru; yalnızca parametre adları (L-08 muadili). |
+| `apps/backend/…/Entities/LoadingPlanPlacement.cs` | `PositionX/Y/Z` adlandırması standartla uyumlu. |
+| `lib/utils/scene/loadOrder.ts:38-52` (`side` / `top` dalları) | `z` yönünden bağımsız; `x`/`y` sıralaması standartla çelişmiyor. |
+
+---
+
+## 4. Artık uyumlu — dokunulmayacak
+
+Aşağıdaki maddeler **sürüm 1 denetiminde ihlal** olarak raporlanmıştı; yeni standartla
+birlikte **doğru** hâle geldiler. Düzeltmeye başlamadan önce bu listeyi okuyun.
+
+| Konu | Dosya | Neden artık doğru |
+| ---- | ----- | ----------------- |
+| **`+X = sağ`, `−X = sol`** | `CargoMeshInstanced.tsx:64-67` | Standart artık right-handed; kapı görünümünde `+x` sağdır. Three.js varsayılanı doğrudan geçerli. |
+| **Aynalama yapılmaması** | tüm sahne | Standart right-handed olduğu için `scale.x = -1` benzeri bir telafi **gerekmiyor** — eklenmemesi doğru. |
+| **`length` alan adı** | `vehicle.ts:36` · `item.ts:19` · `Item.cs:14` · `Vehicle.cs:13` · `OptimizationInput.VehicleLength` | `depth` yerine `length` standart terim oldu. Bu alanlar **zaten doğru**; yeniden adlandırılmayacak. |
+| **`doorSide: 'right'` → `x = width`** | `ContainerMesh.tsx:306` · `VehiclePreview3D.tsx:350` | Yön eşlemesi standartla birebir; yalnızca alan adı `face`'e dönecek (M-02). |
+| **`ISO` kamera yönü** | `scene-config.ts:111` — `dir: [0.55, 0.5, 0.9]` | `+x, +y, +z` = yeni referans izometrik kamera (kapı + sağ + üst). Değer değişmeyecek. |
+| **`BACK` kamera yönü** | `scene-config.ts:108` — `dir: [0, 0.25, 1]` | `+z` tarafı = kapı görünümü. Yalnızca ad değişecek (M-03). |
+| **Origin'in "sol" olması** | `geometry.ts:6` · `calcCenterOfGravity.ts:49` | Origin `x = 0`'da, yani kapı görünümünde solda. Yorumun "left" kısmı doğru; yanlış olan "rear" (M-13). |
+
+---
+
+## 5. Beklemedeki konulara bağlı bulgular
+
+Aşağıdaki üç konu netleşmeden ilgili kod değiştirilmeyecek:
+
+| Konu | Etkilediği bulgu | Durum |
+| ---- | ---------------- | ----- |
+| `x₀` — big door açıklık payı | **H-09** (motor), yerleştirme sınırları | Değer ve `x = width` tarafı onayı bekliyor |
+| Üst kapı (top door) | **H-07** (`LoadingType.Top`, `DoorDirection.Top`), `ContainerMesh` `TopDoor` bileşeni, `loadOrder` `top` dalı | Sektör araştırması |
+| Small door'u olmayan konteyner | **H-07** (origin kuralının hangi yüzden türetileceği) | Sektör araştırması |
+
+---
+
+## 6. Önerilen uygulama sırası
+
+1. **Kapı modeli** (H-07, M-01, M-02) — diğer her şeyin bağlı olduğu sözleşme. `top` ve
+   small-door'suz konteyner konuları hariç tutularak başlanabilir.
+2. **`z` ekseninin çevrilmesi** (H-01 → H-06, M-04, M-05) — tek bir PR'da, golden-master
+   testleriyle birlikte. Parça parça yapılırsa backend ve frontend geçici olarak ters
+   çalışır.
+3. **Terminoloji** (M-00, M-11, M-12, L-01, L-04…L-08) — davranış değişikliği olmayan
+   mekanik rename; ayrı PR.
+4. **Arayüz etiketleri** (H-10, M-09, M-10, L-02) — kullanıcıya görünen kısım.
+5. **Dokümanlar** (M-08, M-14).
+6. **`x₀`** (H-09) — değer tanımlandıktan sonra.

--- a/docs/COORDINATE_STANDARD.md
+++ b/docs/COORDINATE_STANDARD.md
@@ -1,0 +1,254 @@
+# Koordinat Sistemi Standardı (Container / Truck)
+
+> Bu belge Cargo Pilot'un **tek yetkili** koordinat sistemi tanımıdır. Kod, doküman,
+> API sözleşmesi, 3D sahne ve raporlar bu tanımı esas alır. Çelişki hâlinde bu belge
+> kazanır.
+>
+> Görsel/etkileşimli sürüm: [`coordinate-standard.html`](./coordinate-standard.html)
+> Mevcut kodun bu standarda göre denetimi: [`COORDINATE_AUDIT.md`](./COORDINATE_AUDIT.md)
+>
+> **Terim dili:** eksen ve boyut terimleri **İngilizce** yazılır — `width`, `height`,
+> `length`. Türkçe karşılıklar (genişlik, yükseklik, uzunluk) yalnızca son kullanıcıya
+> gösterilen arayüz metninde kullanılabilir. `depth`, `derinlik`, `w`, `h`, `d`, `l`
+> kullanılmaz.
+
+---
+
+## 1. Araç tipleri
+
+| Tip | Tanım | Referans kapı |
+| --- | ----- | ------------- |
+| **TIR konteyneri** (truck container) | Çekiciye bağlı yük kasası. Kabin ucunda kapı **yoktur**. | **back door** — `z = length` |
+| **Düz konteyner** (plain container) | Bağımsız konteyner. Kapılar konuma göre değil **boyuta** göre adlandırılır. | **small door** — `z = length` |
+
+---
+
+## 2. Origin kuralı
+
+**Referans kapıdan içeri bakıldığında görülen _uzaktaki sol-alt köşe_ `(0, 0, 0)`'dır.**
+
+Bu kural her iki araç tipinde aynıdır. Referans kapı, TIR konteynerinde back door, düz
+konteynerde small door'dur.
+
+Konteynerin iki kısa yüzünde de small door bulunması kuralı değiştirmez: hangisinden
+bakılırsa bakılsın tanım aynı şekilde işler ve tutarlı bir sistem üretir. Referans kapı,
+bakılan / yükleme yapılan kapıdır ve her zaman `z = length` yüzünde kabul edilir.
+
+---
+
+## 3. Eksenler
+
+| Eksen | Dimension  | Yön                                                              | Geçerli aralık |
+| ----- | ---------- | ---------------------------------------------------------------- | -------------- |
+| `x`   | **width**  | Referans kapıdan bakıldığında **sağa** doğru artar                | `0 → width`    |
+| `y`   | **height** | Zeminden **yukarı** doğru artar                                   | `0 → height`   |
+| `z`   | **length** | Uzak yüzden (`z = 0`) **referans kapıya** doğru artar             | `0 → length`   |
+
+### 3.1 El kuralı (handedness)
+
+`y` yukarı, `z` kapıya (gözlemciye) ve `x` gözlemcinin sağına arttığı için bu sistem
+**right-handed**'dır — **Three.js / WebGL varsayılanıyla birebir aynıdır**.
+
+Sonuç: sahnede herhangi bir eksen aynalaması **gerekmez**. Backend'den gelen
+`(x, y, z)` üçlüsü doğrudan `position=[x, y, z]` olarak kullanılabilir. Bu, standardın en
+önemli pratik kazancıdır — gizli mirror/telafi dönüşümüne ihtiyaç yoktur ve böyle bir
+dönüşüm görülürse hatadır.
+
+---
+
+## 4. Kapı tipleri
+
+| Door           | Yüz (face)        | Olabileceği konumlar          | TIR konteyneri                                  | Düz konteyner                          |
+| -------------- | ----------------- | ----------------------------- | ----------------------------------------------- | -------------------------------------- |
+| **small door** | `width × height`  | `z = length` ve/veya `z = 0`  | Yalnızca `z = length` (**back door**). `z = 0` kabin ucudur, kapı olmaz. | İki uçta da olabilir; referans `z = length`'tedir. |
+| **big door**   | `length × height` | `x = 0` ve/veya `x = width`   | Olabilir — tek tarafta ya da iki tarafta          | Olabilir — tek tarafta ya da iki tarafta |
+
+Kurallar:
+
+- **Kapılar liste olarak modellenir.** Bir araçta aynı anda birden fazla kapı
+  bulunabildiği için kapı bilgisi tekil bir enum değeri değil, yüz bilgisiyle birlikte bir
+  listedir:
+
+  ```ts
+  doors: [
+    { type: 'small', face: 'z=length' },
+    { type: 'big',   face: 'x=0' },
+    { type: 'big',   face: 'x=width' },
+  ]
+  ```
+
+- **"sağ kapı" / "sol kapı" diye bir kavram yoktur.** Kapılar `small` / `big` olarak
+  sınıflanır, konumları eksen değeriyle yazılır. "sağ" ve "sol" yalnızca kamera
+  bakışlarını adlandırmak için kullanılır (bkz. bölüm 6).
+- **"ön kapı" / "front door" diye bir kavram yoktur.** TIR'da `z = 0` kabin ucudur;
+  düz konteynerde `z = 0` yalnızca karşı küçük yüzdür.
+
+---
+
+## 5. Diyagramlar
+
+### 5.1 Referans kapı görünümü — origin kuralının tanımlandığı bakış
+
+```
+                                    y (height)
+                                        ↑
+      x = 0                             │                    x = width
+        │                               │                        │
+        ▼                                                        ▼
+        ┌────────────────────────────────────────────────────────┐
+        │                                                        │
+        │              REFERANS KAPI  (z = length)               │
+        │        TIR: back door · düz konteyner: small door       │
+        │                                                        │
+        └────────────────────────────────────────────────────────┘
+        ▲                    y = 0 · zemin
+        │
+        └── ORIGIN (0,0,0) bu köşenin hizasındadır, ancak gözlemciden
+            `length` kadar uzakta, z = 0 yüzü üzerindedir.
+
+              x (width) ─────────────────────────────────►
+                        (bu bakışta SAĞA artar)
+```
+
+### 5.2 Üstten görünüm (plan view) — `x` ve `z` birlikte
+
+Sayfada `z` aşağı doğru, referans kapıya doğru artar. Gözlemci sayfanın altındadır.
+
+```
+            x (width) ────────────────────────►
+
+    O ═══════╤═══════════════════════════════════════╗  ← z = 0 (uzak yüz)
+    │        ┊                                       ║
+    │  x₀ →  ┊                                       ║
+    ║        ┊                                       ║
+    ║ BIG    ┊                                       ║      │
+    ║ DOOR   ┊             yük alanı                 ║      │  z
+    ║ x = 0  ┊                                       ║      │  (length)
+    ║        ┊                                       ║      ▼
+    ║        ┊                                       ║
+    ║        ┊                                       ║
+    ╚════════╧═══════════════════════════════════════╝
+    ▲        ▲        REFERANS KAPI · z = length
+    │        │
+    │        └── YÜKLEME BAŞLANGICI (x₀, 0, 0)
+    └── ORIGIN (0,0,0) — uzak sol-alt köşe
+```
+
+`║` = big door'un bulunduğu uzun yüz · `╤┄┄` = big door açıklık payı `x₀`
+
+### 5.3 Isometric — referans kamera: kapı tarafı + sağ + üst (`+z, +x, +y`)
+
+Bu bakışta görünen ve gizli kalan yüzler:
+
+| Yüz | Konum | Durum |
+| --- | ----- | ----- |
+| Referans kapı | `z = length` | **görünür** |
+| Sağ yüz | `x = width` | **görünür** |
+| Üst yüz | `y = height` | **görünür** |
+| Uzak yüz | `z = 0` | gizli |
+| Sol yüz | `x = 0` | gizli |
+| Zemin | `y = 0` | gizli |
+
+**Origin bu bakışta gizli köşededir** (uzak-sol-alt). Teknik çizimde kesikli halka ve
+kesikli eksen oklarıyla gösterilir. Origin'in görünür olması gerektiği durumlarda kamera
+kapı + **sol** + üst (`+z, −x, +y`) yönüne alınır.
+
+Origin'den çıkan eksen üçlüsü, bu kamerada ekrana şöyle düşer:
+
+```
+                          y (height)
+                              ↑
+                              │
+                              │
+                              │
+                              O   (0,0,0) — gizli köşe
+                            ╱   ╲
+                          ╱       ╲
+                        ╱           ╲
+                      ↙               ↘
+            z (length)                 x (width)
+        referans kapıya                 sağ yüze
+        (aşağı-sola)                    (aşağı-sağa)
+```
+
+> Renkli/ölçekli isometrik çizim: [`coordinate-standard.html`](./coordinate-standard.html),
+> bölüm 3.1 ve 4.1.
+
+---
+
+## 6. Standart kamera bakışları
+
+| Bakış | Kamera yönü | Görünen yüz |
+| ----- | ----------- | ----------- |
+| **Kapı görünümü** (referans) | `+z` tarafından, `−z` yönüne bakar | referans kapı — `z = length` |
+| **Karşı görünüm** | `−z` tarafından | uzak yüz — `z = 0` |
+| **Sağ görünüm** | `+x` tarafından | sağ yüz — `x = width` |
+| **Sol görünüm** | `−x` tarafından | sol yüz — `x = 0` |
+| **Üst görünüm** | `+y` tarafından | tavan — `y = height` |
+| **İzometrik** (referans) | `+z, +x, +y` — kapı + sağ + üst | kapı yüzü, sağ yüz, tavan (origin gizli) |
+
+Sağ/sol, **kapı görünümündeki** gözlemciye göredir: gözlemcinin sağı `+x`, solu `x = 0`
+tarafıdır. Üstten veya karşıdan bakışta ekranda görünen sol/sağ ile karıştırılmamalıdır.
+
+---
+
+## 7. Yükleme başlangıcı
+
+Yükleme normalde **origin'den** başlar. **Big door origin'in bulunduğu `x = 0`
+yüzündeyse** yükleme origin'den değil, `x` ekseninde `x₀` kadar kaymış noktadan başlar.
+
+| Durum | Yükleme başlangıç noktası | Kullanılabilir `x` aralığı |
+| ----- | ------------------------- | -------------------------- |
+| Big door yok | `(0, 0, 0)` | `0 → width` |
+| Big door `x = 0` yüzünde | `(x₀, 0, 0)` | `x₀ → width` |
+| Big door `x = width` yüzünde | `(0, 0, 0)` | `0 → width − x₀` ⚠️ onay bekliyor |
+| Big door iki yüzde de | `(x₀, 0, 0)` | `x₀ → width − x₀` ⚠️ onay bekliyor |
+
+⚠️ **`x₀` değeri henüz tanımlı değildir** (bkz. bölüm 10). Son iki satır verilen kuraldan
+türetilmiş önerilerdir, onay bekliyor.
+
+---
+
+## 8. Yerleştirme kuralları
+
+| Konu | Kural |
+| ---- | ----- |
+| Birim | Santimetre (`cm`). Dönüşüm yalnızca API sınırında yapılır. |
+| Kutu pozisyonu | `positionX/Y/Z`, kutunun **origin'e en yakın köşesidir**: `(min x, min y, min z)`. Mesh merkezi değildir. |
+| Kutu sınırları | `x … x + width` · `y … y + height` · `z … z + length`. Hepsi araç iç ölçüsü içinde kalmalı; big door payı varsa `x` alt sınırı `x₀`'dır. |
+| Yükleme yönü | Yükleme referans kapıdan yapılır: `z = 0` (uzak yüz) tarafındaki kutular önce yerleşir, kapıya en yakın olanlar (`z → length`) en son. |
+| Three.js pivot | Backend köşe verir, Three.js mesh merkezini bekler. Dönüşüm tek noktada: `center = position + boyut / 2`. |
+| Terminoloji | Yalnızca `width`, `height`, `length`. |
+
+---
+
+## 9. Common violations (sık görülen ihlaller)
+
+| # | İhlal | Nasıl görünür | Standarttan farkı |
+|---|-------|---------------|-------------------|
+| 1 | **`z` yönü ters** | `z = 0` kapı kabul edilir, `z` kapıdan içeri artar | Bizde `z = 0` **uzak yüz**tür, `z` kapıya doğru artar. Yükleme sırası, LIFO bölgeleri, animasyon giriş noktası ve dingil yükü ters döner. |
+| 2 | **`depth` terimi** | `depth` alanı `z` boyutu için kullanılır | Standart terim **`length`**'tir. `depth` tamamen kaldırılır. |
+| 3 | **`length` = X sanılması** | Formda "Uzunluk (X)" etiketi | `length` **`z`** boyutudur; `x` **`width`**'tir. |
+| 4 | **front / rear / sağ / sol kapı** | `DoorDirection = front \| rear \| side \| top` gibi enum | Kapılar `small` / `big` olarak sınıflanır, konum yüz değeriyle verilir; "ön kapı" ve "sağ/sol kapı" kavramları yoktur. |
+| 5 | **Tek kapı varsayımı** | Araçta tek bir kapı alanı tutulur | Bir araçta small + iki big door olabilir; kapı bilgisi listedir. |
+| 6 | **Origin at center** | Konteyner `BoxGeometry` merkezine kurulur, koordinatlar `±boyut/2` | Origin köşededir, tüm aralıklar `0 → boyut`. Negatif koordinat oluşmaz. |
+| 7 | **Origin kapı yüzünde** | `(0,0,0)` referans kapının köşesi kabul edilir | Origin **uzak yüzdedir** (`z = 0`), kapıdan `length` kadar uzakta. |
+| 8 | **Origin sağ tarafta** | Kapıdan bakınca sağ-alt köşe origin sanılır | Origin **sol-alt** köşedir (kapıdan bakışta `x = 0` solda). |
+| 9 | **z-up convention** | `z` yükseklik, `y` derinlik (CAD/Blender alışkanlığı) | Bizde `y` = height, `z` = length. |
+| 10 | **`y` aşağı artar** | 2D canvas alışkanlığı | `y` zeminden yukarı artar. |
+| 11 | **Gizli telafi dönüşümü** | `scale.x = -1`, `rotation.y = Math.PI`, `length - z` gibi düzeltmeler | Standart right-handed olduğu için Three.js'te **hiçbir aynalama gerekmez**. Böyle bir düzeltme, altta yatan konvansiyon uyuşmazlığının işaretidir. |
+| 12 | **Mesh merkezi ↔ köşe karışması** | Backend köşe verirken `position=[x,y,z]` doğrudan verilir | `+boyut/2` offset'i uygulanmadan kutular yarım boy kayar. |
+| 13 | **Big door payının atlanması** | Yükleme her zaman `x = 0`'dan başlar | Big door `x = 0` yüzündeyse başlangıç `(x₀, 0, 0)`'dır. |
+| 14 | **Birim karışması** | Metre ve santimetre aynı sahnede | Standart birim cm'dir; dönüşüm yalnızca API sınırında. |
+
+---
+
+## 10. Beklemedeki konular
+
+| # | Konu | Durum |
+|---|------|-------|
+| 1 | **Small door'u olmayan konteyner** — yalnızca big door'u olan konteynerde origin kuralı tanımsız | Sektör araştırması bekliyor |
+| 2 | **Üst kapı (top door)** — mevcut sistemde `top` kapı yönü var; yeni adlandırmada karşılığı belirsiz | Sektör araştırması bekliyor |
+| 3 | **`x₀` — big door açıklık payı** — kaç cm, nereden geliyor (sabit / araç kaydı / kanat ölçüsü); `x = width` tarafına da uygulanacak mı | Değer ve onay bekliyor |
+
+Bu üç konu netleşene kadar ilgili kod değişiklikleri başlatılmaz.

--- a/docs/coordinate-standard.html
+++ b/docs/coordinate-standard.html
@@ -1,0 +1,817 @@
+<!doctype html>
+<html lang="tr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Koordinat Sistemi Standardı — Cargo Pilot</title>
+    <style>
+      :root {
+        --bg: #f6f7f9;
+        --surface: #ffffff;
+        --ink: #0f172a;
+        --ink-soft: #475569;
+        --ink-faint: #94a3b8;
+        --line: #cbd5e1;
+        --edge: #334155;
+        --axis-x: #e11d48;
+        --axis-y: #16a34a;
+        --axis-z: #2563eb;
+        --face-top: #e2e8f0;
+        --face-side: #cfd8e3;
+        --face-small-door: #fcd9a4;
+        --face-big-door: #a7e8dd;
+        --halo: #ffffff;
+        --accent: #2563eb;
+        --warn: #b45309;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0b1120;
+          --surface: #111827;
+          --ink: #e5e7eb;
+          --ink-soft: #9ca3af;
+          --ink-faint: #6b7280;
+          --line: #334155;
+          --edge: #cbd5e1;
+          --axis-x: #fb7185;
+          --axis-y: #4ade80;
+          --axis-z: #60a5fa;
+          --face-top: #273349;
+          --face-side: #1b2537;
+          --face-small-door: #7c4a10;
+          --face-big-door: #10514a;
+          --halo: #0b1120;
+          --accent: #60a5fa;
+          --warn: #fbbf24;
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 2.5rem 1.25rem 4rem;
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+          sans-serif;
+        line-height: 1.55;
+      }
+
+      main {
+        max-width: 64rem;
+        margin: 0 auto;
+      }
+
+      header {
+        margin-bottom: 2rem;
+      }
+
+      h1 {
+        margin: 0 0 0.35rem;
+        font-size: 1.6rem;
+        letter-spacing: -0.02em;
+      }
+
+      h2 {
+        margin: 2.75rem 0 0.75rem;
+        font-size: 1.1rem;
+        letter-spacing: -0.01em;
+      }
+
+      h3 {
+        margin: 0 0 0.6rem;
+        font-size: 0.95rem;
+      }
+
+      .lede {
+        margin: 0;
+        color: var(--ink-soft);
+        font-size: 0.95rem;
+      }
+
+      .card {
+        background: var(--surface);
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 1rem;
+      }
+
+      .card + .card {
+        margin-top: 1rem;
+      }
+
+      .figure-scroll {
+        overflow-x: auto;
+      }
+
+      svg {
+        display: block;
+        width: 100%;
+        height: auto;
+        min-width: 32rem;
+      }
+
+      .caption {
+        margin: 0.75rem 0 0;
+        color: var(--ink-soft);
+        font-size: 0.82rem;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.88rem;
+      }
+
+      th,
+      td {
+        text-align: left;
+        padding: 0.5rem 0.6rem;
+        border-bottom: 1px solid var(--line);
+        vertical-align: top;
+      }
+
+      th {
+        font-size: 0.72rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--ink-soft);
+        font-weight: 600;
+      }
+
+      tbody tr:last-child td {
+        border-bottom: 0;
+      }
+
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 0.85em;
+        background: color-mix(in srgb, var(--ink) 8%, transparent);
+        padding: 0.1em 0.35em;
+        border-radius: 5px;
+      }
+
+      .swatch {
+        display: inline-block;
+        width: 0.7rem;
+        height: 0.7rem;
+        border-radius: 3px;
+        margin-right: 0.4rem;
+        vertical-align: -1px;
+      }
+
+      .note {
+        margin-top: 1rem;
+        border-left: 3px solid var(--accent);
+        padding: 0.15rem 0 0.15rem 0.85rem;
+        color: var(--ink-soft);
+        font-size: 0.88rem;
+      }
+
+      .note.warn {
+        border-left-color: var(--warn);
+      }
+
+      ol.assumptions {
+        margin: 0;
+        padding-left: 1.15rem;
+        font-size: 0.88rem;
+        color: var(--ink-soft);
+      }
+
+      ol.assumptions li {
+        margin-bottom: 0.7rem;
+      }
+
+      ol.assumptions li:last-child {
+        margin-bottom: 0;
+      }
+
+      ol.assumptions strong {
+        color: var(--ink);
+      }
+
+      .pill {
+        display: inline-block;
+        font-size: 0.68rem;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        padding: 0.12rem 0.45rem;
+        border-radius: 999px;
+        background: color-mix(in srgb, var(--warn) 22%, transparent);
+        color: var(--warn);
+        vertical-align: 2px;
+      }
+
+      .svg-label {
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        font-size: 13px;
+        font-weight: 600;
+        fill: var(--ink);
+        paint-order: stroke;
+        stroke: var(--halo);
+        stroke-width: 4px;
+        stroke-linejoin: round;
+      }
+
+      .svg-label.small {
+        font-size: 11px;
+        font-weight: 500;
+        fill: var(--ink-soft);
+      }
+
+      .svg-label.axis-x {
+        fill: var(--axis-x);
+      }
+      .svg-label.axis-y {
+        fill: var(--axis-y);
+      }
+      .svg-label.axis-z {
+        fill: var(--axis-z);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Koordinat Sistemi Standardı — Cargo Pilot</h1>
+        <p class="lede">
+          TIR konteyneri ve düz konteyner için ortak eksen sistemi, origin kuralı, kapı adlandırması,
+          standart kamera bakışları ve yükleme başlangıcı. Boyut terimleri İngilizce'dir:
+          <strong>width</strong>, <strong>height</strong>, <strong>length</strong>.
+        </p>
+      </header>
+
+      <h2>1. Ortak eksen sistemi</h2>
+
+      <div class="card">
+        <p style="margin: 0 0 0.9rem; font-size: 0.92rem">
+          <strong>Origin kuralı (her iki araç tipinde aynı):</strong> referans kapıdan içeri
+          bakıldığında görülen <strong>uzaktaki sol-alt köşe</strong> <code>(0, 0, 0)</code>'dır.
+          Referans kapı, TIR konteynerinde <strong>back door</strong>, düz konteynerde
+          <strong>small door</strong>'dur.
+        </p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Eksen</th>
+              <th>Dimension</th>
+              <th>Yön</th>
+              <th>Aralık</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span class="swatch" style="background: var(--axis-x)"></span><code>x</code></td>
+              <td><strong>width</strong></td>
+              <td>Referans kapıdan bakıldığında <strong>sağa</strong> doğru artar</td>
+              <td><code>0 → width</code></td>
+            </tr>
+            <tr>
+              <td><span class="swatch" style="background: var(--axis-y)"></span><code>y</code></td>
+              <td><strong>height</strong></td>
+              <td>Zeminden <strong>yukarı</strong> doğru artar</td>
+              <td><code>0 → height</code></td>
+            </tr>
+            <tr>
+              <td><span class="swatch" style="background: var(--axis-z)"></span><code>z</code></td>
+              <td><strong>length</strong></td>
+              <td>Uzak yüzden (<code>z = 0</code>) <strong>referans kapıya</strong> doğru artar</td>
+              <td><code>0 → length</code></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p class="note">
+          <strong>Right-handed sistem.</strong> <code>y</code> yukarı, <code>z</code> kapıya
+          (gözlemciye) ve <code>x</code> gözlemcinin sağına arttığı için bu sistem
+          <em>right-handed</em>'dır — Three.js / WebGL varsayılanıyla birebir aynıdır. Sahnede
+          herhangi bir eksen aynalaması <strong>gerekmez</strong>; <code>position=[x, y, z]</code>
+          doğrudan kullanılabilir.
+        </p>
+
+        <p class="note">
+          <strong>İki small door'lu konteyner.</strong> Konteynerin iki kısa yüzünde de small door
+          olması kuralı değiştirmez: hangisinden bakılırsa bakılsın "uzaktaki sol-alt köşe" tanımı
+          aynı şekilde işler ve tutarlı bir sistem üretir. Referans kapı, bakılan / yükleme yapılan
+          kapıdır ve her zaman <code>z = length</code> yüzünde kabul edilir.
+        </p>
+      </div>
+
+      <h2>2. Kapı tipleri</h2>
+
+      <div class="card">
+        <table>
+          <thead>
+            <tr>
+              <th>Door</th>
+              <th>Yüz (face)</th>
+              <th>Olabileceği konumlar</th>
+              <th>TIR konteyneri</th>
+              <th>Düz konteyner</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <strong>small door</strong><br />
+                <span style="color: var(--ink-soft)">küçük kapı</span>
+              </td>
+              <td><code>width × height</code></td>
+              <td><code>z = length</code> ve/veya <code>z = 0</code></td>
+              <td>
+                Yalnızca <code>z = length</code> — <strong>back door</strong>.
+                <code>z = 0</code> kabin ucudur, kapı olmaz.
+              </td>
+              <td>İki uçta da olabilir; referans olan <code>z = length</code>'tedir.</td>
+            </tr>
+            <tr>
+              <td>
+                <strong>big door</strong><br />
+                <span style="color: var(--ink-soft)">büyük kapı</span>
+              </td>
+              <td><code>length × height</code></td>
+              <td><code>x = 0</code> ve/veya <code>x = width</code></td>
+              <td>Olabilir — tek tarafta ya da iki tarafta</td>
+              <td>Olabilir — tek tarafta ya da iki tarafta</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p class="note">
+          <strong>Kapılar liste olarak modellenir.</strong> Bir araçta aynı anda birden fazla kapı
+          bulunabildiği için (ör. back door + iki big door) kapı bilgisi tekil bir enum değeri değil,
+          yüz bilgisiyle birlikte bir liste olmalıdır:<br />
+          <code>doors: [{ type: 'small', face: 'z=length' }, { type: 'big', face: 'x=0' }, { type: 'big', face: 'x=width' }]</code>
+        </p>
+
+        <p class="note">
+          <strong>sağ / sol kapı diye bir kavram yoktur.</strong> "sağ" ve "sol" yalnızca kamera
+          bakışlarını adlandırmak için kullanılır (bkz. bölüm 6) ve her zaman referans kapıdan bakışa
+          göre tanımlanır. Kapılar <code>small</code> / <code>big</code> olarak sınıflanır,
+          konumları eksen değeriyle (<code>x = 0</code>, <code>z = length</code> …) yazılır.
+        </p>
+      </div>
+
+      <h2>3. TIR konteyneri (truck container)</h2>
+
+      <div class="card figure-scroll">
+        <h3>3.1 Isometric — referans kamera: kapı tarafı + sağ + üst</h3>
+        <svg
+          viewBox="-90 40 840 400"
+          role="img"
+          aria-label="TIR konteynerinin izometrik görünümü: sağ üstten bakış, back door solda, sağ yüzde opsiyonel big door, origin gizli köşede"
+        >
+          <defs>
+            <marker id="ah-x" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--axis-x)" />
+            </marker>
+            <marker id="ah-y" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--axis-y)" />
+            </marker>
+            <marker id="ah-z" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--axis-z)" />
+            </marker>
+          </defs>
+
+          <!-- görünür yüzler: üst · sağ yüz (x = width) · back door (z = length) -->
+          <polygon points="340,53.4 453.9,119.2 182.2,276.1 68.3,210.3" fill="var(--face-top)" />
+          <polygon points="453.9,255.8 453.9,119.2 182.2,276.1 182.2,412.7" fill="var(--face-big-door)" fill-opacity="0.55" />
+          <polygon points="68.3,346.9 182.2,412.7 182.2,276.1 68.3,210.3" fill="var(--face-small-door)" />
+
+          <!-- gizli kenarlar (origin köşesinden çıkanlar) -->
+          <g stroke="var(--ink-faint)" stroke-width="1.4" stroke-dasharray="6 5" fill="none">
+            <line x1="340" y1="190" x2="453.9" y2="255.8" />
+            <line x1="340" y1="190" x2="340" y2="53.4" />
+            <line x1="340" y1="190" x2="68.3" y2="346.9" />
+          </g>
+
+          <!-- görünür kenarlar -->
+          <g stroke="var(--edge)" stroke-width="2" fill="none" stroke-linejoin="round">
+            <polyline points="340,53.4 453.9,119.2 453.9,255.8 182.2,412.7 68.3,346.9 68.3,210.3 340,53.4" />
+            <polyline points="453.9,119.2 182.2,276.1 68.3,210.3" />
+            <line x1="182.2" y1="276.1" x2="182.2" y2="412.7" />
+          </g>
+
+          <!-- yüz etiketleri -->
+          <text class="svg-label" x="125" y="296" text-anchor="middle">BACK DOOR</text>
+          <text class="svg-label small" x="125" y="312" text-anchor="middle">small · z = length</text>
+          <text class="svg-label small" x="125" y="326" text-anchor="middle">REFERANS KAPI</text>
+
+          <text class="svg-label" x="318" y="254" text-anchor="middle">BIG DOOR</text>
+          <text class="svg-label small" x="318" y="270" text-anchor="middle">opsiyonel · x = width</text>
+          <text class="svg-label small" x="318" y="284" text-anchor="middle">(x = 0'da da olabilir)</text>
+
+          <text class="svg-label small" x="261" y="132" text-anchor="middle">üst yüz · y = height</text>
+
+          <!-- gizli sol yüz -->
+          <line x1="204" y1="200" x2="140" y2="140" stroke="var(--ink-faint)" stroke-width="1.2" stroke-dasharray="4 4" />
+          <text class="svg-label small" x="132" y="118" text-anchor="end">sol yüz · x = 0 (gizli)</text>
+          <text class="svg-label small" x="132" y="132" text-anchor="end">burada da big door olabilir</text>
+
+          <!-- gizli uzak yüz -->
+          <line x1="400" y1="150" x2="500" y2="92" stroke="var(--ink-faint)" stroke-width="1.2" stroke-dasharray="4 4" />
+          <text class="svg-label" x="505" y="74" text-anchor="start">UZAK YÜZ · z = 0</text>
+          <text class="svg-label small" x="505" y="88" text-anchor="start">kabin / çekici ucu — KAPI YOK (gizli)</text>
+
+          <!-- eksen okları — origin gizli köşede olduğu için kesikli -->
+          <g stroke-width="2.5" fill="none" stroke-linecap="round" stroke-dasharray="7 4">
+            <line x1="340" y1="190" x2="422" y2="237.4" stroke="var(--axis-x)" marker-end="url(#ah-x)" />
+            <line x1="340" y1="190" x2="340" y2="87.6" stroke="var(--axis-y)" marker-end="url(#ah-y)" />
+            <line x1="340" y1="190" x2="171.5" y2="287.3" stroke="var(--axis-z)" marker-end="url(#ah-z)" />
+          </g>
+          <text class="svg-label axis-x" x="430" y="232" text-anchor="start">x — width</text>
+          <text class="svg-label axis-y" x="352" y="84" text-anchor="start">y — height</text>
+          <text class="svg-label axis-z" x="152" y="262" text-anchor="end">z — length</text>
+
+          <!-- origin (gizli köşe) -->
+          <line x1="348" y1="196" x2="474" y2="262" stroke="var(--ink-faint)" stroke-width="1.2" stroke-dasharray="4 4" />
+          <circle cx="340" cy="190" r="7" fill="var(--surface)" stroke="var(--ink)" stroke-width="2.5" stroke-dasharray="3 2" />
+          <circle cx="340" cy="190" r="2.6" fill="var(--ink)" />
+          <text class="svg-label" x="480" y="254" text-anchor="start">ORIGIN (0,0,0)</text>
+          <text class="svg-label small" x="480" y="270" text-anchor="start">uzak yüz · x = 0 · y = 0 · z = 0</text>
+          <text class="svg-label small" x="480" y="284" text-anchor="start">bu bakışta GİZLİ köşedir</text>
+        </svg>
+        <p class="caption">
+          Referans kamera <strong>kapı tarafı + sağ + üst</strong> yönündedir
+          (<code>+z, +x, +y</code>). Bu bakışta back door, sağ yüz ve üst yüz görünür; uzak yüz
+          (<code>z = 0</code>, kabin ucu) ve sol yüz gizlidir. Origin, uzak-sol-alt köşe olduğu için
+          bu bakışta <strong>kutunun arkasında kalır</strong> — kesikli halka ve kesikli eksen okları
+          bunu gösterir. TIR konteynerinde <strong>ön kapı yoktur</strong>; ancak yan yüzlerde
+          (<code>x = 0</code> ve/veya <code>x = width</code>) <strong>big door</strong> bulunabilir.
+        </p>
+      </div>
+
+      <div class="card figure-scroll">
+        <h3>3.2 Referans kapı görünümü — origin kuralının tanımlandığı bakış</h3>
+        <svg
+          viewBox="-40 0 800 360"
+          role="img"
+          aria-label="Referans kapıdan bakış: x sağa artar, origin uzaktaki sol alt köşededir"
+        >
+          <defs>
+            <marker id="ah-x2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--axis-x)" />
+            </marker>
+            <marker id="ah-y2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--axis-y)" />
+            </marker>
+          </defs>
+
+          <rect x="150" y="40" width="400" height="210" fill="var(--face-small-door)" stroke="var(--edge)" stroke-width="2" rx="3" />
+          <text class="svg-label" x="350" y="132" text-anchor="middle">REFERANS KAPI (z = length)</text>
+          <text class="svg-label small" x="350" y="150" text-anchor="middle">TIR: back door · düz konteyner: small door</text>
+
+          <text class="svg-label small" x="150" y="30" text-anchor="middle">x = 0</text>
+          <text class="svg-label small" x="550" y="30" text-anchor="middle">x = width</text>
+          <text class="svg-label small" x="350" y="268" text-anchor="middle">y = 0 · zemin</text>
+
+          <line x1="160" y1="292" x2="540" y2="292" stroke="var(--axis-x)" stroke-width="3" marker-end="url(#ah-x2)" stroke-linecap="round" />
+          <text class="svg-label axis-x" x="350" y="316" text-anchor="middle">x — width (bu bakışta SAĞA artar)</text>
+
+          <line x1="580" y1="250" x2="580" y2="55" stroke="var(--axis-y)" stroke-width="3" marker-end="url(#ah-y2)" stroke-linecap="round" />
+          <text class="svg-label axis-y" x="590" y="48" text-anchor="start">y — height</text>
+
+          <circle cx="150" cy="250" r="7" fill="var(--surface)" stroke="var(--ink)" stroke-width="2.5" stroke-dasharray="3 2" />
+          <circle cx="150" cy="250" r="2.6" fill="var(--ink)" />
+          <line x1="142" y1="250" x2="120" y2="228" stroke="var(--ink-faint)" stroke-width="1.2" stroke-dasharray="4 4" />
+          <text class="svg-label" x="112" y="200" text-anchor="end">ORIGIN (0,0,0)</text>
+          <text class="svg-label small" x="112" y="216" text-anchor="end">bu köşenin hizasında ama</text>
+          <text class="svg-label small" x="112" y="230" text-anchor="end">gözlemciden length kadar</text>
+          <text class="svg-label small" x="112" y="244" text-anchor="end">uzakta (z = 0 yüzünde)</text>
+        </svg>
+        <p class="caption">
+          Origin bu bakışta <strong>sol-alt</strong> köşe hizasındadır, ancak gözlemciden
+          <code>length</code> kadar uzakta, <code>z = 0</code> yüzü üzerindedir (kesikli halka bunu
+          gösterir). <code>z</code> ekseni gözlemciye doğru artar.
+        </p>
+      </div>
+
+      <h2>4. Düz konteyner (plain container)</h2>
+
+      <div class="card figure-scroll">
+        <h3>4.1 Isometric — small door ve big door bir arada</h3>
+        <svg
+          viewBox="-90 40 840 400"
+          role="img"
+          aria-label="Düz konteynerin izometrik görünümü: sağ üstten bakış, small door solda, big door sağ yüzde, origin gizli köşede"
+        >
+          <defs>
+            <marker id="ah-x3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--axis-x)" />
+            </marker>
+            <marker id="ah-y3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--axis-y)" />
+            </marker>
+            <marker id="ah-z3" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--axis-z)" />
+            </marker>
+          </defs>
+
+          <polygon points="340,53.4 453.9,119.2 182.2,276.1 68.3,210.3" fill="var(--face-top)" />
+          <polygon points="453.9,255.8 453.9,119.2 182.2,276.1 182.2,412.7" fill="var(--face-big-door)" />
+          <polygon points="68.3,346.9 182.2,412.7 182.2,276.1 68.3,210.3" fill="var(--face-small-door)" />
+
+          <g stroke="var(--ink-faint)" stroke-width="1.4" stroke-dasharray="6 5" fill="none">
+            <line x1="340" y1="190" x2="453.9" y2="255.8" />
+            <line x1="340" y1="190" x2="340" y2="53.4" />
+            <line x1="340" y1="190" x2="68.3" y2="346.9" />
+          </g>
+
+          <g stroke="var(--edge)" stroke-width="2" fill="none" stroke-linejoin="round">
+            <polyline points="340,53.4 453.9,119.2 453.9,255.8 182.2,412.7 68.3,346.9 68.3,210.3 340,53.4" />
+            <polyline points="453.9,119.2 182.2,276.1 68.3,210.3" />
+            <line x1="182.2" y1="276.1" x2="182.2" y2="412.7" />
+          </g>
+
+          <text class="svg-label" x="125" y="296" text-anchor="middle">SMALL DOOR</text>
+          <text class="svg-label small" x="125" y="312" text-anchor="middle">küçük kapı · z = length</text>
+          <text class="svg-label small" x="125" y="326" text-anchor="middle">REFERANS KAPI</text>
+
+          <text class="svg-label" x="318" y="254" text-anchor="middle">BIG DOOR</text>
+          <text class="svg-label small" x="318" y="270" text-anchor="middle">büyük kapı · x = width</text>
+          <text class="svg-label small" x="318" y="284" text-anchor="middle">(x = 0'da da olabilir)</text>
+
+          <text class="svg-label small" x="261" y="132" text-anchor="middle">üst yüz · y = height</text>
+
+          <line x1="204" y1="200" x2="140" y2="140" stroke="var(--ink-faint)" stroke-width="1.2" stroke-dasharray="4 4" />
+          <text class="svg-label small" x="132" y="118" text-anchor="end">sol yüz · x = 0 (gizli)</text>
+          <text class="svg-label small" x="132" y="132" text-anchor="end">burada da big door olabilir</text>
+
+          <line x1="400" y1="150" x2="500" y2="92" stroke="var(--ink-faint)" stroke-width="1.2" stroke-dasharray="4 4" />
+          <text class="svg-label" x="505" y="74" text-anchor="start">UZAK KÜÇÜK YÜZ · z = 0</text>
+          <text class="svg-label small" x="505" y="88" text-anchor="start">burada ikinci bir small door olabilir</text>
+
+          <g stroke-width="2.5" fill="none" stroke-linecap="round" stroke-dasharray="7 4">
+            <line x1="340" y1="190" x2="422" y2="237.4" stroke="var(--axis-x)" marker-end="url(#ah-x3)" />
+            <line x1="340" y1="190" x2="340" y2="87.6" stroke="var(--axis-y)" marker-end="url(#ah-y3)" />
+            <line x1="340" y1="190" x2="171.5" y2="287.3" stroke="var(--axis-z)" marker-end="url(#ah-z3)" />
+          </g>
+          <text class="svg-label axis-x" x="430" y="232" text-anchor="start">x — width</text>
+          <text class="svg-label axis-y" x="352" y="84" text-anchor="start">y — height</text>
+          <text class="svg-label axis-z" x="152" y="262" text-anchor="end">z — length</text>
+
+          <line x1="348" y1="196" x2="474" y2="262" stroke="var(--ink-faint)" stroke-width="1.2" stroke-dasharray="4 4" />
+          <circle cx="340" cy="190" r="7" fill="var(--surface)" stroke="var(--ink)" stroke-width="2.5" stroke-dasharray="3 2" />
+          <circle cx="340" cy="190" r="2.6" fill="var(--ink)" />
+          <text class="svg-label" x="480" y="254" text-anchor="start">ORIGIN (0,0,0)</text>
+          <text class="svg-label small" x="480" y="270" text-anchor="start">uzak yüz · x = 0 · y = 0 · z = 0</text>
+          <text class="svg-label small" x="480" y="284" text-anchor="start">bu bakışta GİZLİ köşedir</text>
+        </svg>
+        <p class="caption">
+          Düz konteynerde <strong>ön/arka/sağ/sol kapı diye bir sınıflandırma yoktur</strong>;
+          yalnızca <strong>small door</strong> (kısa yüzde, <code>width × height</code>) ve
+          <strong>big door</strong> (uzun yan yüzde, <code>length × height</code>) vardır. İki kısa
+          yüzde de small door, iki uzun yüzde de big door bulunabilir. Referans olan, bakılan /
+          yükleme yapılan small door'dur ve <code>z = length</code> yüzünde kabul edilir.
+        </p>
+      </div>
+
+      <h2>5. Yükleme başlangıcı</h2>
+
+      <div class="card figure-scroll">
+        <h3>5.1 Üstten görünüm — big door origin tarafındayken başlangıç kayması</h3>
+        <svg
+          viewBox="-60 20 840 440"
+          role="img"
+          aria-label="Üstten görünüm: yükleme origin'den başlar, big door x=0 yüzündeyse başlangıç x ekseninde kayar"
+        >
+          <defs>
+            <marker id="ah-x4" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--axis-x)" />
+            </marker>
+            <marker id="ah-z4" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--axis-z)" />
+            </marker>
+            <marker id="ah-load" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--ink-faint)" />
+            </marker>
+          </defs>
+
+          <rect x="240" y="70" width="220" height="320" fill="var(--face-top)" stroke="var(--edge)" stroke-width="2" />
+
+          <!-- big door açıklık payı -->
+          <rect x="240" y="70" width="32" height="320" fill="var(--axis-x)" fill-opacity="0.13" />
+          <line x1="272" y1="70" x2="272" y2="390" stroke="var(--axis-x)" stroke-width="1.5" stroke-dasharray="5 4" />
+          <text class="svg-label small" x="256" y="372" text-anchor="middle">x₀</text>
+
+          <!-- big door -->
+          <rect x="231" y="110" width="10" height="240" fill="var(--face-big-door)" stroke="var(--edge)" stroke-width="1" />
+          <text class="svg-label" x="222" y="236" text-anchor="end">BIG DOOR</text>
+          <text class="svg-label small" x="222" y="251" text-anchor="end">x = 0 yüzü</text>
+
+          <!-- referans kapı -->
+          <rect x="250" y="386" width="200" height="10" fill="var(--face-small-door)" stroke="var(--edge)" stroke-width="1" />
+          <text class="svg-label" x="350" y="424" text-anchor="middle">REFERANS KAPI · z = length</text>
+          <text class="svg-label small" x="350" y="439" text-anchor="middle">gözlemci / yükleme bu taraftan</text>
+
+          <!-- yükleme yönü -->
+          <line x1="400" y1="110" x2="400" y2="350" stroke="var(--ink-faint)" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#ah-load)" />
+          <text class="svg-label small" x="408" y="230" text-anchor="start">yükleme yönü</text>
+
+          <!-- eksenler -->
+          <line x1="240" y1="48" x2="460" y2="48" stroke="var(--axis-x)" stroke-width="3" marker-end="url(#ah-x4)" stroke-linecap="round" />
+          <text class="svg-label axis-x" x="350" y="38" text-anchor="middle">x — width</text>
+          <line x1="492" y1="70" x2="492" y2="390" stroke="var(--axis-z)" stroke-width="3" marker-end="url(#ah-z4)" stroke-linecap="round" />
+          <text class="svg-label axis-z" x="502" y="200" text-anchor="start">z — length</text>
+          <text class="svg-label small" x="466" y="82" text-anchor="start">z = 0</text>
+
+          <!-- origin -->
+          <circle cx="240" cy="70" r="7" fill="var(--surface)" stroke="var(--ink)" stroke-width="2.5" />
+          <circle cx="240" cy="70" r="2.6" fill="var(--ink)" />
+          <text class="svg-label" x="228" y="88" text-anchor="end">ORIGIN (0,0,0)</text>
+          <text class="svg-label small" x="228" y="103" text-anchor="end">uzak sol-alt köşe</text>
+
+          <!-- yükleme başlangıcı -->
+          <rect x="266" y="64" width="12" height="12" fill="var(--axis-x)" stroke="var(--halo)" stroke-width="1.5" />
+          <line x1="278" y1="76" x2="298" y2="104" stroke="var(--ink-faint)" stroke-width="1.2" stroke-dasharray="4 4" />
+          <text class="svg-label" x="302" y="112" text-anchor="start">YÜKLEME BAŞLANGICI</text>
+          <text class="svg-label small" x="302" y="127" text-anchor="start">(x₀, 0, 0) — big door x = 0'da</text>
+          <text class="svg-label small" x="302" y="141" text-anchor="start">olduğu için x ekseninde kayar</text>
+        </svg>
+        <p class="caption">
+          Üstten bakış: <code>x</code> sağa, <code>z</code> aşağı (referans kapıya doğru) artar.
+          Yükleme normalde <code>(0, 0, 0)</code>'dan başlar. <strong>Big door origin'in bulunduğu
+          <code>x = 0</code> yüzündeyse</strong> yükleme origin'den değil, <code>x</code> ekseninde
+          <code>x₀</code> kadar kaymış <code>(x₀, 0, 0)</code> noktasından başlar; taralı şerit bu
+          payı gösterir.
+        </p>
+      </div>
+
+      <div class="card">
+        <table>
+          <thead>
+            <tr>
+              <th>Durum</th>
+              <th>Yükleme başlangıç noktası</th>
+              <th>Kullanılabilir <code>x</code> aralığı</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Big door yok</td>
+              <td><code>(0, 0, 0)</code></td>
+              <td><code>0 → width</code></td>
+            </tr>
+            <tr>
+              <td>Big door <code>x = 0</code> yüzünde</td>
+              <td><code>(x₀, 0, 0)</code></td>
+              <td><code>x₀ → width</code></td>
+            </tr>
+            <tr>
+              <td>Big door <code>x = width</code> yüzünde</td>
+              <td><code>(0, 0, 0)</code></td>
+              <td><code>0 → width − x₀</code> <span class="pill">onay bekliyor</span></td>
+            </tr>
+            <tr>
+              <td>Big door iki yüzde de</td>
+              <td><code>(x₀, 0, 0)</code></td>
+              <td><code>x₀ → width − x₀</code> <span class="pill">onay bekliyor</span></td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p class="note warn">
+          <strong><code>x₀</code> değeri henüz tanımlı değil.</strong> Big door açıklık payının kaç
+          cm olduğu (sabit mi, kapı kanadı kalınlığına mı bağlı, araç kaydından mı gelecek)
+          belirlenmeli. Tabloda <span class="pill">onay bekliyor</span> ile işaretli iki satır,
+          verdiğin kuraldan türetilmiş önerilerdir — <code>x = width</code> tarafındaki big door için
+          aynı payın uygulanıp uygulanmayacağını onaylaman gerekiyor.
+        </p>
+      </div>
+
+      <h2>6. Standart kamera bakışları</h2>
+
+      <div class="card">
+        <table>
+          <thead>
+            <tr>
+              <th>Bakış</th>
+              <th>Kamera yönü</th>
+              <th>Görünen yüz</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Kapı görünümü</strong> (referans)</td>
+              <td><code>+z</code> tarafından, <code>−z</code> yönüne bakar</td>
+              <td>referans kapı — <code>z = length</code></td>
+            </tr>
+            <tr>
+              <td><strong>Karşı görünüm</strong></td>
+              <td><code>−z</code> tarafından</td>
+              <td>uzak yüz — <code>z = 0</code></td>
+            </tr>
+            <tr>
+              <td><strong>Sağ görünüm</strong></td>
+              <td><code>+x</code> tarafından</td>
+              <td>sağ yüz — <code>x = width</code></td>
+            </tr>
+            <tr>
+              <td><strong>Sol görünüm</strong></td>
+              <td><code>−x</code> tarafından</td>
+              <td>sol yüz — <code>x = 0</code></td>
+            </tr>
+            <tr>
+              <td><strong>Üst görünüm</strong></td>
+              <td><code>+y</code> tarafından</td>
+              <td>tavan — <code>y = height</code></td>
+            </tr>
+            <tr>
+              <td><strong>İzometrik</strong> (referans)</td>
+              <td><code>+z, +x, +y</code> — kapı + sağ + üst</td>
+              <td>kapı yüzü, sağ yüz, tavan (origin gizli köşede kalır)</td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="note">
+          Sağ/sol, <strong>kapı görünümündeki</strong> gözlemciye göredir: gözlemcinin sağı
+          <code>+x</code>, solu <code>x = 0</code> tarafıdır. Üstten veya karşıdan bakışta ekranda
+          gördüğün sol/sağ ile karıştırılmamalıdır.
+        </p>
+      </div>
+
+      <h2>7. Yerleştirme kuralları</h2>
+
+      <div class="card">
+        <table>
+          <thead>
+            <tr>
+              <th>Konu</th>
+              <th>Kural</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Birim</td>
+              <td>Santimetre (<code>cm</code>). Dönüşüm yalnızca API sınırında yapılır.</td>
+            </tr>
+            <tr>
+              <td>Kutu pozisyonu</td>
+              <td>
+                <code>positionX/Y/Z</code>, kutunun <strong>origin'e en yakın köşesidir</strong>:
+                <code>(min x, min y, min z)</code>. Mesh merkezi değildir.
+              </td>
+            </tr>
+            <tr>
+              <td>Kutu sınırları</td>
+              <td>
+                <code>x … x + width</code> · <code>y … y + height</code> ·
+                <code>z … z + length</code>. Hepsi araç iç ölçüsü içinde kalmalı; big door payı varsa
+                <code>x</code> alt sınırı <code>x₀</code>'dır.
+              </td>
+            </tr>
+            <tr>
+              <td>Yükleme yönü</td>
+              <td>
+                Yükleme referans kapıdan yapılır: <code>z = 0</code> (uzak yüz) tarafındaki kutular
+                önce yerleşir, kapıya en yakın olanlar (<code>z → length</code>) en son.
+              </td>
+            </tr>
+            <tr>
+              <td>Terminoloji</td>
+              <td>
+                Kod, tip, alan adı ve teknik dokümanda yalnızca <code>width</code>,
+                <code>height</code>, <code>length</code>. <code>depth</code>, <code>uzunluk</code>,
+                <code>derinlik</code>, <code>w/h/d/l</code> kullanılmaz.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h2>8. Beklemedeki konular</h2>
+
+      <div class="card">
+        <ol class="assumptions">
+          <li>
+            <strong>Small door'u olmayan konteyner</strong>
+            <span class="pill">sektör araştırması</span><br />
+            Yalnızca big door'u olan bir konteynerde origin kuralı tanımsız kalıyor. Sektör
+            araştırması sonrasında karara bağlanacak.
+          </li>
+          <li>
+            <strong>Üst kapı (top door)</strong>
+            <span class="pill">sektör araştırması</span><br />
+            Mevcut sistemde <code>top</code> kapı yönü var. Yeni adlandırmada üçüncü bir kapı tipi mi
+            olacağı, yoksa hiç modellenmeyeceği araştırma sonrasında belirlenecek.
+          </li>
+          <li>
+            <strong><code>x₀</code> — big door açıklık payı</strong>
+            <span class="pill">değer gerekli</span><br />
+            Kaç cm olduğu ve nereden geldiği (sabit / araç kaydı / kapı kanadı ölçüsü) tanımlanmalı.
+            Ayrıca <code>x = width</code> tarafındaki big door için aynı payın uygulanıp
+            uygulanmayacağı onaylanmalı (bkz. bölüm 5 tablosu).
+          </li>
+        </ol>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
Koordinat sistemi standardı ve kod denetimi dokümanları `test`'ten `main`'e terfi ediyor.

- `docs/COORDINATE_STANDARD.md` — standardın metin hâli
- `docs/coordinate-standard.html` — görsel referans (bağımsız tek dosya, inline SVG)
- `docs/COORDINATE_AUDIT.md` — mevcut kodun denetimi (32 bulgu: 9 high · 15 medium · 8 low)

Yalnızca doküman; kaynak kodda değişiklik yok.