### PR TITLE
DevOps sertleştirme: action SHA pinleri, Dependabot, CodeQL, parola temizliği, rollback düzeltmesi

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,81 @@
+version: 2
+updates:
+  # ── npm / frontend ──────────────────────────────────────────
+  - package-ecosystem: "npm"
+    directory: "/apps/frontend"
+    # enforce-promotion (ci.yml) main'e yalnızca test/hotfix'ten PR kabul eder;
+    # varsayılan davranış (main'e PR) her Dependabot PR'ını kırar.
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Istanbul"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "npm"]
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+    ignore:
+      # 3D sahne ve routing major'ları manuel QA istiyor
+      - dependency-name: "three"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/three"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@react-three/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-router*"
+        update-types: ["version-update:semver-major"]
+
+  # ── NuGet / backend ─────────────────────────────────────────
+  - package-ecosystem: "nuget"
+    directory: "/apps/backend"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Istanbul"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "nuget"]
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      nuget-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+
+  # ── Docker ──────────────────────────────────────────────────
+  - package-ecosystem: "docker"
+    directory: "/apps/frontend"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "docker"]
+
+  - package-ecosystem: "docker"
+    directory: "/apps/backend"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "docker"]
+
+  # ── GitHub Actions ──────────────────────────────────────────
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "ci"]
+    groups:
+      actions-all:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,10 @@ jobs:
 
     steps:
       - name: Kodu al
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Node.js kur
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -104,10 +104,10 @@ jobs:
 
     steps:
       - name: Kodu al
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: .NET 8 SDK kur
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '8.0.x'
 
@@ -142,20 +142,20 @@ jobs:
 
     steps:
       - name: Kodu al
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Docker Buildx kur
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: GHCR'a giriş yap
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Backend Docker image build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./apps/backend/
           push: false
@@ -167,7 +167,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=cargo-pilot-backend-ci
 
       - name: Frontend Docker image build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./apps/frontend/
           push: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: CodeQL
+
+# Yalnızca dev'e açılan PR'lar + haftalık tam tarama.
+# feat/** push'larına bilerek bağlı DEĞİL: C# analizi ~8-15 dk sürüyor.
+on:
+  pull_request:
+    branches:
+      - dev
+  schedule:
+    - cron: '0 3 * * 1'   # Pazartesi 03:00 UTC — haftalık tam tarama
+
+jobs:
+  analyze:
+    name: CodeQL Analiz (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: none   # derlemesiz analiz — SDK kurulumu ve build gerekmez
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Kodu al
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: CodeQL init
+        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config: |
+            paths-ignore:
+              - '**/docs/**'
+              - '**/tests/**'
+              - 'apps/backend/CargoPilot.Engine.Tests/**'
+              - 'apps/backend/CargoPilot.Infrastructure.Tests/**'
+              - '**/*.test.ts'
+              - '**/*.test.tsx'
+
+      - name: CodeQL analyze
+        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Kodu al
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Kodu al
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -48,7 +48,7 @@ jobs:
 
       - name: Test sunucusuna rollback yap
         if: github.event.inputs.environment == 'test'
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.TEST_SSH_HOST }}
           username: root
@@ -60,7 +60,7 @@ jobs:
 
       - name: Prod sunucusuna rollback yap
         if: github.event.inputs.environment == 'prod'
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.PROD_SSH_HOST }}
           username: root

--- a/.github/workflows/sync-base-images.yml
+++ b/.github/workflows/sync-base-images.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: GHCR'a giriş yap
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Kodu al
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: .NET 8 SDK kur
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '8.0.x'
 
@@ -87,18 +87,18 @@ jobs:
 
     steps:
       - name: Kodu al
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: "Image tag belirle (immutable: test-{short-sha})"
         id: sha
         run: echo "tag=test-$(echo '${{ github.sha }}' | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Docker Buildx kur
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Base image pull + push için GHCR auth; GITHUB_TOKEN her trigger'da geçerli
       - name: GHCR'a giriş yap
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -107,7 +107,7 @@ jobs:
       # push: PR'larda false, test branch push'ta true
       # :test → mutable (latest), :test-{sha} → immutable (rollback için)
       - name: Backend image build ve GHCR push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./apps/backend
           file: ./apps/backend/Dockerfile
@@ -122,7 +122,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=backend-test
 
       - name: Frontend image build ve GHCR push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./apps/frontend
           file: ./apps/frontend/Dockerfile
@@ -181,14 +181,14 @@ jobs:
 
     steps:
       - name: Kodu al
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Docker Buildx kur
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Base image pull için GHCR auth; GITHUB_TOKEN her trigger'da geçerli
       - name: GHCR'a giriş yap
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -199,7 +199,7 @@ jobs:
       # Tag'ler docker-compose.test.yml'deki image: alanlarıyla eşleşmeli.
       # load: true → image'ı local Docker daemon'a yükle (no push)
       - name: Backend image build (deploy için)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./apps/backend
           file: ./apps/backend/Dockerfile
@@ -213,7 +213,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=backend-test
 
       - name: Frontend image build (deploy için)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./apps/frontend
           file: ./apps/frontend/Dockerfile
@@ -232,7 +232,7 @@ jobs:
       # Infrastructure image'ları (MSSQL ~490MB, MinIO ~100MB) cache'lenir.
       - name: Infrastructure image cache'i kontrol et
         id: infra-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /tmp/infra-images
           key: infra-images-mssql2022-minio-release-2022-v1
@@ -306,7 +306,7 @@ jobs:
       # US-D27-I: Sunucu artık build yapmıyor; GHCR'dan pull edilen image'ı kullanıyor.
       # Packages public olduğundan PAT login gerekmez; IMAGE_TAG ile immutable tag kullanılır.
       - name: Sunucuya bağlan ve test stack'ini güncelle
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         env:
           IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
         with:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cp infra/env/.env.test.example infra/env/.env.test
 docker compose -f infra/compose/docker-compose.test.yml --env-file infra/env/.env.test up -d
 ```
 
-**Default login:** `admin@cargopilot.com` / `Admin@CargoPilot1!`
+**Default login:** `admin@cargopilot.com` — parola için `docs/setup/local-setup.md`'ye bakın. Test sunucusunda parola `SEED_DEFAULT_ADMIN_PASSWORD` secret'ından gelir.
 
 ---
 

--- a/infra/scripts/rollback.sh
+++ b/infra/scripts/rollback.sh
@@ -34,12 +34,12 @@ cd "${DEPLOY_DIR}"
 
 # Hedef ref belirlenmemişse bir önceki tag'i bul
 if [[ -z "${TARGET_REF}" ]]; then
-    CURRENT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+    CURRENT_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
     if [[ -z "${CURRENT_TAG}" ]]; then
         echo "[ERROR] Mevcut tag bulunamadı. Hedef ref manuel belirtin."
         exit 1
     fi
-    TARGET_REF=$(git describe --tags --abbrev=0 "${CURRENT_TAG}^" 2>/dev/null || echo "")
+    TARGET_REF=$(git describe --tags --abbrev=0 --match 'v*' "${CURRENT_TAG}^" 2>/dev/null || echo "")
     if [[ -z "${TARGET_REF}" ]]; then
         echo "[ERROR] Önceki tag bulunamadı."
         exit 1


### PR DESCRIPTION
## Özet

2026-08-13 DevOps denetiminin öncelik matrisindeki "etki yüksek / efor düşük" kalemleri:

- **28 GitHub Actions referansının tamamı commit SHA'sına sabitlendi** (eski tag satır sonunda yorum olarak duruyor; v5 kullanımlar v5 SHA'sında kaldı, sürüm yükseltme yok). Root SSH anahtarı tutan `appleboy/ssh-action` artık immutable.
- **`.github/dependabot.yml` eklendi:** npm + NuGet + Docker ×2 + github-actions; haftalık, minor+patch gruplu, limit 5, three.js/@react-three/react-router major'ları ignore. Tüm PR'lar `target-branch: dev` — `enforce-promotion` main'e dış PR kabul etmediği için zorunlu.
- **`.github/workflows/codeql.yml` eklendi:** yalnızca PR→dev + haftalık cron (feat/** push'larına bilerek bağlı değil — C# analizi ~8-15 dk); csharp + javascript-typescript, `build-mode: none`, test/doküman yolları hariç.
- **README'den default admin parolası kaldırıldı** (canlı test URL'siyle yan yana yayınlanıyordu); giriş bilgisi `docs/setup/local-setup.md`'ye devredildi.
- **`rollback.sh` "önceki tag" çözümü `--match 'v*'` ile sınırlandı** — boş hedefle çağrıda `archive/dev-2026-08-03` gibi arşiv tag'lerine düşüyordu.

Repo ayarlarında da (bu PR'dan bağımsız, API ile): Dependabot alerts açıldı, secret scanning + push protection açıldı, Dependabot security updates **bilinçli kapalı** bırakıldı (güvenlik PR'ları `target-branch`'i yok sayıp main'e açılır ve terfi zinciri kontrolünü kırar).

## İlgili User Story / Issue

DevOps denetim raporu (`devops-audit-raporu.md`) — öncelik matrisi sol üst köşe.

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)
- [x] 🔧 Altyapı / CI-CD (infra)

## Test Edildi mi?

- [x] Manuel test yapıldı — `grep` ile 28/28 pin doğrulandı, pinsiz `@vN` satırı 0; iki yeni YAML `safe_load` ile doğrulandı; `bash -n rollback.sh` geçti.

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/commits.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

- CodeQL'in ilk tam taraması ilk haftalık cron'da koşacak; ilk PR analizlerinde diff yerine tam liste görünebilir, ilk schedule sonrası normalleşir. İlk bulgu seti için ~2-4 saat triyaj ayrılmalı.
- `xlsx` açığı Dependabot'la kapanamaz (npm'de fix yok) — SheetJS CDN / exceljs kararı ayrı iş.
- Dependabot ilk hafta ~10-15 PR açabilir (gruplama limitiyle), hepsi `dev` hedefli.
