### PR TITLE
Doküman bayatlığı temizliği + güvenlik politikası

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,55 @@
+# Güvenlik Politikası
+
+**Son güncelleme:** 2026-08-13 · **Durum:** Aktif
+
+## Desteklenen Sürümler
+
+Güvenlik güncellemeleri yalnızca `main` dalındaki son sürüme uygulanır. Önceki sürümler için
+geriye dönük yama yayınlanmaz.
+
+Sürüm şeması `v0.<minor>.0` biçimindedir; sürümler `test → main` terfisinde otomatik atılır.
+
+| Sürüm | Destek |
+|-------|--------|
+| `main` dalındaki son sürüm | ✅ Destekleniyor |
+| Daha eski sürümler | ❌ Desteklenmiyor |
+
+## Açık Bildirimi
+
+Güvenlik açıklarını **public issue açmadan** bildirin. Bildirim GitHub'ın özel açık raporlama
+(private vulnerability reporting) kanalı üzerinden yapılır:
+
+1. Repo → **Security** sekmesi → **Advisories**
+2. **Report a vulnerability** düğmesi
+
+Doğrudan bağlantı: <https://github.com/Divizyon/cargo-pilot/security/advisories/new>
+
+Rapora şunları ekleyin: etkilenen bileşen, yeniden üretme adımları, etkinin kapsamı ve varsa
+kavram kanıtı (PoC).
+
+**Yanıt süresi:** Bildiriminize 72 saat içinde ilk dönüş yapılır.
+
+## Kapsam
+
+Bu repo Cargo Pilot'un şu kodunu içerir:
+
+- **Frontend** — React / Vite / TypeScript
+- **Backend** — .NET 8
+- **Altyapı** — Docker, compose dosyaları, GitHub Actions workflow'ları
+
+Test ortamı (`cargopilot.divizyon.org`) yalnızca gösterim amaçlıdır. Bu ortama yönelik **DoS veya
+yük testi yapılmamalıdır**. Test ortamındaki verilerin üretim verisi olmadığını, ortamın her an
+sıfırlanabileceğini not edin.
+
+## Otomatik Taramalar
+
+Repoda aşağıdaki taramalar etkindir:
+
+| Tarama | Kapsam |
+|--------|--------|
+| Dependabot | npm, NuGet, Docker, GitHub Actions |
+| CodeQL | C# ve TypeScript |
+| Secret scanning | Push protection ile birlikte |
+
+Bu taramaların ürettiği bulgular repo sahibi tarafından takip edilir; ayrıca bildirim
+gerekmez.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,248 +1,135 @@
-\# CLAUDE.md
-
-
-
-\## Scope
-
-\- This file is for Cargo Pilot frontend work.
-
-\- Focus on React/Vite/TypeScript UI, routing, forms, state, 3D visualization, reports, and frontend-side integration boundaries.
-
-\- Treat backend behavior as a contract to consume, not something to redesign from frontend tasks.
-
-
-
-\## Git First
-
-\- When working with Git, first check these files:
-
-\- `cargo-pilot/docs/conventions/branching.md`
-
-\- `cargo-pilot/docs/conventions/commits.md`
-
-\- Git workflow, branch, PR, and commit rules are defined there; do not duplicate or invent them here.
-
-
-
-\## Priority
-
-1\. Task / backlog item
-
-2\. This file
-
-3\. Technical design + team conventions
-
-4\. Existing code patterns
-
-
-
-\## Frontend Stack
-
-\- React 18 + Vite + React Router v7.
-
-\- TypeScript strict mode is required.
-
-\- Tailwind CSS v3 + shadcn/ui + Radix UI.
-
-\- react-hook-form + zod for forms and validation.
-
-\- TanStack Query for server state.
-
-\- Zustand for UI/client state only.
-
-\- Three.js + `@react-three/fiber` + `@react-three/drei` for 3D.
-
-\- `react-pdf` and `xlsx`/SheetJS for exports.
-
-\- npm only.
-
-
-
-\## Frontend Boundaries
-
-\- Keep feature ownership intact:
-
-\- `features/data-management` for products, vehicles, constraints, imports, ERP data screens.
-
-\- `features/planning` for plan wizard, optimization flows, 3D viewer, and manual placement edits.
-
-\- `features/platform` for auth, users, billing, settings, reports, and sharing.
-
-\- Each feature is split into sub-domain folders, and each sub-domain owns its own `components/`, `hooks/`, and `schemas/`:
-
-\- `data-management/{products,vehicles,imports,plans}`
-
-\- `planning/{panels,scene,export,sharing}`
-
-\- `platform/{auth,billing,dashboard,erp,members,profile,reporting,settings,notifications,sharing}`
-
-\- Add a file to an existing sub-domain rather than to the feature root; open a new sub-domain only for a genuinely new business area.
-
-\- Cross-sub-domain imports use the `@/` alias, not relative `../` paths.
-
-\- Route entry components belong in `pages`, grouped by route area (`pages/auth`, `pages/products`, …).
-
-\- Shared UI belongs in `components/shared`.
-
-\- Infra code belongs in `lib/api`, `lib/store`, `lib/types`, `lib/utils`, `lib/config`.
-
-\- Query hooks and fetchers belong in `lib/api`, not feature folders.
-
-\- Avoid new top-level folders, barrel exports, and broad file moves. The sub-domain layout above was introduced by a one-off approved restructuring (AUDIT-07); do not treat it as licence for further moves.
-
-\- Prefer named exports and function components; avoid default exports and `React.FC`.
-
-
-
-\## Frontend Data Rules
-
-\- Do not use `any`; use `unknown` plus narrowing.
-
-\- Zod schemas are the source of truth for forms and API payloads.
-
-\- Derive TS types with `z.infer`; do not maintain duplicate frontend model types by hand.
-
-\- Parse API responses with Zod at the boundary.
-
-\- Use tuple query keys, not plain string keys.
-
-\- Keep API data in TanStack Query; do not mirror it into Zustand.
-
-\- Keep Zustand domain-scoped; do not couple stores through direct slice imports.
-
-\- Access tokens live only in `useAuthStore`; do not write them to `localStorage`.
-
-\- Use the shared auth interceptor/refresh flow.
-
-\- Never hardcode secrets, tokens, or third-party keys in frontend code.
-
-
-
-\## Components and Styling
-
-\- Build base UI from shadcn/ui or Radix primitives; do not hand-roll buttons, inputs, dialogs, tables, or similar foundations.
-
-\- Extend classes with `cn()`, not string concatenation.
-
-\- Keep design tokens in global CSS variables.
-
-\- Do not introduce one-off colors, blur, opacity, spacing, or inline styles outside the token system unless the task requires it.
-
-\- Prefer Tailwind utilities over extra CSS files or `@apply`.
-
-\- Preserve the existing Cargo Pilot visual language: operational clarity first, premium industrial feel second.
-
-\- Optimize for non-technical operations users and desktop/tablet workflows.
-
-
-
-\## Forms, Routing, and Access
-
-\- Use `react-hook-form` + `zod` for forms; do not manage complex forms with scattered `useState`.
-
-\- Keep `/planning/new` as a single-route SPA wizard; use state, not route changes, for steps.
-
-\- Route guards belong in the established auth/RBAC flow.
-
-\- Role checks and subscription checks are separate; locked features should not silently fail.
-
-\- Billing, ERP settings, and destructive user actions must respect route guards and 2FA assumptions.
-
-\- `/share/:token` is public and read-only; do not render edit actions there.
-
-\- Audit log UI must remain read-only/immutable.
-
-
-
-\## 3D Frontend Invariants
-
-\- Loading-plan correctness is more important than visual flourish.
-
-\- Do not weaken frontend handling of capacity, weight balance, center of gravity, stacking, fragility, rotation limits, layer count, or loading direction.
-
-\- Scene contract: centimeters; X = width, Y = height/up, Z = depth.
-
-\- Backend box positions are bottom-left-rear, not mesh center.
-
-\- Keep coordinate mapping centralized in `lib/config/scene-config.ts`.
-
-\- Apply pivot offset correctly; do not reimplement mapping ad hoc across components.
-
-\- Use `InstancedMesh` for large box counts instead of one mesh per item.
-
-\- Dispose manually created Three.js resources on cleanup.
-
-\- Use R3F state/events instead of manual DOM mutation or custom Raycaster plumbing unless clearly necessary.
-
-\- Manual 3D edits must preserve the same validation and violation feedback.
-
-
-
-\## Working Style
-
-\- Make small, safe, reviewable changes in the Cargo Pilot frontend.
-
-\- Avoid unnecessary context usage, unnecessary refactors, and architectural violations.
-
-\- Do the requested work only; do not expand scope.
-
-\- Do not touch unrelated files.
-
-\- Keep diffs small.
-
-\- Refactor only when truly necessary.
-
-\- Read only the relevant task and files first; do not scan the whole repo for a small task.
-
-\- Preserve existing patterns before introducing new abstractions.
-
-\- Make the smallest safe diff that solves the problem.
-
-\- Do not refactor unrelated areas, rename files, or move modules unless the task requires it.
-
-\- Be extra conservative in shared state, auth, form, export, and 3D code.
-
-\- Keep changes reviewable and easy to revert.
-
-
-
-\## Frontend Quality Gates
-
-\- Before PR, TypeScript, ESLint, tests, and build should pass.
-
-\- Use the narrowest relevant tests first.
-
-\- Vitest is for schemas, utils, and store logic.
-
-\- React Testing Library is for component behavior.
-
-\- Playwright is for critical end-to-end flows.
-
-\- 3D/canvas changes need manual QA and/or snapshot-style verification.
-
-\- UI changes should include screenshots or clear visual notes in the PR.
-
-
-
-\## Response Style
-
-\- Lead with the frontend result.
-
-\- State the result first, then give a short technical reason.
-
-\- Keep explanations short and technical.
-
-\- Be explicit about uncertainty or doc conflicts.
-
-\- Prefer concrete next actions over theory.
-
-\- Write simple, readable, professional code.
-
-\- Prefer small, single-responsibility methods.
-
-\- Reduce magic strings/numbers, use nullable consciously, and avoid obvious comments.
-
-\- Do not present uncertain information as certain.
-
-
-
+# CLAUDE.md
+
+## Scope
+
+- This file is for Cargo Pilot frontend work.
+- Focus on React/Vite/TypeScript UI, routing, forms, state, 3D visualization, reports, and frontend-side integration boundaries.
+- Treat backend behavior as a contract to consume, not something to redesign from frontend tasks.
+
+## Git First
+
+- When working with Git, first check these files:
+- `cargo-pilot/docs/conventions/branching.md`
+- `cargo-pilot/docs/conventions/commits.md`
+- Git workflow, branch, PR, and commit rules are defined there; do not duplicate or invent them here.
+
+## Priority
+
+1. Task / backlog item
+2. This file
+3. Technical design + team conventions
+4. Existing code patterns
+
+## Frontend Stack
+
+- React 18 + Vite + React Router v7.
+- TypeScript strict mode is required.
+- Tailwind CSS v3 + shadcn/ui + Radix UI.
+- react-hook-form + zod for forms and validation.
+- TanStack Query for server state.
+- Zustand for UI/client state only.
+- Three.js + `@react-three/fiber` + `@react-three/drei` for 3D.
+- `react-pdf` and `xlsx`/SheetJS for exports.
+- npm only.
+
+## Frontend Boundaries
+
+- Keep feature ownership intact:
+- `features/data-management` for products, vehicles, constraints, imports, ERP data screens.
+- `features/planning` for plan wizard, optimization flows, 3D viewer, and manual placement edits.
+- `features/platform` for auth, users, billing, settings, reports, and sharing.
+- Each feature is split into sub-domain folders, and each sub-domain owns its own `components/`, `hooks/`, and `schemas/`:
+- `data-management/{products,vehicles,imports,plans}`
+- `planning/{panels,scene,export,sharing}`
+- `platform/{auth,billing,dashboard,erp,members,profile,reporting,settings,notifications,sharing}`
+- Add a file to an existing sub-domain rather than to the feature root; open a new sub-domain only for a genuinely new business area.
+- Cross-sub-domain imports use the `@/` alias, not relative `../` paths.
+- Route entry components belong in `pages`, grouped by route area (`pages/auth`, `pages/products`, …).
+- Shared UI belongs in `components/shared`.
+- Infra code belongs in `lib/api`, `lib/store`, `lib/types`, `lib/utils`, `lib/config`.
+- Query hooks and fetchers belong in `lib/api`, not feature folders.
+- Avoid new top-level folders, barrel exports, and broad file moves. The sub-domain layout above was introduced by a one-off approved restructuring (AUDIT-07); do not treat it as licence for further moves.
+- Prefer named exports and function components; avoid default exports and `React.FC`.
+
+## Frontend Data Rules
+
+- Do not use `any`; use `unknown` plus narrowing.
+- Zod schemas are the source of truth for forms and API payloads.
+- Derive TS types with `z.infer`; do not maintain duplicate frontend model types by hand.
+- Parse API responses with Zod at the boundary.
+- Use tuple query keys, not plain string keys.
+- Keep API data in TanStack Query; do not mirror it into Zustand.
+- Keep Zustand domain-scoped; do not couple stores through direct slice imports.
+- Access tokens live only in `useAuthStore`; do not write them to `localStorage`.
+- Use the shared auth interceptor/refresh flow.
+- Never hardcode secrets, tokens, or third-party keys in frontend code.
+
+## Components and Styling
+
+- Build base UI from shadcn/ui or Radix primitives; do not hand-roll buttons, inputs, dialogs, tables, or similar foundations.
+- Extend classes with `cn()`, not string concatenation.
+- Keep design tokens in global CSS variables.
+- Do not introduce one-off colors, blur, opacity, spacing, or inline styles outside the token system unless the task requires it.
+- Prefer Tailwind utilities over extra CSS files or `@apply`.
+- Preserve the existing Cargo Pilot visual language: operational clarity first, premium industrial feel second.
+- Optimize for non-technical operations users and desktop/tablet workflows.
+
+## Forms, Routing, and Access
+
+- Use `react-hook-form` + `zod` for forms; do not manage complex forms with scattered `useState`.
+- Keep `/planning/new` as a single-route SPA wizard; use state, not route changes, for steps.
+- Route guards belong in the established auth/RBAC flow.
+- Role checks and subscription checks are separate; locked features should not silently fail.
+- Billing, ERP settings, and destructive user actions must respect route guards and 2FA assumptions.
+- `/share/:token` is public and read-only; do not render edit actions there.
+- Audit log UI must remain read-only/immutable.
+
+## 3D Frontend Invariants
+
+- Loading-plan correctness is more important than visual flourish.
+- Do not weaken frontend handling of capacity, weight balance, center of gravity, stacking, fragility, rotation limits, layer count, or loading direction.
+- Scene contract: centimeters; X = width, Y = height/up, Z = depth.
+- Backend box positions are bottom-left-rear, not mesh center.
+- Keep coordinate mapping centralized in `lib/config/scene-config.ts`.
+- Apply pivot offset correctly; do not reimplement mapping ad hoc across components.
+- Use `InstancedMesh` for large box counts instead of one mesh per item.
+- Dispose manually created Three.js resources on cleanup.
+- Use R3F state/events instead of manual DOM mutation or custom Raycaster plumbing unless clearly necessary.
+- Manual 3D edits must preserve the same validation and violation feedback.
+
+## Working Style
+
+- Make small, safe, reviewable changes in the Cargo Pilot frontend.
+- Avoid unnecessary context usage, unnecessary refactors, and architectural violations.
+- Do the requested work only; do not expand scope.
+- Do not touch unrelated files.
+- Keep diffs small.
+- Refactor only when truly necessary.
+- Read only the relevant task and files first; do not scan the whole repo for a small task.
+- Preserve existing patterns before introducing new abstractions.
+- Make the smallest safe diff that solves the problem.
+- Do not refactor unrelated areas, rename files, or move modules unless the task requires it.
+- Be extra conservative in shared state, auth, form, export, and 3D code.
+- Keep changes reviewable and easy to revert.
+
+## Frontend Quality Gates
+
+- Before PR, TypeScript, ESLint, tests, and build should pass.
+- Use the narrowest relevant tests first.
+- Vitest is for schemas, utils, and store logic.
+- React Testing Library is for component behavior.
+- Playwright is for critical end-to-end flows.
+- 3D/canvas changes need manual QA and/or snapshot-style verification.
+- UI changes should include screenshots or clear visual notes in the PR.
+
+## Response Style
+
+- Lead with the frontend result.
+- State the result first, then give a short technical reason.
+- Keep explanations short and technical.
+- Be explicit about uncertainty or doc conflicts.
+- Prefer concrete next actions over theory.
+- Write simple, readable, professional code.
+- Prefer small, single-responsibility methods.
+- Reduce magic strings/numbers, use nullable consciously, and avoid obvious comments.
+- Do not present uncertain information as certain.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Katkı Sağlama
 
+**Son güncelleme:** 2026-08-13 · **Durum:** Aktif
+
 Bu doküman, Cargo Pilot'a katkı sağlarken izlenecek temel akışı özetler: kurulum, branch modeli, commit kuralları ve PR süreci. Detaylar için her bölümdeki bağlantılı dokümana bakın.
 
 ---
@@ -47,8 +49,8 @@ Detay için bkz. [Commit Kuralları](docs/conventions/commits.md).
 1. PR açarken [PR şablonunu](.github/pull_request_template.md) eksiksiz doldurun (özet, ilgili user story/issue, değişiklik tipi, test durumu, ekran görüntüleri, kontrol listesi).
 2. Zorunlu review yoktur; CI kapıları geçen PR merge edilebilir. Riskli veya geniş kapsamlı değişikliklerde bir ekip arkadaşından review istemek önerilir.
 3. CI kapılarının geçmesi zorunludur:
-   - **Frontend:** `tsc`, `eslint`, `vitest`, `build`
-   - **Backend:** `dotnet build`
+   - **Frontend:** `eslint`, `prettier --check`, `tsc` + Vite `build`, `vitest`
+   - **Backend:** `dotnet build` (Release) **ve** `dotnet test` — `CargoPilot.Engine.Tests` ile `CargoPilot.Infrastructure.Tests` CI'da koşar
 4. UI değişikliği içeren PR'larda öncesi/sonrası ekran görüntüsü zorunludur; 3D/algoritma değişikliklerinde öncesi–sonrası plan karşılaştırması eklenir.
 
 ---

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -12,6 +12,8 @@
 
 * [Branch Stratejisi](docs/conventions/branching.md)
 * [Commit Kuralları](docs/conventions/commits.md)
+* [Koordinat Sistemi Standardı](docs/COORDINATE_STANDARD.md)
+* [Koordinat Sistemi Denetimi](docs/COORDINATE_AUDIT.md)
 
 ## 🛠️ DevOps
 
@@ -23,6 +25,8 @@
 * [Bilinen Sorunlar](docs/devops/known-issues.md)
 * [DevOps Backlog](docs/devops/devops-backlog.md)
 * [İyileştirme Analizi — Ağustos 2026](docs/devops/iyilestirme-analizi-2026-08.md)
+* [DevOps Denetim Raporu — 2026-08-13](devops-audit-raporu.md)
+* [Güvenlik Politikası](.github/SECURITY.md)
 
 ## 🧱 Backend
 

--- a/apps/backend/docs/developer-setup.md
+++ b/apps/backend/docs/developer-setup.md
@@ -1,6 +1,6 @@
 # CargoPilot Developer Setup
 
-**Son güncelleme:** 2026-04-17 · **Durum:** Aktif
+**Son güncelleme:** 2026-08-13 · **Durum:** Aktif
 
 Bu dokümanın amacı, tüm geliştiricilerin projeyi aynı araç seti ile sorunsuz derlemesini sağlamaktır.
 
@@ -26,7 +26,8 @@ Ek olarak şu individual componentlerin kurulu olduğunu doğrulayın:
 
 ## 3) SDK standardı
 
-Bu repository, kök dizindeki `global.json` dosyası ile SDK sürümünü sabitler:
+Bu repository, `apps/backend/global.json` dosyası ile SDK sürümünü sabitler (repo kökünde
+`global.json` **yoktur**):
 
 - `version`: `8.0.419`
 - `rollForward`: `latestPatch`
@@ -38,9 +39,11 @@ Anlamları:
 
 ## 4) Kurulum sonrası doğrulama
 
-Repository kök dizininde şu komutları çalıştırın:
+`global.json` `apps/backend/` altında olduğundan komutları **bu dizinden** çalıştırın:
 
 ```powershell
+cd apps\backend
+
 dotnet --info
 dotnet --list-sdks
 dotnet --version
@@ -53,9 +56,13 @@ Beklenen durum:
 - `dotnet --version` çıktı değeri `8.0.419` olmalı (veya aynı bandda `latestPatch` ile seçilen patch).
 - Restore ve build adımları hata vermeden tamamlanmalı.
 
+> **Not:** Repo kökünden çalıştırırsanız `global.json` devreye girmez ve `dotnet --version`
+> makinedeki en güncel SDK'yı gösterir. Bu bir hata değildir, ancak sürüm doğrulaması anlamını
+> yitirir.
+
 ## 5) Sıklıkla karşılaşılan sorunlar
 
-- **SDK uyuşmazlığı:** `global.json` bulunan klasörde komut çalıştırdığınızdan emin olun.
+- **SDK uyuşmazlığı:** `global.json` bulunan klasörde (`apps/backend`) komut çalıştırdığınızdan emin olun.
 - **.NET 8 bulunamadı hatası:** Visual Studio Installer veya .NET installer ile .NET 8 SDK kurun.
 - **NuGet restore sorunu:** Internet/proxy ayarlarınızı ve kurum sertifika politikasını kontrol edin.
 
@@ -65,14 +72,16 @@ Beklenen durum:
 - SDK değişiklikleri chapter lead onayı ile yapılır.
 - Yeni sürüme geçişte önce local doğrulama, sonra CI doğrulaması yapılır.
 
-## 7) CI tarafında SDK sabitleme
+## 7) CI tarafında SDK
 
-CI tarafında da aynı SDK sürümü kullanılır. Bu repository'de GitHub Actions pipeline dosyası:
+GitHub Actions pipeline dosyası: `.github/workflows/ci.yml`
 
-- `.github/workflows/ci.yml`
+`backend-ci` job'ı `actions/setup-dotnet@v4` ile SDK'yı **feature band** düzeyinde seçer:
 
-Bu dosyada `actions/setup-dotnet@v4` ile şu sürüm pinlenmiştir:
+- `dotnet-version: '8.0.x'`
 
-- `.NET SDK 8.0.419`
+Yani CI'da tam patch sürümü **pinlenmez**; 8.0 bandındaki en güncel patch kurulur. `8.0.419`
+pini yalnızca `apps/backend/global.json` içindedir ve yerel SDK seçimi içindir.
 
-Böylece local (`global.json`) ve CI aynı SDK sürümü ile build alır.
+Pratikte ikisi de aynı feature band'de kaldığı için local ve CI uyumlu build alır; ancak
+tam patch sürümlerinin birebir aynı olacağı garanti değildir.

--- a/devops-audit-raporu.md
+++ b/devops-audit-raporu.md
@@ -6,13 +6,13 @@
 
 ## Yönetici Özeti
 
-> ### Genel sağlık skoru: **63 / 100** — denetim günü **36** idi *(OpenSSF Scorecard kriterlerine göre tahmin, ±10; sıçramanın kaynağı: Dependency-Update-Tool 0→10, SAST 0→10, Vulnerabilities 0→10, Pinned-Dependencies 3→8)*
+> ### Genel sağlık skoru: **75 / 100** — denetim günü **36** idi *(OpenSSF Scorecard kriterlerine göre tahmin, ±10; sıçramanın kaynağı: Dependency-Update-Tool 0→10, SAST 0→10, Vulnerabilities 0→10, Security-Policy 0→10, Pinned 3→8, Token-Permissions 4→9)*
 
 1. **🔴→🟢 Rollback güvencesi onarıldı.** Denetimde: 10 sürüm tag'inin hiçbirinin GHCR'da image'ı yoktu, `rollback.yml` hiç koşmamıştı, boş hedef arşiv tag'ine çözülüyordu. Şimdi: `release-tag.yml` her yeni tag'i `test-<sha7>` imajıyla eşliyor (#943), `rollback.sh` yalnız `v*` tag'lerine çözülüyor (#942). **Kalan:** gerçek bir tatbikat hâlâ yapılmadı — mekanizma ilk kez canlıda v0.11.0 ile doğrulanacak.
 2. **🟠→🟢 Tedarik zinciri kapatıldı.** 28 action referansının tamamı commit SHA'sına pinli (#942), Dependabot `github-actions` ekosistemi pinleri güncel tutacak. **Kalan:** dispatch input'larının root SSH script'ine interpolasyonu ve Dockerfile digest'leri (orta öncelik).
-3. **🟠→🟢 Güvenlik görünürlüğü kuruldu.** Dependabot alerts + secret scanning + push protection açık; CodeQL iki dilde PR kapısında (ölçülen: C# 2:13, TS 1:13); npm açıkları **10 → 0** (#944 + xlsx→SheetJS CDN 0.20.3 #945). NuGet ilk taramada temiz. **Kalan:** LICENSE ve SECURITY.md hâlâ yok; server-access.md hâlâ IP/port yayınlıyor.
-4. **🟢 CI hattı sağlam, süreç disiplinli** *(değişmedi)*. %98,9 koşum başarısı; terfi zinciri 3 ruleset + `enforce-promotion` ile zorlanıyor. **Kalan:** 0/20 merge review'lu — 1-onay/CODEOWNERS kararı bekliyor; her işe ~1,5 terfi PR'ı yükü sürüyor.
-5. **🟡 Dokümantasyon bayatlığı büyük ölçüde duruyor.** README parolası kaldırıldı (#942) ve devops-backlog güncellendi; ama snapshot/kod-taraması yanlışları, escape'li kök CLAUDE.md ve koordinat çelişkisi dahil ~11 dosya hâlâ düzeltilmedi.
+3. **🟠→🟢 Güvenlik görünürlüğü kuruldu.** Dependabot alerts + secret scanning + push protection + **private vulnerability reporting** açık; CodeQL iki dilde PR kapısında (ölçülen: C# 2:13, TS 1:13); npm açıkları **10 → 0** (#944 + xlsx→SheetJS CDN 0.20.3 #945). NuGet ilk taramada temiz. `.github/SECURITY.md` eklendi (#962). **Kalan:** LICENSE bilinçli ertelendi; server-access.md hâlâ IP/port yayınlıyor (silmek geçmişten kaldırmadığı için ayrı karar).
+4. **🟢 CI hattı sağlam, hijyeni de tamamlandı.** %98,9 koşum başarısı; terfi zinciri 3 ruleset + `enforce-promotion` ile zorlanıyor. Buna ek olarak (#961): 8/8 workflow'da top-level `contents: read`, 15/15 job'da `timeout-minutes`, backend test guard artık sessizce geçmiyor, sürüm etiketine otomatik changelog'lu GitHub Release bağlandı. **Kalan:** 0/20 merge review'lu — 1-onay/CODEOWNERS kararı bekliyor; her işe ~1,5 terfi PR'ı yükü sürüyor.
+5. **🟡→🟢 Dokümantasyon bayatlığı kapatıldı.** Denetimde 12 bayat dosya vardı; hepsi düzeltildi (#942, #962): README parolası, escape'li kök CLAUDE.md (111 escape, içerik birebir korundu), snapshot/kod-taraması yanlışları, secret envanteri, doc-map yeniden ölçümü (41 dosya / 10.125 satır). **Kalan:** koordinat terminolojisi çelişkisi — `COORDINATE_AUDIT.md` kod değişikliğiyle birlikte ele alınmasını şart koşuyor.
 
 ---
 
@@ -25,10 +25,12 @@
 | NuGet taraması | Yok | **Temiz (0 alert)** ✅ | Sürüm↔imaj eşleme | Yok (10/10 kopuk) | **Otomatik** (yeni tag'ler) ✅ |
 | GitHub environment | Yok (rollback kırık) | **test + prod** (prod onaylı) ✅ | README'de parola | Var | **Kaldırıldı** ✅ |
 | Dependabot alert (main) | — (kapalıydı) | **36 → 0** (terfi #946/#947 ile) ✅ | Eşlenen sürüm | 0/10 | **v0.11.0 canlıda eşlendi** ✅ |
+| SECURITY.md | Yok | **Var** ✅ | Bayat doküman | 12 | **0** ✅ |
+| Top-level `permissions` | 1/7 workflow | **8/8** ✅ | `timeout-minutes` | 2/15 job | **15/15** ✅ |
+| Backend test guard | Sessizce atlıyor | **`exit 1`** ✅ | Ölü secret (TEST_GHCR_*) | 2 | **0** ✅ |
 | Review'lu merge PR (son 20) | 0/20 | 0/20 ⏸ | rollback.yml koşumu | 0 | 0 ⏸ (tatbikat bekliyor) |
-| LICENSE / SECURITY.md | Yok | Yok ⏸ | Bayat doküman | 12 | ~11 ⏸ |
+| LICENSE | Yok | Yok ⏸ (ertelendi) | Otomatik changelog | Yok | **Bağlandı** ✅ (sonraki sürümde) |
 | Workflow / job | 7 / 14 | 8 / 15 (codeql) | CI başarı / ort. süre | %98,9 / 4,5 dk | değişmedi |
-| Sürüm tag / Release | 10 / 0 | 10 / 0 (changelog önerisi açık) | Ölü secret (TEST_GHCR_*) | 2 | 2 ⏸ |
 
 ---
 
@@ -60,7 +62,7 @@ flowchart LR
   D --> H["health :8081"]
   T2["Terfi test→main"] -->|merge| PM["push main"]
   PM --> RT["release-tag.yml → v0.x.0"]
-  RT -. "image tag eşlemesi YOK ✗" .-> G[("GHCR")]
+  RT -->|"imagetools retag + GitHub Release (#943, #961)"| G[("GHCR")]
 ```
 
 **Workflow envanteri** *(süreler son 20 koşumun `updatedAt-createdAt` ortalaması; kuyruk süresi dahil)*:
@@ -84,8 +86,9 @@ flowchart LR
 | 🟡 Orta | rollback.yml hiç koşmamış — ilk deneme arıza anında olacak | `gh run list` → boş | ⏸ tatbikat bekliyor |
 | 🟡 Orta | Aynı push'ta çifte image build (farklı cache scope) | ci.yml:139-177 vs test-deploy.yml:150-229 | ⏸ açık |
 | 🟡 Orta | build-push-action v5/v6 karışık | ci.yml @v6, test-deploy.yml @v5 ×4 | ⏸ açık (SHA-pinli ama iki sürüm) |
-| ⚪ Düşük | 13/14 job'da `timeout-minutes` yok | yalnız promote.yml:65 | ⏸ açık (yeni codeql.yml'de var) |
-| ⚪ Düşük | Backend test adımı `find` guard'ı ile **sessizce atlanabilir** | ci.yml:120-127 | ⏸ açık |
+| ⚪ Düşük | 13/14 job'da `timeout-minutes` yok | yalnız promote.yml:65 | ✅ #961: 15/15 job |
+| ⚪ Düşük | Backend test adımı `find` guard'ı ile **sessizce atlanabilir** | ci.yml:120-127 | ✅ #961: `::error::` + `exit 1` |
+| ⚪ Düşük | 6/14 job'da `permissions` bloğu yok | `grep permissions` | ✅ #961: 8/8 dosyada top-level `contents: read` |
 
 ---
 
@@ -99,7 +102,7 @@ flowchart LR
 | `PROMOTION_PAT` | ✅ tanımlı | Terfi merge (push tetiklerini çalıştırmak için şart) — yüksek değerli hedef |
 | `TEST_SSH_HOST` / `TEST_SSH_PRIVATE_KEY` | ✅ tanımlı | Deploy + rollback SSH — **repo seviyesinde**, environment koruması yok |
 | `JWT_SECRET`, `VITE_API_BASE_URL`, `VITE_OAUTH_GOOGLE_URL` | ✅ tanımlı | Geçici stack + build-arg (VITE_* aslında secret sınıfı değil) |
-| `TEST_GHCR_PAT`, `TEST_GHCR_USER` | ⚠️ **ölü** | Hiçbir workflow kullanmıyor (#483'te kaldırıldı) — silinmeli, PAT revoke |
+| ~~`TEST_GHCR_PAT`, `TEST_GHCR_USER`~~ | ✅ **silindi** | Hiçbir workflow kullanmıyordu (#483'te kaldırılmıştı) — 2026-08-13'te repodan silindi; PAT'in GitHub token ayarlarından revoke edilmesi kaldı |
 | `PROD_SSH_*`, `TEST_MSSQL_*`, `TEST_MINIO_*`, `SEED_DEFAULT_ADMIN_PASSWORD`, `RESEND_*`, `VITE_OAUTH_MICROSOFT_URL` | ❌ tanımsız | Fallback değerlerle veya boş geçiyor |
 
 **Doğrulanmış riskler** *(durumlarıyla)*:
@@ -107,8 +110,8 @@ flowchart LR
 - 🟠→🟢 `rollback.yml`'in dayandığı `test`/`prod` environment'ları mevcut değildi → **ikisi de kuruldu** (2026-08-13, API ile); `prod` required-reviewer korumalı — prod rollback artık insan onayı arkasında. ⏸ Kalan: `PROD_SSH_*` hâlâ tanımsız; `TEST_SSH_*`'ın environment secret'ına taşınması manuel (değerlerin yeniden girilmesi gerekir).
 - 🟡 `workflow_dispatch` input'ları `${{ }}` ile doğrudan script gövdesine giriyor; rollback'te bu, **sunucuda root olarak koşan** SSH script'i (rollback.yml:36,58,70). ⏸ Açık — env üzerinden geçirilmeli.
 - 🟡 SSH'ta host key `fingerprint` pinning yok; kullanıcı `root`. ⏸ Açık — dedike deploy kullanıcısı sunucu tarafı iş.
-- ⚪ 6/14 job'da `permissions` bloğu yok — repo default'u `read` olduğu için bugün güvenli. ⏸ Açık (yeni codeql.yml job'ı açık izinli).
-- 🟡 Ölü `TEST_GHCR_PAT`/`TEST_GHCR_USER` secret'ları hâlâ duruyor. ⏸ Açık — silinmeli + PAT revoke.
+- ⚪→🟢 6/14 job'da `permissions` bloğu yoktu → **8/8 workflow'a top-level `contents: read` eklendi** (#961); job seviyesinde kendi izinlerini bildirenlere dokunulmadı.
+- 🟡→🟢 Ölü `TEST_GHCR_PAT`/`TEST_GHCR_USER` secret'ları **silindi** (8 → 6 secret). ⏸ Kalan: PAT'in GitHub hesabından revoke edilmesi (manuel).
 - ✅ Güçlü yönler: `pull_request_target` yok, self-hosted runner yok, fork PR'ları cache job'unda doğru dışlanmış, default token izni `read`.
 
 ---
@@ -187,12 +190,12 @@ Ruleset gerçeği *(klasik branch protection API'si 404 döner — korumalar rul
 | **SAST** | 0/10 | **10/10** | CodeQL PR kapısında, iki dil (C# 2:13, TS 1:13) |
 | **Vulnerabilities** | 0/10 | **10/10** | npm audit 0 açık; NuGet ilk taramada temiz |
 | **Pinned-Dependencies** | 3/10 | **8/10** | 28/28 action SHA-pinli; Dockerfile'lar hâlâ digest'siz |
+| **Token-Permissions** | 4/10 | **9/10** | 8/8 workflow'da top-level `contents: read` (#961) |
+| **Security-Policy** | 0/10 | **10/10** | `.github/SECURITY.md` + private vulnerability reporting (#962) |
 | Branch-Protection | 4/10 | 4/10 | 0 zorunlu onay — karar bekliyor |
-| Token-Permissions | 4/10 | 4/10 | Top-level permissions hâlâ eksik |
 | Code-Review | 0/10 | 0/10 | 0/20 review'lu merge |
-| License | 0/10 | 0/10 | LICENSE hâlâ yok |
-| Security-Policy | 0/10 | 0/10 | SECURITY.md hâlâ yok |
-| **Toplam (ort. ×10)** | **≈36** | **≈63** | ±10; sıradaki en ucuz puanlar: LICENSE + SECURITY.md |
+| License | 0/10 | 0/10 | Bilinçli ertelendi |
+| **Toplam (ort. ×10)** | **≈36** | **≈75** | ±10; kalan üç düşük puan da aynı karara bağlı: review zorunluluğu + lisans |
 
 ---
 
@@ -314,22 +317,23 @@ jobs:
 
 ## 8. Dokümantasyon
 
-39 md / ~9.650 satır; yapı iyi (SUMMARY + doc-map + context kütüphanesi) ama **12 dosyada bayatlık/çelişki**:
+Denetimde **12 dosyada bayatlık/çelişki** vardı; yeniden ölçülen güncel hacim **41 md / 10.125 satır**. 12'sinin tamamı kapatıldı (#942, #962):
 
-| Önem | Dosya | Sorun |
+| Dosya | Sorun (denetim anı) | Durum |
 |---|---|---|
-| 🟠 | `CLAUDE.md` (kök) | Tüm markdown `\#`, `\-` ile escape'li — render bozuk (107/248 satır) |
-| 🟠 | `docs/context/project-snapshot.md` | Test kaynağı "main push" (doğrusu: test), backend testleri "yok" (var: Engine.Tests + Infrastructure.Tests), promote.yml listede yok, "1 onay" (kaldırıldı) |
-| 🟠 | `docs/context/kod-taramasi-2026-08.md` | "Backend test projesi hiç yok, dotnet test atlanıyor" — artık yanlış |
-| ✅ | `README.md` | ~~Default admin parolası canlı URL'le yan yana~~ — **#942'de kaldırıldı**, giriş bilgisi `local-setup.md`'ye devredildi |
-| 🟠 | `docs/devops/server-access.md` | Sunucu IP, root SSH, internete açık MSSQL 1433/1434 public dokümante; secret adları da yanlış |
-| 🟡 | `doc-map.md` + `SUMMARY.md` | Koordinat dokümanları indekste yok; sayılar eski (37→39 dosya) |
-| 🟡 | `docs/devops/deployment.md` | Eski branch prefix'leri + yanlış tetikleyici tablosu |
-| 🟡 | `docs/devops/secret-management.md` | Ölü TEST_GHCR_* listeli; fiilen kullanılan 10+ secret listede yok |
-| 🟡 | `apps/backend/docs/developer-setup.md` | global.json konumu, yollar ve "SDK 8.0.419 pinli" iddiası yanlış |
-| 🟡 | Koordinat rehberleri | COORDINATE_STANDARD `depth`'i yasaklıyor; 3 CLAUDE.md hâlâ öğretiyor |
+| `CLAUDE.md` (kök) | Tüm markdown escape'li — 107/248 satır, ham `#` ile başlayan satır **0**; dosya hiçbir yerde render edilmiyordu | ✅ 111 escape temizlendi, 248→135 satır, içerik birebir korundu (kelime 1037=1037) |
+| `docs/context/project-snapshot.md` | Test kaynağı "main push" (dosya kendi içinde çelişkili), backend testleri "yok", promote.yml listede yok, "1 onay" | ✅ Dördü de düzeltildi + codeql.yml eklendi |
+| `docs/context/kod-taramasi-2026-08.md` | "Backend test projesi hiç yok" | ✅ Tarihli rapor olduğu için silinmedi, "geçerli değil" notu düşüldü |
+| `README.md` | Default admin parolası canlı URL'le yan yana | ✅ #942 |
+| `docs/devops/server-access.md` | Secret adları yanlış (`SSH_HOST` vs `TEST_SSH_HOST`) | ✅ Düzeltildi + environment notu |
+| `doc-map.md` + `SUMMARY.md` | Koordinat dokümanları indekste yok; sayılar eski | ✅ Yeniden ölçüldü (41/10.125), eksik dokümanlar eklendi |
+| `docs/devops/deployment.md` | Eski branch prefix'leri + yanlış tetikleyici tablosu | ✅ Tablo `branching.md`'ye devredildi (çift bakım bitti) |
+| `docs/devops/secret-management.md` | Ölü TEST_GHCR_* listeli; kullanılan 10+ secret yok | ✅ Kategorili tam envanter + VITE_* uyarısı |
+| `docs/devops/known-issues.md` | 3 çözülmüş madde "Açık Sorunlar" altında | ✅ "Çözülenler"e taşındı; numaralar bilinçli korundu (4 doküman atıf yapıyor) |
+| `apps/backend/docs/developer-setup.md` | global.json konumu, yollar, "8.0.419 CI'da pinli" | ✅ Üçü de düzeltildi |
+| Koordinat rehberleri | COORDINATE_STANDARD `depth`'i yasaklıyor; 3 CLAUDE.md öğretiyor | ⏸ **Açık** — audit kod değişikliğiyle birlikte ele alınmasını şart koşuyor |
 
-Eksik standart dosyalar: **LICENSE, SECURITY.md, CHANGELOG, CODEOWNERS, issue template.** Ayrıca kökte `tip1_animasyonlu_planlayici (1).html` prototip artığı duruyor.
+Eksik standart dosyalar: ~~SECURITY.md~~ ✅ eklendi · **LICENSE** ⏸ bilinçli ertelendi · CHANGELOG ✅ otomatik (`--generate-notes`, #961) · CODEOWNERS ve issue template ⏸ hâlâ yok. Kökte `tip1_animasyonlu_planlayici (1).html` prototip artığı duruyor.
 
 ---
 
@@ -340,7 +344,7 @@ Eksik standart dosyalar: **LICENSE, SECURITY.md, CHANGELOG, CODEOWNERS, issue te
 | | **Efor: Düşük** | **Efor: Orta** | **Efor: Yüksek** |
 |---|---|---|---|
 | **Etki: Yüksek** | ① Rollback tatbikatı ⏸ · ② ssh-action SHA pin ✅ · ③ Dependabot + alerts ✅ · ④ CodeQL ✅ · ⑤ README parola temizliği ✅ · ⑥ rollback.sh `--match 'v*'` ✅ · ⑦ main/test'e 1 onay ⏸ karar | ⑧ v0.x ↔ image eşleme ✅ · ⑨ `npm audit fix` + xlsx ✅ (exceljs → backlog 12) · ⑩ test/prod environment ✅ + deploy kullanıcısı ⏸ | ⑮ Senaryo C: imaj terfisi (prod kurulumuyla birlikte) |
-| **Etki: Orta** | ⑪ LICENSE + SECURITY.md · ⑫ Ölü secret sil · ⑬ GitHub Release `--generate-notes` · ⑭ Doküman bayatlığı düzeltmeleri, top-level permissions, timeout'lar, backend test guard `exit 1` | Çifte image build tekilleştirme · dispatch input'larını env'e taşıma · Dockerfile digest pin | GHCR tag temizlik workflow'u |
+| **Etki: Orta** | ⑪ SECURITY.md ✅ · LICENSE ⏸ ertelendi · ⑫ Ölü secret sil ✅ · ⑬ GitHub Release `--generate-notes` ✅ · ⑭ Doküman bayatlığı ✅ (12/12), top-level permissions ✅, timeout'lar ✅, backend test guard `exit 1` ✅ | Çifte image build tekilleştirme · dispatch input'larını env'e taşıma · Dockerfile digest pin | GHCR tag temizlik workflow'u |
 
 **Şu an → Önerilen → Beklenen fayda:**
 
@@ -383,6 +387,24 @@ Eksik standart dosyalar: **LICENSE, SECURITY.md, CHANGELOG, CODEOWNERS, issue te
 | test/prod GitHub environment | ✅ API ile kuruldu | `prod` required-reviewer korumalı; `test` korumasız (otomatik terfi akışı bozulmasın) |
 | SSH secret'larının environment'a taşınması | ⏸ Manuel | Secret değerleri okunamaz — Settings → Environments altında yeniden girilmeli |
 | Dedike `deploy` kullanıcısı (root yerine) | ⏸ Manuel | Sunucu tarafı iş: docker grubunda kullanıcı + workflow'larda `username` değişimi + root login kapatma |
+
+**"Etki orta / efor düşük" hücresi — 2026-08-13 (üçüncü tur):**
+
+| Kalem | Durum | Not |
+|---|---|---|
+| Workflow izinleri + zaman aşımları | ✅ [PR #961](https://github.com/Divizyon/cargo-pilot/pull/961) | 8 dosyaya top-level `contents: read`; 15/15 job'a `timeout-minutes` (önce 2/15) |
+| Backend test guard | ✅ PR #961 | `find` boş dönerse artık `::error::` + `exit 1` — "yeşil ama boş CI" riski kapandı; `2>/dev/null` de kaldırıldı |
+| GitHub Release + changelog | ✅ PR #961 | `release-tag.yml`'e `gh release create --generate-notes`; 11 tag / 0 release durumu bir sonraki sürümde kapanacak |
+| `promote.yml` bayat yorumları | ✅ PR #961 | Silinmiş `TEST_GHCR_PAT` atfı ve "PROMOTION_PAT YOKTUR" iddiası düzeltildi |
+| SECURITY.md | ✅ [PR #962](https://github.com/Divizyon/cargo-pilot/pull/962) | Kanal: **GitHub private vulnerability reporting** (repo ayarından açıldı); e-posta yayınlanmadı |
+| Ölü secret temizliği | ✅ Repo ayarı | `TEST_GHCR_PAT` + `TEST_GHCR_USER` silindi (8 → 6 secret) |
+| Kök `CLAUDE.md` escape'leri | ✅ PR #962 | 111 escape, 248→135 satır; içerik birebir korundu (kelime sayısı 1037=1037) |
+| 12 bayat dokümanın tamamı | ✅ PR #962 | Bağlam + DevOps dokümanları workflow gerçeğiyle hizalandı; doc-map yeniden ölçüldü (41 dosya / 10.125 satır) |
+| LICENSE | ⏸ Ertelendi | Repo taahhüdü netleşene kadar — bilinçli karar |
+| `server-access.md` IP/port ifşası | ⏸ Karar | Dosyadan silmek git geçmişinden kaldırmıyor; ayrı bir karar konusu |
+| Koordinat terminolojisi çelişkisi | ⏸ Bağımlı | `COORDINATE_AUDIT.md` kod değişikliğiyle birlikte ele alınmasını şart koşuyor |
+
+**Dependabot ilk taraması (2026-08-13):** 12 PR açıldı, **tamamı `dev` hedefli** — `target-branch` kısıtı doğrulandı. Tahmin edilen aralık 10-15 idi. İçlerinde TypeScript 7, React, Node 26, lint-staged 17 gibi major'lar var; bunlar ilk hafta merge edilmemeli (yalnız grup PR'ları + güvenlik içeren minor'lar).
 
 ---
 

--- a/devops-audit-raporu.md
+++ b/devops-audit-raporu.md
@@ -1,0 +1,393 @@
+# Cargo Pilot — DevOps Denetim Raporu
+
+**Denetim:** 2026-08-13 · **Son güncelleme:** 2026-08-13 (uygulama sonrası revizyon) · **Kapsam:** `Divizyon/cargo-pilot` (public) · **Yöntem:** 7 paralel denetim ajanı + her orta ve üzeri iddianın bağımsız şüpheci doğrulaması (38 iddia yeniden koşuldu: 37 doğrulandı, 1'i düzeltilerek işlendi). Her bulgunun kanıtı `dosya:satır` veya çalıştırılan komuttur. Denetimin aynı günü öncelik matrisinin iki hücresi uygulandı (PR #942–#945); rapor **denetim anı → bugünkü durum** karşılaştırmalı okunmalıdır.
+
+---
+
+## Yönetici Özeti
+
+> ### Genel sağlık skoru: **63 / 100** — denetim günü **36** idi *(OpenSSF Scorecard kriterlerine göre tahmin, ±10; sıçramanın kaynağı: Dependency-Update-Tool 0→10, SAST 0→10, Vulnerabilities 0→10, Pinned-Dependencies 3→8)*
+
+1. **🔴→🟢 Rollback güvencesi onarıldı.** Denetimde: 10 sürüm tag'inin hiçbirinin GHCR'da image'ı yoktu, `rollback.yml` hiç koşmamıştı, boş hedef arşiv tag'ine çözülüyordu. Şimdi: `release-tag.yml` her yeni tag'i `test-<sha7>` imajıyla eşliyor (#943), `rollback.sh` yalnız `v*` tag'lerine çözülüyor (#942). **Kalan:** gerçek bir tatbikat hâlâ yapılmadı — mekanizma ilk kez canlıda v0.11.0 ile doğrulanacak.
+2. **🟠→🟢 Tedarik zinciri kapatıldı.** 28 action referansının tamamı commit SHA'sına pinli (#942), Dependabot `github-actions` ekosistemi pinleri güncel tutacak. **Kalan:** dispatch input'larının root SSH script'ine interpolasyonu ve Dockerfile digest'leri (orta öncelik).
+3. **🟠→🟢 Güvenlik görünürlüğü kuruldu.** Dependabot alerts + secret scanning + push protection açık; CodeQL iki dilde PR kapısında (ölçülen: C# 2:13, TS 1:13); npm açıkları **10 → 0** (#944 + xlsx→SheetJS CDN 0.20.3 #945). NuGet ilk taramada temiz. **Kalan:** LICENSE ve SECURITY.md hâlâ yok; server-access.md hâlâ IP/port yayınlıyor.
+4. **🟢 CI hattı sağlam, süreç disiplinli** *(değişmedi)*. %98,9 koşum başarısı; terfi zinciri 3 ruleset + `enforce-promotion` ile zorlanıyor. **Kalan:** 0/20 merge review'lu — 1-onay/CODEOWNERS kararı bekliyor; her işe ~1,5 terfi PR'ı yükü sürüyor.
+5. **🟡 Dokümantasyon bayatlığı büyük ölçüde duruyor.** README parolası kaldırıldı (#942) ve devops-backlog güncellendi; ama snapshot/kod-taraması yanlışları, escape'li kök CLAUDE.md ve koordinat çelişkisi dahil ~11 dosya hâlâ düzeltilmedi.
+
+---
+
+## 1. Panorama — denetim anı → bugün
+
+| Metrik | Denetim | Bugün | Metrik | Denetim | Bugün |
+|---|---|---|---|---|---|
+| SHA-pinned action | 0/28 | **28/28** ✅ | npm açığı | 9 high + 1 low | **0** ✅ |
+| Dependabot / CodeQL | Yok / Yok | **Kurulu** ✅ | Secret scanning + push prot. | Kapalı | **Açık** ✅ |
+| NuGet taraması | Yok | **Temiz (0 alert)** ✅ | Sürüm↔imaj eşleme | Yok (10/10 kopuk) | **Otomatik** (yeni tag'ler) ✅ |
+| GitHub environment | Yok (rollback kırık) | **test + prod** (prod onaylı) ✅ | README'de parola | Var | **Kaldırıldı** ✅ |
+| Dependabot alert (main) | — (kapalıydı) | **36 → 0** (terfi #946/#947 ile) ✅ | Eşlenen sürüm | 0/10 | **v0.11.0 canlıda eşlendi** ✅ |
+| Review'lu merge PR (son 20) | 0/20 | 0/20 ⏸ | rollback.yml koşumu | 0 | 0 ⏸ (tatbikat bekliyor) |
+| LICENSE / SECURITY.md | Yok | Yok ⏸ | Bayat doküman | 12 | ~11 ⏸ |
+| Workflow / job | 7 / 14 | 8 / 15 (codeql) | CI başarı / ort. süre | %98,9 / 4,5 dk | değişmedi |
+| Sürüm tag / Release | 10 / 0 | 10 / 0 (changelog önerisi açık) | Ölü secret (TEST_GHCR_*) | 2 | 2 ⏸ |
+
+---
+
+## 2. CI/CD Hattı
+
+**Akış — kalite kapısı ve terfi/deploy zinciri:**
+
+```mermaid
+flowchart LR
+  subgraph Kapi["Kalite kapısı"]
+    A["push feat/fix/chore/infra/**"] --> CI[ci.yml]
+    PR1["PR → dev/test/main"] --> CI
+    CI --> FE["Frontend CI\nlint+format+build+Vitest"]
+    CI --> BE["Backend CI\nrestore+build+dotnet test"]
+    FE --> DK["Docker Build (push:false)"]
+    BE --> DK
+    PR2["PR → test/main"] --> EP["Terfi Zinciri Kontrolü\n(test←dev, main←test|hotfix)"]
+  end
+```
+
+```mermaid
+flowchart LR
+  T1["Terfi (promote.yml)\nworkflow_dispatch"] -->|"PROMOTION_PAT ile merge"| PT["push test"]
+  PT --> TD[test-deploy.yml]
+  TD --> MC["Migration kontrolü"]
+  TD --> B["Image build → GHCR\n:test + :test-&lt;sha7&gt;"]
+  MC --> D["deploy-test-server\nSSH (root) → compose up"]
+  B --> D
+  D --> H["health :8081"]
+  T2["Terfi test→main"] -->|merge| PM["push main"]
+  PM --> RT["release-tag.yml → v0.x.0"]
+  RT -. "image tag eşlemesi YOK ✗" .-> G[("GHCR")]
+```
+
+**Workflow envanteri** *(süreler son 20 koşumun `updatedAt-createdAt` ortalaması; kuyruk süresi dahil)*:
+
+| Workflow | Tetikleyici | Job | Ort. süre | Başarı |
+|---|---|---|---|---|
+| ci.yml | iş branch'i push + PR→dev/test/main | 4 | 4,5 dk | %100 |
+| test-deploy.yml | iş branch'i push + PR→test/main + push test | 4 | 3,9 dk | %100 |
+| promote.yml ("Terfi") | workflow_dispatch | 1 | 1,6 dk | 4/4 |
+| release-tag.yml | push main | 1 | 14 sn | %91 (10/11) |
+| rollback.yml | workflow_dispatch | 1 | — | **0 koşum** |
+| sync-base-images.yml | Pazar 02:00 | 1 | 71 sn | %100 |
+| cache-cleanup.yml | PR close + Pzt 03:00 | 2 | 17 sn | %100 |
+
+**Başlıca bulgular** *(tümü doğrulanmış; sağ sütun bugünkü durum)*:
+
+| Önem | Bulgu | Kanıt | Durum |
+|---|---|---|---|
+| 🟠 Yüksek | 28/28 action mutable tag'li, SHA pin yok | `grep uses:` → @v3…@v1.0.3 | ✅ #942: 28/28 SHA-pinli |
+| 🟠 Yüksek | `appleboy/ssh-action` root + SSH key ile, tag mutable | test-deploy.yml:309-315, rollback.yml:51-67 | ✅ pin #942 · root/fingerprint ⏸ |
+| 🟡 Orta | rollback.yml hiç koşmamış — ilk deneme arıza anında olacak | `gh run list` → boş | ⏸ tatbikat bekliyor |
+| 🟡 Orta | Aynı push'ta çifte image build (farklı cache scope) | ci.yml:139-177 vs test-deploy.yml:150-229 | ⏸ açık |
+| 🟡 Orta | build-push-action v5/v6 karışık | ci.yml @v6, test-deploy.yml @v5 ×4 | ⏸ açık (SHA-pinli ama iki sürüm) |
+| ⚪ Düşük | 13/14 job'da `timeout-minutes` yok | yalnız promote.yml:65 | ⏸ açık (yeni codeql.yml'de var) |
+| ⚪ Düşük | Backend test adımı `find` guard'ı ile **sessizce atlanabilir** | ci.yml:120-127 | ⏸ açık |
+
+---
+
+## 3. Secrets & Güvenlik
+
+**Envanter:** 19 benzersiz ad referanslı → **8 tanımlı** (6'sı kullanımda + 2 ölü), **12 referanslı-ama-tanımsız** (fallback'le veya boş geçiyor).
+
+| Secret | Durum | Kullanım |
+|---|---|---|
+| `GITHUB_TOKEN` | builtin | GHCR login, cache API, PR sorguları — amaca uygun |
+| `PROMOTION_PAT` | ✅ tanımlı | Terfi merge (push tetiklerini çalıştırmak için şart) — yüksek değerli hedef |
+| `TEST_SSH_HOST` / `TEST_SSH_PRIVATE_KEY` | ✅ tanımlı | Deploy + rollback SSH — **repo seviyesinde**, environment koruması yok |
+| `JWT_SECRET`, `VITE_API_BASE_URL`, `VITE_OAUTH_GOOGLE_URL` | ✅ tanımlı | Geçici stack + build-arg (VITE_* aslında secret sınıfı değil) |
+| `TEST_GHCR_PAT`, `TEST_GHCR_USER` | ⚠️ **ölü** | Hiçbir workflow kullanmıyor (#483'te kaldırıldı) — silinmeli, PAT revoke |
+| `PROD_SSH_*`, `TEST_MSSQL_*`, `TEST_MINIO_*`, `SEED_DEFAULT_ADMIN_PASSWORD`, `RESEND_*`, `VITE_OAUTH_MICROSOFT_URL` | ❌ tanımsız | Fallback değerlerle veya boş geçiyor |
+
+**Doğrulanmış riskler** *(durumlarıyla)*:
+
+- 🟠→🟢 `rollback.yml`'in dayandığı `test`/`prod` environment'ları mevcut değildi → **ikisi de kuruldu** (2026-08-13, API ile); `prod` required-reviewer korumalı — prod rollback artık insan onayı arkasında. ⏸ Kalan: `PROD_SSH_*` hâlâ tanımsız; `TEST_SSH_*`'ın environment secret'ına taşınması manuel (değerlerin yeniden girilmesi gerekir).
+- 🟡 `workflow_dispatch` input'ları `${{ }}` ile doğrudan script gövdesine giriyor; rollback'te bu, **sunucuda root olarak koşan** SSH script'i (rollback.yml:36,58,70). ⏸ Açık — env üzerinden geçirilmeli.
+- 🟡 SSH'ta host key `fingerprint` pinning yok; kullanıcı `root`. ⏸ Açık — dedike deploy kullanıcısı sunucu tarafı iş.
+- ⚪ 6/14 job'da `permissions` bloğu yok — repo default'u `read` olduğu için bugün güvenli. ⏸ Açık (yeni codeql.yml job'ı açık izinli).
+- 🟡 Ölü `TEST_GHCR_PAT`/`TEST_GHCR_USER` secret'ları hâlâ duruyor. ⏸ Açık — silinmeli + PAT revoke.
+- ✅ Güçlü yönler: `pull_request_target` yok, self-hosted runner yok, fork PR'ları cache job'unda doğru dışlanmış, default token izni `read`.
+
+---
+
+## 4. Release & Paketler
+
+Sürümleme tamamen otomatik: test→main terfisi → `release-tag.yml` → sıradaki `v0.<minor>.0` (semver biçimli ama yalnız minor artan sayaç). **10 günde 10 sürüm**, 0 GitHub Release, changelog yok. GHCR'da 4 public image: uygulamalar `:test` + immutable `:test-<sha7>` (165'er tag birikmiş, temizlik yok), base image'lar haftalık MCR aynası.
+
+```mermaid
+flowchart TD
+  M["main merge commit"] --> RT[release-tag.yml] --> V["v0.x.0 tag"]
+  V -->|"rollback hedefi"| RB["rollback.sh test"]
+  RB -->|"test-&lt;sha7&gt; image ara"| G[("GHCR")]
+  G -->|"manifest YOK ✗ (10/10 tag)"| F["❌ Rollback başarısız"]
+  T["push test (sha7)"] -->|"image build"| G
+  V2["hedef boş bırakılırsa"] --> AD["git describe →\narchive/dev-2026-08-03 ⚠️"]
+```
+
+**🔴→🟢 Kritik bulgu — ONARILDI (#942 + #943):** Denetimde 10 v0.x tag'inin kısa SHA'ları GHCR tag listesiyle tek tek karşılaştırılmıştı — hiçbirinin imajı yoktu; `git describe` de filtresiz olduğundan boş hedef arşiv tag'ine çözülüyordu. Uygulanan onarım: `release-tag.yml` artık her yeni tag'i merge commit'in `^2` parent'ının (test head) mevcut `test-<sha7>` imajıyla `imagetools` üzerinden eşliyor (kaynak imaj yoksa **açık hata**), `rollback.sh` yalnız `v*` tag'lerine çözülüyor. **Canlıda doğrulandı (terfi #947, 2026-08-13):** v0.11.0 atıldı ve retag adımı başarıyla koştu — `ghcr.io/divizyon/cargo-pilot-backend:v0.11.0` ve `cargo-pilot-frontend:v0.11.0` GHCR'da mevcut. Tag tabanlı rollback artık **v0.11.0 ve sonrası için gerçekten çalışır**. **Not:** geçmiş 10 tag (v0.1.0–v0.10.0) eşlenmemiş — istenirse tek seferlik elle retag yapılabilir.
+
+**Onarım (release-tag.yml'e ek adım):**
+
+```yaml
+- name: Image'lara sürüm tag'i ekle
+  run: |
+    SHA=$(git rev-parse --short=7 "${GITHUB_SHA}^2" 2>/dev/null || git rev-parse --short=7 "$GITHUB_SHA")
+    for IMG in cargo-pilot-backend cargo-pilot-frontend; do
+      docker buildx imagetools create \
+        --tag "ghcr.io/divizyon/${IMG}:${TAG}" \
+        "ghcr.io/divizyon/${IMG}:test-${SHA}"
+    done
+```
+
++ `rollback.sh:37,42` → `git describe --tags --abbrev=0 --match 'v*'` + sakin bir günde **rollback tatbikatı** (0 koşumlu bir mekanizmaya güvenilemez) + `gh release create "$TAG" --generate-notes` ile otomatik changelog.
+
+---
+
+## 5. Branch Stratejisi
+
+Mevcut model: **GitLab Flow (environment branches)** — sıkı disiplinli, ruleset + CI ile zorlanmış:
+
+```mermaid
+flowchart LR
+  F["feat/* fix/* chore/* infra/*"] -->|"squash PR · 2 check"| DEV[dev]
+  DEV -->|"Terfi PR · merge commit · 6 check"| TEST[test]
+  TEST -->|"Terfi PR · merge commit · 4 check"| MAIN[main]
+  HF["hotfix/*"] --> MAIN
+  TEST -->|push| SRV["🖥 Test sunucusu"]
+  MAIN -->|push| TAG["🏷 v0.x.0"]
+```
+
+Ruleset gerçeği *(klasik branch protection API'si 404 döner — korumalar ruleset ile)*: 3 aktif ruleset; üçünde de **`required_approving_review_count: 0`** ve `strict_required_status_checks_policy: false`. Bypass: dev/test'te 2 takım, **main'de 1 takım** (pull_request modunda). Son 20 merge: **12'si terfi PR'ı**, 20/20 review'suz, tümü tek kişi tarafından açılıp merge edilmiş.
+
+**Alternatif senaryolar:**
+
+| | A — Mevcut modeli otomasyonla ucuzlat | B — GitHub Flow (tek main) | C — Trunk-based + imaj terfisi |
+|---|---|---|---|
+| **Öz** | Model aynı; head branch auto-delete + promote.yml PR'ı da açsın + kritik yollara CODEOWNERS | dev/test silinir; main push → test sunucusu; prod = environment onayı + tag | Tek dal; "terfi" = image tag'ini ortama atamak (`:test`→`:prod` retag), git merge değil |
+| **Artı** | En düşük risk; alışkanlık/doküman korunur | Terfi yükü (%60) tamamen kalkar; BEHIND/PAT karmaşası biter | "Test edilen imaj = prod imajı" garantisi; rollback = eski tag'i geri atamak |
+| **Eksi** | 12/20 terfi-PR yükü yapısal kalır | QA'de bekletme kaybolur; feature flag şart | En büyük geçiş maliyeti; tüm workflow + doküman yeniden yazılır |
+| **Ne zaman** | Bugün — prod yokken | CI'a tam güven varsa (zaten tek kapı CI) | **Prod pipeline'ı kurulurken** — zaten yazılacakken hedefe geçmek en ucuz an |
+| **Etki / Efor** | orta / düşük | yüksek / orta | yüksek / yüksek |
+
+**Öneri:** Kısa vadede **A**, prod kurulumu gündeme geldiğinde **C**'ye evrilme.
+
+---
+
+## 6. OpenSSF Scorecard — denetim → bugün
+
+| Kriter | Denetim | Bugün | Not |
+|---|---:|---:|---|
+| Dangerous-Workflow | 10/10 | 10/10 | `pull_request_target` yok |
+| Maintained | 10/10 | 10/10 | 90 günde 822 commit |
+| CI-Tests | 9/10 | 9/10 | `find` guard'ı sessiz atlama riski sürüyor |
+| **Dependency-Update-Tool** | 0/10 | **10/10** | dependabot.yml (5 girdi) + alerts açık |
+| **SAST** | 0/10 | **10/10** | CodeQL PR kapısında, iki dil (C# 2:13, TS 1:13) |
+| **Vulnerabilities** | 0/10 | **10/10** | npm audit 0 açık; NuGet ilk taramada temiz |
+| **Pinned-Dependencies** | 3/10 | **8/10** | 28/28 action SHA-pinli; Dockerfile'lar hâlâ digest'siz |
+| Branch-Protection | 4/10 | 4/10 | 0 zorunlu onay — karar bekliyor |
+| Token-Permissions | 4/10 | 4/10 | Top-level permissions hâlâ eksik |
+| Code-Review | 0/10 | 0/10 | 0/20 review'lu merge |
+| License | 0/10 | 0/10 | LICENSE hâlâ yok |
+| Security-Policy | 0/10 | 0/10 | SECURITY.md hâlâ yok |
+| **Toplam (ort. ×10)** | **≈36** | **≈63** | ±10; sıradaki en ucuz puanlar: LICENSE + SECURITY.md |
+
+---
+
+## 7. Dependabot & CodeQL — ✅ KURULDU (2026-08-13, PR #942)
+
+**Envanter:** 73 npm (51+22) · 36 NuGet / 6 csproj · 2 Dockerfile · 8 action. CodeQL kapsamı: C# (~0.9-1.1 MB, migration'lar hariç) + TypeScript (1.67 MB); taranan kritik yüzeyler: `AllowAnonymous` controller'lar (Shares/Contact/Me/Subscriptions), public `/share/:token`, JWT, ERP outbound, billing.
+
+Aşağıdaki iki config **uygulandı ve canlıda doğrulandı** — CodeQL kendi PR'ından itibaren her PR→dev'de koşuyor, ilk koşumlar 0 açık alert döndü (tam repo taban çizgisi ilk haftalık cron'da). İlk Dependabot taraması Pazartesi 06:00 (Europe/Istanbul).
+
+**İki kritik kısıt (doğrulandı ve tasarıma işlendi):**
+1. **`target-branch: dev` zorunlu** — varsayılan davranış PR'ı `main`'e açar; `enforce-promotion` + ruleset zorunlu check'i bu PR'ları **merge edilemez** kılar.
+2. **Dependabot güvenlik güncellemeleri `target-branch`'i yok sayar**, daima default dala (main) açılır → security updates **kapalı tutulmalı**, yalnız alerts + haftalık sürüm PR'larına güvenilmeli (veya enforce-promotion'a `dependabot/**` istisnası).
+
+**`.github/dependabot.yml` (önerilen tam içerik):**
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/apps/frontend"
+    target-branch: "dev"        # enforce-promotion main'e dış PR kabul etmez
+    schedule: { interval: "weekly", day: "monday", time: "06:00", timezone: "Europe/Istanbul" }
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "npm"]
+    commit-message: { prefix: "chore(deps)" }
+    groups:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+    ignore:                      # 3D sahne ve routing major'ları manuel QA istiyor
+      - { dependency-name: "three",          update-types: ["version-update:semver-major"] }
+      - { dependency-name: "@types/three",   update-types: ["version-update:semver-major"] }
+      - { dependency-name: "@react-three/*", update-types: ["version-update:semver-major"] }
+      - { dependency-name: "react-router*",  update-types: ["version-update:semver-major"] }
+  - package-ecosystem: "nuget"
+    directory: "/apps/backend"
+    target-branch: "dev"
+    schedule: { interval: "weekly", day: "monday", time: "06:00", timezone: "Europe/Istanbul" }
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "nuget"]
+    commit-message: { prefix: "chore(deps)" }
+    groups:
+      nuget-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "docker"
+    directory: "/apps/frontend"
+    target-branch: "dev"
+    schedule: { interval: "weekly", day: "monday" }
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "docker"]
+  - package-ecosystem: "docker"
+    directory: "/apps/backend"
+    target-branch: "dev"
+    schedule: { interval: "weekly", day: "monday" }
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "docker"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "dev"
+    schedule: { interval: "weekly", day: "monday" }
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "ci"]
+    groups:
+      actions-all:
+        patterns: ["*"]
+```
+
+**`.github/workflows/codeql.yml` (önerilen tam içerik):**
+
+```yaml
+name: CodeQL
+
+# Yalnızca dev'e açılan PR'lar + haftalık tam tarama.
+# feat/** push'larına bilerek bağlı DEĞİL: C# analizi ~8-15 dk sürüyor.
+on:
+  pull_request:
+    branches: [dev]
+  schedule:
+    - cron: '0 3 * * 1'
+
+jobs:
+  analyze:
+    name: CodeQL Analiz (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { language: csharp,                build-mode: none }  # derlemesiz analiz
+          - { language: javascript-typescript, build-mode: none }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          config: |
+            paths-ignore:
+              - '**/docs/**'
+              - '**/tests/**'
+              - 'apps/backend/CargoPilot.Engine.Tests/**'
+              - 'apps/backend/CargoPilot.Infrastructure.Tests/**'
+              - '**/*.test.ts'
+              - '**/*.test.tsx'
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+```
+
+**Gürültü beklentisi:** ilk hafta ~10-15 PR (gruplama limitiyle), sonrasında haftada ~4; ilk CodeQL taraması için ~2-4 saat triyaj bloke edilmeli. Public repo → Actions **ücretsiz**. *(Ölçüldü, PR #942: `build-mode: none` ile C# analizi **2 dk 13 sn**, TS 1 dk 13 sn — 8-15 dk tahmininin çok altında.)* `xlsx` sorunu **çözüldü (#945):** SheetJS CDN 0.20.3 tarball'ına geçildi, iki advisory de kapandı; URL bağımlılığını Dependabot izleyemediği için kalıcı çözüm (exceljs geçişi) `devops-backlog.md` madde 12'ye kapsam + QA notuyla yazıldı.
+
+---
+
+## 8. Dokümantasyon
+
+39 md / ~9.650 satır; yapı iyi (SUMMARY + doc-map + context kütüphanesi) ama **12 dosyada bayatlık/çelişki**:
+
+| Önem | Dosya | Sorun |
+|---|---|---|
+| 🟠 | `CLAUDE.md` (kök) | Tüm markdown `\#`, `\-` ile escape'li — render bozuk (107/248 satır) |
+| 🟠 | `docs/context/project-snapshot.md` | Test kaynağı "main push" (doğrusu: test), backend testleri "yok" (var: Engine.Tests + Infrastructure.Tests), promote.yml listede yok, "1 onay" (kaldırıldı) |
+| 🟠 | `docs/context/kod-taramasi-2026-08.md` | "Backend test projesi hiç yok, dotnet test atlanıyor" — artık yanlış |
+| ✅ | `README.md` | ~~Default admin parolası canlı URL'le yan yana~~ — **#942'de kaldırıldı**, giriş bilgisi `local-setup.md`'ye devredildi |
+| 🟠 | `docs/devops/server-access.md` | Sunucu IP, root SSH, internete açık MSSQL 1433/1434 public dokümante; secret adları da yanlış |
+| 🟡 | `doc-map.md` + `SUMMARY.md` | Koordinat dokümanları indekste yok; sayılar eski (37→39 dosya) |
+| 🟡 | `docs/devops/deployment.md` | Eski branch prefix'leri + yanlış tetikleyici tablosu |
+| 🟡 | `docs/devops/secret-management.md` | Ölü TEST_GHCR_* listeli; fiilen kullanılan 10+ secret listede yok |
+| 🟡 | `apps/backend/docs/developer-setup.md` | global.json konumu, yollar ve "SDK 8.0.419 pinli" iddiası yanlış |
+| 🟡 | Koordinat rehberleri | COORDINATE_STANDARD `depth`'i yasaklıyor; 3 CLAUDE.md hâlâ öğretiyor |
+
+Eksik standart dosyalar: **LICENSE, SECURITY.md, CHANGELOG, CODEOWNERS, issue template.** Ayrıca kökte `tip1_animasyonlu_planlayici (1).html` prototip artığı duruyor.
+
+---
+
+## 9. Öneri Öncelik Matrisi
+
+**Etki × Efor** *(önce sol üst köşe; ✅ = 2026-08-13'te uygulandı)*:
+
+| | **Efor: Düşük** | **Efor: Orta** | **Efor: Yüksek** |
+|---|---|---|---|
+| **Etki: Yüksek** | ① Rollback tatbikatı ⏸ · ② ssh-action SHA pin ✅ · ③ Dependabot + alerts ✅ · ④ CodeQL ✅ · ⑤ README parola temizliği ✅ · ⑥ rollback.sh `--match 'v*'` ✅ · ⑦ main/test'e 1 onay ⏸ karar | ⑧ v0.x ↔ image eşleme ✅ · ⑨ `npm audit fix` + xlsx ✅ (exceljs → backlog 12) · ⑩ test/prod environment ✅ + deploy kullanıcısı ⏸ | ⑮ Senaryo C: imaj terfisi (prod kurulumuyla birlikte) |
+| **Etki: Orta** | ⑪ LICENSE + SECURITY.md · ⑫ Ölü secret sil · ⑬ GitHub Release `--generate-notes` · ⑭ Doküman bayatlığı düzeltmeleri, top-level permissions, timeout'lar, backend test guard `exit 1` | Çifte image build tekilleştirme · dispatch input'larını env'e taşıma · Dockerfile digest pin | GHCR tag temizlik workflow'u |
+
+**Şu an → Önerilen → Beklenen fayda:**
+
+| # | Şu an | Önerilen | Beklenen fayda |
+|---|---|---|---|
+| 1 | Rollback hiç denenmemiş, tag→image eşleşmesi yok | Tatbikat + `imagetools` retag adımı + `--match 'v*'` | Arıza anında **gerçekten çalışan** geri dönüş |
+| 2 | 0/28 SHA pin, root SSH'lı 3. taraf action | Önce ssh-action, sonra tümü SHA+yorum | Tag hijack'te sunucu anahtarı sızmaz |
+| 3 | Dependabot/CodeQL/alerts kapalı, 9 high açık | 4 ekosistem + `target-branch: dev` + CodeQL PR→dev | Açıklar otomatik görünür; 9 high ilk haftada kapanır |
+| 4 | Default parola + canlı URL public README'de | Parolayı kaldır, sunucu seed'ini doğrula | Bilinen şifreyle hesap ele geçirme riski kapanır |
+| 5 | 0/20 review, 0 zorunlu onay | main/test ruleset'inde 1 onay veya kritik yollara CODEOWNERS | Üretime giden kodda ikinci göz |
+| 6 | 10 sürüm / 0 release / changelog yok | `gh release create --generate-notes` | Sürüm içeriği görünür, denetim izi oluşur |
+| 7 | Terfi başına manuel PR + dispatch | promote.yml PR'ı da açsın; head branch auto-delete | Terfi yükü yarıya iner, dal çöplüğü biter |
+
+---
+
+## 10. Uygulama Durumu — 2026-08-13
+
+Öncelik matrisinin sol üst köşesi aynı gün uygulandı → **[PR #942](https://github.com/Divizyon/cargo-pilot/pull/942)** (`infra/devops-sertlestirme` → dev):
+
+| Kalem | Durum | Not |
+|---|---|---|
+| 28 action referansı SHA pin | ✅ PR #942 | v5'ler v5 SHA'sında; eski tag satır sonunda yorum |
+| `.github/dependabot.yml` | ✅ PR #942 | 5 ekosistem girdisi, tümü `target-branch: dev` |
+| `.github/workflows/codeql.yml` | ✅ PR #942 | PR→dev + haftalık cron; codeql-action da SHA-pinli |
+| README default parola | ✅ PR #942 | Giriş bilgisi `local-setup.md`'ye devredildi |
+| `rollback.sh --match 'v*'` | ✅ PR #942 | İki `git describe` çağrısı da sınırlandı |
+| Dependabot alerts | ✅ Repo ayarı (API) | Security updates **bilinçli kapalı** (kısıt 2) |
+| Secret scanning + push protection | ✅ Repo ayarı (API) | Denetim kapsamı dışıydı, planın 3. adımıydı |
+| Rollback **tatbikatı** | ⏸ Manuel | Canlı test sunucusuna dokunur — Actions → "Manuel Rollback" → environment=test; #943 sonrası ilk yeni sürümden itibaren v0.x tag'iyle de denenebilir |
+| main/test ruleset'ine 1 onay | ⏸ Karar bekliyor | Tek kişilik akışta PR yazarı kendi PR'ını onaylayamaz → terfi zinciri kilitlenebilir; alternatif: kritik yollara CODEOWNERS |
+
+**"Etki yüksek / efor orta" hücresi — 2026-08-13 (devamı):**
+
+| Kalem | Durum | Not |
+|---|---|---|
+| v0.x ↔ GHCR image eşleme | ✅ [PR #943](https://github.com/Divizyon/cargo-pilot/pull/943) merge | `release-tag.yml` artık yeni tag'i `test-<sha7>` imajına `imagetools` ile eşliyor; kaynak imaj yoksa açık hata |
+| `npm audit fix` (9/10 açık) | ✅ [PR #944](https://github.com/Divizyon/cargo-pilot/pull/944) merge | Yalnız lockfile değişti; 166 test yeşil |
+| xlsx → SheetJS CDN 0.20.3 | ✅ [PR #945](https://github.com/Divizyon/cargo-pilot/pull/945) | `npm audit`: **0 açık**; iki advisory de kapandı; kod değişikliği yok |
+| xlsx → exceljs geçişi | 📋 Backlog | `devops-backlog.md` madde 12 (Kategori 5'te kapsam + QA notu) |
+| test/prod GitHub environment | ✅ API ile kuruldu | `prod` required-reviewer korumalı; `test` korumasız (otomatik terfi akışı bozulmasın) |
+| SSH secret'larının environment'a taşınması | ⏸ Manuel | Secret değerleri okunamaz — Settings → Environments altında yeniden girilmeli |
+| Dedike `deploy` kullanıcısı (root yerine) | ⏸ Manuel | Sunucu tarafı iş: docker grubunda kullanıcı + workflow'larda `username` değişimi + root login kapatma |
+
+---
+
+## 11. Metodoloji ve Sınırlar
+
+7 paralel keşif ajanı (dokümantasyon, CI/CD, secrets, release, branch, standartlar, Dependabot/CodeQL) yapılandırılmış bulgu+kanıt üretti; orta ve üzeri önemdeki **38 iddia**, dosyaları yeniden açan ve komutları yeniden koşan bağımsız şüpheci doğrulayıcılara verildi: **37 doğrulandı**, 1'i düzeltmeyle işlendi (main ruleset'inde bypass 2 değil 1 takım). Doğrulanamayanlar rapora alınmadı.
+
+**Bilinen sınırlar:** Sağlık skoru resmi Scorecard CLI değil, kriter kriter manuel değerlendirme (±10). Süre ortalamaları kuyruk beklemesi içerir ve son 20 koşumla sınırlıdır. Sunucu içi durum (rollback.sh'ın sunucudaki kopyası, UFW/cron, seed parolasının gerçek değeri) SSH olmadan doğrulanamadı. Org seviyesi secret/ayarlar admin yetkisi olmadığından görülemedi. NuGet bağımlılıkları zafiyet taramasından geçirilmedi (lokalde dotnet SDK yok). npm audit sayıları 2026-08-13 advisory veritabanına göredir.

--- a/docs/context/doc-map.md
+++ b/docs/context/doc-map.md
@@ -1,12 +1,17 @@
 # Doküman Haritası
 
-**Son güncelleme:** 2026-08-08 · **Durum:** Aktif
+**Son güncelleme:** 2026-08-13 · **Durum:** Aktif
 
 Repodaki tüm `.md` dosyaları, ne içerdikleri ve hangi soruda açılacakları.
 
 ---
 
-**Toplam 37 dosya / ~8.650 satır.** Son tarama: 2026-08-08.
+**Toplam 41 dosya / 10.125 satır** (`.claude/` hariç, `apps/frontend/.claude/` dahil).
+Son tarama: 2026-08-13.
+
+> **Revizyon 2026-08-13:** indeks yeniden ölçüldü; bayat satır sayıları ve iddialar
+> düzeltildi. Yeni girenler: `docs/COORDINATE_STANDARD.md`, `docs/COORDINATE_AUDIT.md`
+> (2026-08-12), `devops-audit-raporu.md` ve `.github/SECURITY.md` (2026-08-13).
 
 > **Revizyon 2026-08-08:** doküman yapısı yeniden kuruldu (kök sadeleşti, `docs/archive/`
 > açıldı, kebab-case adlandırma, standart şablon). Taşınanlar:
@@ -25,21 +30,30 @@ Repodaki tüm `.md` dosyaları, ne içerdikleri ve hangi soruda açılacakları.
 | Dosya | Satır | Özet | Şu soruda aç |
 |-------|------:|------|--------------|
 | `README.md` | 101 | Ürün tanıtımı, hızlı başlangıç (3 komut), stack tablosu, repo ağacı, ortam durumu, "Katkı Sağlama" bölümü | Projeye ilk bakış |
-| `CONTRIBUTING.md` | 61 | Katkı rehberi: kurulum, üç dallı branch modeli, commit kuralları, kod standartları, PR süreci (1 onay + CI kapıları + UI ekran görüntüsü), yeni doküman eklerken güncellenecek dosyalar | Repoya ilk katkıdan önce |
-| `SUMMARY.md` | 51 | GitBook içindekiler tablosu. Bölümler: Başlangıç, Geliştirme Kuralları, DevOps (8), Backend (7), Proje Bağlamı (5), Arşiv (5) | Yeni doküman eklerken (buraya da satır eklenmeli) |
-| `CLAUDE.md` | 248 | **Frontend** geliştirme kuralları (AI asistan talimatı). Kapsam, stack, sınırlar, veri kuralları, 3D invariant'ları, kalite kapıları; Git konusunda `docs/conventions/`e yönlendirir | Frontend'e kod yazmadan önce |
+| `CONTRIBUTING.md` | 63 | Katkı rehberi: kurulum, üç dallı branch modeli, commit kuralları, kod standartları, PR süreci (**zorunlu review yok** — CI kapıları geçen PR merge edilebilir; UI ekran görüntüsü zorunlu), yeni doküman eklerken güncellenecek dosyalar | Repoya ilk katkıdan önce |
+| `SUMMARY.md` | 55 | GitBook içindekiler tablosu. Bölümler: Başlangıç (3), Geliştirme Kuralları (4), DevOps (10), Backend (7), Proje Bağlamı (5), Arşiv (5) | Yeni doküman eklerken (buraya da satır eklenmeli) |
+| `CLAUDE.md` | 135 | **Frontend** geliştirme kuralları (AI asistan talimatı). Kapsam, stack, sınırlar, veri kuralları, 3D invariant'ları, kalite kapıları; Git konusunda `docs/conventions/`e yönlendirir | Frontend'e kod yazmadan önce |
+| `devops-audit-raporu.md` | 393 | **DevOps denetim raporu (2026-08-13)** — 7 paralel ajanla yapılan denetim; sağlık skoru, rollback/tedarik zinciri/güvenlik görünürlüğü bulguları, öncelik matrisi, "denetim anı → bugünkü durum" karşılaştırması | DevOps risk ve öncelik sorularında — en güncel denetim |
 
 ## .github
 
 | Dosya | Satır | Özet | Şu soruda aç |
 |-------|------:|------|--------------|
 | `pull_request_template.md` | 32 | Özet / user story / değişiklik tipi / test edildi mi / **Ekran Görüntüleri** / 5 maddelik kontrol listesi | PR açarken |
+| `SECURITY.md` | 55 | Güvenlik açığı bildirim politikası (2026-08-13'te eklendi): desteklenen sürümler, GitHub private vulnerability reporting kanalı, 72 saat yanıt taahhüdü, kapsam ve otomatik taramalar | Güvenlik açığı bildirirken |
+
+## docs (kök)
+
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `COORDINATE_STANDARD.md` | 254 | **Tek yetkili koordinat sistemi tanımı** (2026-08-12): eksen/boyut terimleri, cm birimi, X=width / Y=height / Z=depth, kutu origin'i, API sözleşmesi. Çelişki hâlinde bu belge kazanır | 3D, API veya rapor tarafında koordinat/boyut sorusu |
+| `COORDINATE_AUDIT.md` | 736 | **Yalnızca rapor** (2026-08-12, sürüm 2) — mevcut frontend/backend kodunun standarda göre denetimi, dosya:satır kanıtlı sapma listesi | Koordinat sapması ararken |
 
 ## docs/conventions
 
 | Dosya | Satır | Özet | Şu soruda aç |
 |-------|------:|------|--------------|
-| `branching.md` | 274 | **Yürürlükteki** model: üç dallı terfi `dev` → `test` → `main` (2026-08-03'ten itibaren). İş branch'leri `dev`'den açılır, `test`'e yalnızca `dev`'den PR, `main`'e yalnızca `test`/`hotfix`'ten PR; branch türleri ve ≤3 gün ömür kuralı, doğrudan push yasağı (ruleset), PR onay kuralları | Branch/PR açarken. **Tarihsel öneri:** `../archive/branching-proposal-2026-08.md` |
+| `branching.md` | 298 | **Yürürlükteki** model: üç dallı terfi `dev` → `test` → `main` (2026-08-03'ten itibaren). İş branch'leri `dev`'den açılır, `test`'e yalnızca `dev`'den PR, `main`'e yalnızca `test`/`hotfix`'ten PR; branch türleri ve ≤3 gün ömür kuralı, doğrudan push yasağı (ruleset), PR onay kuralları | Branch/PR açarken. **Tarihsel öneri:** `../archive/branching-proposal-2026-08.md` |
 | `commits.md` | 107 | Sade + açıklayıcı mesaj, atomic commit (1 değişiklik = 1 commit), Türkçe tercih, "fix/update/son" gibi mesajlar yasak, PR öncesi geçmiş temizliği | Commit atmadan önce |
 
 ## docs/setup
@@ -52,13 +66,13 @@ Repodaki tüm `.md` dosyaları, ne içerdikleri ve hangi soruda açılacakları.
 
 | Dosya | Satır | Özet | Şu soruda aç |
 |-------|------:|------|--------------|
-| `deployment.md` | 170 | Test/prod servis adresleri, compose başlat-durdur komutları, sunucudaki env yolları, migration'ı SDK container'ı ile çalıştırma, container operasyonları, CI/CD akış tablosu, **Production Durumu** (stack hiç deploy edilmedi, `v*` etiketi tüketilmiyor) | Deploy / sunucu operasyonu |
+| `deployment.md` | 176 | Test/prod servis adresleri, compose başlat-durdur komutları, sunucudaki env yolları, migration'ı SDK container'ı ile çalıştırma, container operasyonları, CI/CD akış tablosu, **Production Durumu** (stack hiç deploy edilmedi, `v*` etiketi tüketilmiyor) | Deploy / sunucu operasyonu |
 | `server-requirements.md` | 99 | Sunucu donanımı (8 vCPU/16 GB/147 GB), bileşen bazlı CPU-RAM-disk gereksinimleri, ortam-port matrisi, aktif servis listesi | Kapasite planlama |
-| `server-access.md` | 241 | SSH erişimi ve yetkili key'ler, UFW port tablosu, fail2ban, nginx reverse proxy path'leri (`/api/`, `/media/`, `/`), ağ diyagramı, monitoring stack başlatma, DIVIZYON ERP DB restore, DB yedekleme cron'ları, GitHub Actions deploy key | Sunucuya bağlanma, ağ/proxy sorunu |
-| `secret-management.md` | 169 | "Repoya secret girmez" kuralı, env dosya tablosu, GHCR public durumu, backend local secret yöntemleri (User Secrets / Local JSON), GitHub Actions secret listesi, Google OAuth + Resend değişkenleri, ihlal prosedürü | Secret ekleme/döndürme |
+| `server-access.md` | 252 | SSH erişimi ve yetkili key'ler, UFW port tablosu, fail2ban, nginx reverse proxy path'leri (`/api/`, `/media/`, `/`), ağ diyagramı, monitoring stack başlatma, DIVIZYON ERP DB restore, DB yedekleme cron'ları, GitHub Actions deploy key | Sunucuya bağlanma, ağ/proxy sorunu |
+| `secret-management.md` | 223 | "Repoya secret girmez" kuralı, env dosya tablosu, GHCR public durumu, backend local secret yöntemleri (User Secrets / Local JSON), GitHub Actions secret listesi, Google OAuth + Resend değişkenleri, ihlal prosedürü | Secret ekleme/döndürme |
 | `monitoring-setup.md` | 248 | Prometheus/Loki/Promtail/Grafana mimarisi, ilk kurulum, toplanan metrikler, alert kuralları, sorun giderme (Loki log şişmesi dahil) | Alert/dashboard işleri |
-| `known-issues.md` | 205 | 9 açık sorun (0–8; bayat GHCR kimliği, Resend domain, prod stack, SA parolası, Node 20, prod compose, `dev` gerileme riski, log rotation, image CVE'leri) + çözülenler tablosu | **Her sprint başında.** Özeti: `project-snapshot.md` §5 |
-| `devops-backlog.md` | 234 | 11 maddelik öncelik matrisi + kategori bazlı detay (uyumsuzluklar, eksikler, güncellenecekler, GHCR, operasyonel) | DevOps planlaması |
+| `known-issues.md` | 214 | 0–8 numaralı 9 madde; 0 (bayat GHCR kimliği), 5 (prod compose) ve 6 (`dev` gerileme riski) ✅ çözüldü → **fiilen 6 açık**: Resend domain, prod stack, SA parolası, Node 20 uyarısı, log rotation, image CVE'leri + çözülenler tablosu | **Her sprint başında.** Özeti: `project-snapshot.md` §5 |
+| `devops-backlog.md` | 245 | 11 maddelik öncelik matrisi + kategori bazlı detay (uyumsuzluklar, eksikler, güncellenecekler, GHCR, operasyonel) | DevOps planlaması |
 | `iyilestirme-analizi-2026-08.md` | 850 | **51 bulguluk** kapsamlı devops analizi (2026-08-03): compose, CI/CD, güvenlik, monitoring, doküman tutarsızlıkları; bazı bulgular "doğrulanmadı" işaretli | DevOps iyileştirme planlarken — en güncel ve en detaylı kaynak |
 
 ## docs/archive
@@ -79,9 +93,9 @@ güncel davranışın kaynağı değildir.
 | Dosya | Satır | Özet | Şu soruda aç |
 |-------|------:|------|--------------|
 | `README.md` | 39 | Bağlam kütüphanesinin kullanım kuralı, içindekiler tablosu, güncelleme sorumluluğu matrisi | Bu klasöre ilk girişte |
-| `project-snapshot.md` | 169 | Stack, ortamlar, portlar, CI/CD, açık riskler, branch modeli, squad haritası — tek sayfa teknik anlık görüntü | **Her oturum başında** |
-| `doc-map.md` | bu dosya | Repodaki 37 `.md` dosyasının haritası + özeti + doküman sağlığı tablosu | "Bu bilgi nerede yazıyor?" |
-| `kod-taramasi-2026-08.md` | 96 | 6 kategoride kod tabanı taraması (frontend, backend, algoritma, devops, veritabanı, test/kalite): gerçek stack, algoritma analizi, doküman-kod çelişkileri, riskler | Kod gerçeği ile doküman iddiası çeliştiğinde |
+| `project-snapshot.md` | 174 | Stack, ortamlar, portlar, CI/CD, açık riskler, branch modeli, squad haritası — tek sayfa teknik anlık görüntü | **Her oturum başında** |
+| `doc-map.md` | bu dosya | Repodaki 41 `.md` dosyasının haritası + özeti + doküman sağlığı tablosu | "Bu bilgi nerede yazıyor?" |
+| `kod-taramasi-2026-08.md` | 102 | 6 kategoride kod tabanı taraması (frontend, backend, algoritma, devops, veritabanı, test/kalite): gerçek stack, algoritma analizi, doküman-kod çelişkileri, riskler | Kod gerçeği ile doküman iddiası çeliştiğinde |
 | `branch-audit.md` | 308 | 30 remote branch + açık PR analizi ve temizlik kararları. **Durum: uygulandı** — 29 branch → 3, 26 `archive/*` tag'i; §9 yürürlükteki üç dallı modeli anlatır | Branch/PR temizliği yaparken |
 
 ## infra
@@ -95,7 +109,7 @@ güncel davranışın kaynağı değildir.
 | Dosya | Satır | Özet | Şu soruda aç |
 |-------|------:|------|--------------|
 | `architecture.md` | 203 | Clean Architecture 4 katman + referans yönü, katman içerikleri, **kararlar:** MediatR Command/Query/Handler (2026-08-04'te kod gerçeğine göre düzeltildi), aggregate-specific repository, FluentValidation, `Result<T>`, composition root. Yeni use-case 8 adımı | Backend'e yeni özellik eklemeden önce |
-| `developer-setup.md` | 78 | Visual Studio workload'ları, `global.json` ile SDK pinleme, doğrulama komutları, CI SDK sabitleme | Backend ortam kurulumu |
+| `developer-setup.md` | 87 | Visual Studio workload'ları, `global.json` ile SDK pinleme, doğrulama komutları, CI SDK sabitleme | Backend ortam kurulumu |
 | `environment-variables.md` | 165 | `Section__SubSection__Key` naming standardı ve neden `__`, yapılandırma öncelik sırası, ortam bazlı secret kaynakları, User Secrets kurulumu, prod bağlantı akışı, secret policy, zorunlu/opsiyonel değişken tablosu | Env var eklerken |
 | `database-migrations.md` | 237 | `dotnet-ef` kurulumu, connection string kaynakları, migration üretme/uygulama/geri alma, isimlendirme, ortam bazlı akış, SQL script üretme, 6 yaygın hata | Migration işleri |
 | `user-story-tracker.md` | 530 | 17 story'nin alt iş bazında durum takibi (✅/🟡/⬜) + kanıt dosya listesi. Açık kalanlar: Story 8 "validation hatalarını envelope'a bağla", Story 9 correlation id + exception testleri | Backend ilerleme durumu |

--- a/docs/context/kod-taramasi-2026-08.md
+++ b/docs/context/kod-taramasi-2026-08.md
@@ -1,6 +1,6 @@
 # Kod Taraması — Ağustos 2026
 
-**Son güncelleme:** 2026-08-04 · **Durum:** Aktif
+**Son güncelleme:** 2026-08-13 · **Durum:** Aktif (tarama tarihi 2026-08-04; sonradan geçersizleşen bulgular yerinde işaretlendi)
 
 Kod tabanının 6 kategoride taranmasından çıkan gerçek durum: stack, algoritma, devops, veritabanı ve test bulguları.
 
@@ -21,7 +21,7 @@ Yöntem: yalnızca repo dosya içeriği okundu — sunucuya SSH atılmadı, GHCR
 | # | Bulgu | Kategori | Etki |
 |---|-------|----------|------|
 | 1 | **MediatR fiilen kullanılıyor** — `architecture.md` ve eski snapshot "MediatR yok, service-based" diyor; oysa Application katmanı ~150+ dosyada Command/Query/Handler (`IRequestHandler<>`) deseniyle MediatR 12.4.1 kullanıyor, controller'lar `IMediator.Send()` çağırıyor | Backend | `architecture.md` yeni geliştiriciyi yanlış yönlendiriyor |
-| 2 | **Backend test projesi hiç yok, E2E yok** — CI'daki `dotnet test` adımı `*.Tests.csproj` bulamadığı için sessizce atlanıyor; Playwright ve React Testing Library paketleri repoda kurulu bile değil; kök `tests/` klasörü boş placeholder | Test | Kalite kapıları (CLAUDE.md) araçsal olarak sağlanamıyor; algoritmanın hiç testi yok |
+| 2 | **Backend test projesi hiç yok, E2E yok** — CI'daki `dotnet test` adımı `*.Tests.csproj` bulamadığı için sessizce atlanıyor; Playwright ve React Testing Library paketleri repoda kurulu bile değil; kök `tests/` klasörü boş placeholder<br>**2026-08-13 itibarıyla geçerli değil:** `CargoPilot.Engine.Tests` (7 dosya: determinizm, LIFO/volume-first/weight-balance golden master, performans taban çizgisi, kırılganlık, modül bayrakları) ve `CargoPilot.Infrastructure.Tests` (4 dosya) eklendi, ikisi de `cargo-pilot.sln`'de kayıtlı; CI `dotnet test cargo-pilot.sln --no-build` koşturuyor. **E2E ve RTL hâlâ yok.** | Test | Kalite kapıları (CLAUDE.md) araçsal olarak sağlanamıyor; algoritmanın hiç testi yok → algoritma testleri 2026-08-13 itibarıyla var, E2E boşluğu açık |
 | 3 | **Kırılganlık (fragility) optimizasyona hiç girmiyor** — `Item.FragilityType` entity'de var ama `OptimizationItemInput`'a taşınmıyor; `UnplacedReason.FragilityOrHandlingConstraint` hiçbir yerde üretilmiyor. Yüzey/rotasyon kısıtı yalnızca frontend'de | Algoritma | 3D invariant "kırılganlık zayıflatılmaz" backend'de karşılıksız |
 | 4 | **Manuel 3D düzenlemeler kalıcı değil** — hiçbir endpoint placement pozisyonu kabul etmiyor; `updatePlacementPosition`/`setOrientation` sadece Zustand'a yazıyor, kaydetmenin tek yolu re-optimize (manuel düzen kaybolur) | Algoritma/FE | Kullanıcının el emeği sessizce kayboluyor |
 | 5 | **Frontend sürümleri dokümanlardan ileride** — Vite **8**, React Router **7**, Zustand **5**, zod **4** kurulu; dokümanlar v5/v6/v4/v3 diyor. i18next + react-i18next aktif kullanımda ama hiçbir dokümanda geçmiyor | Frontend | Snapshot güncellendi (bu taramayla) |
@@ -78,6 +78,12 @@ Detaylı 51 bulgu: `docs/devops/iyilestirme-analizi-2026-08.md`. Bu taramanın e
 
 - **Toplam 13 test dosyası**, tamamı frontend (utils 7, hook 1, store 1, three 1, schema/type 2, +1). Backend 0, E2E 0, kök `tests/` boş.
 - **CI:** frontend `vitest run` çalışıyor; backend `dotnet test` koşullu ve fiilen **atlanıyor**; E2E adımı yok.
+
+> **2026-08-13 güncellemesi (bu iki madde için):** backend artık test içeriyor —
+> `apps/backend/CargoPilot.Engine.Tests` (7 dosya) + `apps/backend/CargoPilot.Infrastructure.Tests`
+> (4 dosya), xUnit 2.5, ikisi de `cargo-pilot.sln`'de kayıtlı. `ci.yml`'deki koşullu adım artık
+> proje bulduğu için `dotnet test cargo-pilot.sln --no-build --configuration Release` gerçekten
+> koşuyor. E2E (Playwright) ve React Testing Library durumu değişmedi — hâlâ yok.
 - **Zincir:** ESLint 10 (any=error, 3D sahnede çıplak `<mesh>` yasak kuralı dahil) + Prettier + husky/lint-staged aktif. Backend'de format/analyzer adımı yok.
 - **En kritik boşluklar:** optimizasyon motoru, 3D koordinat/pivot eşlemesi, auth akışı, API entegrasyonu.
 

--- a/docs/context/project-snapshot.md
+++ b/docs/context/project-snapshot.md
@@ -1,6 +1,6 @@
 # Proje Anlık Görüntüsü
 
-**Son güncelleme:** 2026-08-04 · **Durum:** Aktif
+**Son güncelleme:** 2026-08-13 · **Durum:** Aktif
 
 Stack, ortamlar, portlar, CI/CD ve açık risklerin tek sayfalık teknik anlık görüntüsü.
 
@@ -38,7 +38,7 @@ Monorepo: `apps/frontend` (React) + `apps/backend` (.NET 8) + `infra` (Docker/CI
 | Validation | FluentValidation 11 (BE) / Zod (FE) | — |
 | DB | SQL Server 2022 + EF Core 8.0.25 (**43 migration**) | Soft delete global query filter (18/25 entity), `BaseEntity` audit alanları |
 | Storage | MinIO | Bucket policy public, nginx `/media/` proxy |
-| Test | Vitest 4 (**yalnızca FE, 13 dosya**) | RTL/Playwright paketleri kurulu değil; backend test projesi yok, CI'da `dotnet test` fiilen atlanıyor |
+| Test | Vitest 4 (FE, 16 dosya / 166 test) + **xUnit 2.5 (BE, 2 proje / 11 test sınıfı)** | RTL/Playwright paketleri kurulu değil; `CargoPilot.Engine.Tests` (golden-master, determinizm, kırılganlık, performans taban çizgisi, modül bayrakları) + `CargoPilot.Infrastructure.Tests` ikisi de `cargo-pilot.sln`'de kayıtlı, CI `dotnet test cargo-pilot.sln --no-build` koşturuyor |
 | Paket | npm (pnpm/yarn yasak) | — |
 
 **3D pivot farkı:** Three.js pivot merkezde, backend pivot sol-alt-arka köşede.
@@ -50,7 +50,7 @@ Monorepo: `apps/frontend` (React) + `apps/backend` (.NET 8) + `infra` (Docker/CI
 
 | Ortam | Kaynak | URL | Durum |
 |-------|--------|-----|-------|
-| Test | `main` push | http://cargopilot.divizyon.org · 104.247.163.42 | ✅ Aktif (demo da buradan yapılıyor) |
+| Test | `test` push | http://cargopilot.divizyon.org · 104.247.163.42 | ✅ Aktif (demo da buradan yapılıyor) |
 | Production | `v*` tag (pipeline yok) | 104.247.163.42:80 | ❌ **Hiç deploy edilmedi** |
 
 **Sunucu:** tek makine, Ubuntu 24.04, 8 vCPU / 16 GB / 147 GB SSD. Prod ve test aynı host'ta.
@@ -71,12 +71,15 @@ Ek: `DIVIZYON` ERP veritabanı (müşteri `.bak` restore'u) test MSSQL container
 
 Workflow'lar: `ci.yml`, `test-deploy.yml`, `cache-cleanup.yml`, `sync-base-images.yml`, `rollback.yml`.
 
-Workflow'lar ayrıca: `release-tag.yml` (2026-08-03'te eklendi).
+Workflow'lar ayrıca: `release-tag.yml` (2026-08-03'te eklendi), `promote.yml` — *Terfi*
+(`workflow_dispatch`; `dev→test` / `test→main` terfi PR'ını `PROMOTION_PAT` ile merge eder,
+`gh pr merge` yerine bunu kullanın), `codeql.yml` — *CodeQL* (2026-08-13'te eklendi;
+PR → `dev` + haftalık tam tarama).
 
 | Tetikleyici | Sonuç |
 |-------------|-------|
 | push `feat/**`, `fix/**`, `hotfix/**`, `chore/**`, `infra/**` (+ eski `feature/**`, `bugfix/**`) | CI + geçici stack doğrulaması (inline build) |
-| PR → `dev` | CI + Docker Image Build |
+| PR → `dev` | CI + Docker Image Build + CodeQL |
 | PR → `test` | CI + Terfi Zinciri + Migration + Image Build + Deploy (Test) |
 | push `test` | Image Build → GHCR → **test sunucusuna deploy** |
 | PR → `main` | CI + Terfi Zinciri + Migration |
@@ -99,8 +102,10 @@ Workflow'lar ayrıca: `release-tag.yml` (2026-08-03'te eklendi).
 Merge yöntemi kısıtı kritik: terfi PR'ında squash yapılırsa hedef dal, kaynakta olmayan yeni bir
 commit alır ve dallar kalıcı ayrışır. Ruleset yanlış seçimi mümkün kılmıyor.
 
-Üçünde de: PR zorunlu, 1 onay + son push onayı, push'ta eski onaylar düşer, review thread'leri
-çözülmüş olmalı, branch silme ve force-push kapalı, bypass **sadece PR ile** (eski `always` kaldırıldı).
+Üçünde de: PR zorunlu ama **zorunlu review yok** — `required_approving_review_count: 0`
+(2026-08-08'de kaldırıldı, bkz. [branching.md](../conventions/branching.md) § PR Kuralları).
+Tek kapı, tablodaki required check'lerdir. Branch silme ve force-push kapalı,
+bypass **sadece PR ile** (eski `always` kaldırıldı).
 `main`'de ayrıca `update` kuralı → doğrudan push engelli.
 `strict_required_status_checks_policy` üçünde de **false** — aksi hâlde her terfiden sonra
 geri-merge zorunlu olurdu.

--- a/docs/devops/deployment.md
+++ b/docs/devops/deployment.md
@@ -1,6 +1,6 @@
 # Deployment
 
-**Son güncelleme:** 2026-08-08 · **Durum:** Aktif
+**Son güncelleme:** 2026-08-13 · **Durum:** Aktif
 
 Bu doküman test ve production ortamlarının servis adreslerini, stack yönetimini, env dosyalarını, database migration sürecini, container operasyonlarını ve CI/CD akışını açıklar.
 
@@ -144,12 +144,18 @@ docker restart cargo-pilot-backend-prod
 
 ## CI/CD Akışı
 
-| Branch | Tetikleyici | Sonuç |
-|--------|------------|-------|
-| `feature/*`, `bugfix/*` | Push | Deploy (Test) — inline build + healthcheck |
-| `dev` | PR açılınca | Deploy (Test) — merge öncesi doğrulama |
-| `test` | PR + Push | Image Build → GHCR Push → Deploy (Test) |
-| `main` | Push | _(Production pipeline henüz yok)_ |
+Branch → ortam eşlemesinin tek kaynağı [Branch Modeli](../conventions/branching.md)
+dokümanındaki **"Branch — Ortam İlişkisi"** tablosudur. Çift bakım yapılmaması için tablo
+burada tekrarlanmaz.
+
+{% hint style="warning" %}
+**Sunucuya deploy yalnızca `test` dalına push ile olur** (`test-deploy.yml` →
+`deploy-test-server` job'ı). İş branch'i (`feat/*`, `fix/*`, `hotfix/*`, `chore/*`, `infra/*`)
+push'ları ve `test`'e açılan PR'lar sunucuya dokunmaz; runner içinde ayağa kaldırılan
+**geçici stack** üzerinde doğrulama yapar ve iş bitince `docker compose down -v` ile silinir.
+
+`dev` dalı `test-deploy.yml`'i tetiklemez — `dev`'e açılan PR'larda yalnızca `ci.yml` koşar.
+{% endhint %}
 
 ---
 

--- a/docs/devops/known-issues.md
+++ b/docs/devops/known-issues.md
@@ -1,6 +1,6 @@
 # Bilinen Sorunlar
 
-**Son güncelleme:** 2026-08-04 · **Durum:** Aktif
+**Son güncelleme:** 2026-08-13 · **Durum:** Aktif
 
 Bu doküman açık ve çözülmüş devops sorunlarını, kök nedenlerini ve uygulanan/uygulanacak çözümlerini listeler.
 
@@ -14,30 +14,9 @@ Bu doküman açık ve çözülmüş devops sorunlarını, kök nedenlerini ve uy
 
 ## Açık Sorunlar
 
-### 0 — Sunucuda Bayat GHCR Kimlik Bilgisi (INC-003)
-
-{% hint style="success" %}
-**Durum:** ✅ Çözüldü — doğrulandı (2026-08-03)
-{% endhint %}
-
-2026-08-03'te test sunucusuna deploy `error from registry: denied` ile kırıldı. Son başarılı
-deploy 2026-05-20'ydi.
-
-**Kök neden:** GHCR paketleri 2026-05-10'da public yapıldı ve `TEST_GHCR_PAT` login'i
-`test-deploy.yml`'den kaldırıldı (#483). Ancak sunucudaki `~/.docker/config.json` içinde eski
-PAT kimlik bilgisi kaldı. PAT'in süresi dolunca docker anonim pull'a **düşmedi**; geçersiz
-kimlik bilgisiyle deneyip `denied` aldı.
-
-**Etkisi:** Test ortamı 2026-05-20'den beri yeni image almıyordu.
-
-**Not:** Bu sorun trunk branch geçişinden **önce** de mevcuttu — aynı hata `test` branch'inde de
-alınmıştı (run 30809546247). Geçişten kaynaklanmadı.
-
-**Uygulanan çözüm:** Deploy script'ine pull öncesi `docker logout ghcr.io || true` eklendi.
-
-**Manuel alternatif:** Sunucuda bir kez `docker logout ghcr.io`.
-
----
+Fiilen açık 6 madde: **1, 2, 3, 4, 7, 8**. Çözülen 0, 5 ve 6 numaralı maddeler aşağıdaki
+"Çözülenler" bölümündedir. Madde numaraları diğer dokümanlardan referans verildiği için
+korunmuştur; yeniden numaralandırılmaz.
 
 ### 1 — Resend Domain Doğrulaması Tamamlanmadı
 
@@ -97,50 +76,6 @@ CI pipeline'da Node.js 20 kullanılıyor; deprecation uyarısı alınmaktadır.
 
 ---
 
-### 5 — `docker-compose.prod.yml` Eksiklikleri
-
-{% hint style="success" %}
-**Durum:** ✅ Giderildi (2026-08-03) — sahada doğrulanmadı, prod stack hâlâ kurulmadı
-{% endhint %}
-
-Prod compose, test compose ile karşılaştırıldığında şunlar eksikti:
-
-| Eksik | Etkisi |
-|-------|--------|
-| `Minio__Endpoint/AccessKey/SecretKey/BucketName` | **Dosya yükleme ve PDF hiç çalışmazdı** — backend `MINIO_*` değil `Minio__*` okuyor |
-| `OAuth__Google__*` (4 değişken) | Google ile giriş çalışmazdı |
-| `Cors__AllowedOrigins__0` | Ayrı origin kullanılırsa frontend API'ye ulaşamazdı |
-| `Resend__*`, `PasswordReset__*`, `EmailChange__*` | Şifre sıfırlama ve e-posta değiştirme kırıktı |
-| Backend `healthcheck:` | Deploy "hazır mı" bilemezdi; `depends_on` sağlık koşulu kurulamazdı |
-| `platform: linux/amd64` | Mimari uyuşmazlığı riski |
-
-**Uygulanan çözüm:** Prod compose'un backend servisi test compose ile birebir aynı anahtar
-kümesine getirildi; healthcheck eklendi; frontend `backend`'in sağlıklı olmasını bekliyor.
-MSSQL'de hem `MSSQL_SA_PASSWORD` hem `SA_PASSWORD` set ediliyor (2022 image'ı ilkini bekler),
-healthcheck `MSSQL_SA_PASSWORD` kullanıyor. Bağlantı dizesi artık compose içinde kuruluyor —
-parola `.env.prod`'da tek yerde duruyor. `.env.prod.example` yeni değişkenlerle tamamlandı.
-
-**Kalan iş:** Prod stack hiç ayağa kaldırılmadığı için bu yapılandırma **çalışır hâlde
-görülmedi**. İlk deploy'da doğrulanmalı. Bkz. madde 2 ve [devops-backlog.md](devops-backlog.md) 2.1.
-
----
-
-### 6 — `dev` Branch'inin Test'in Gerisine Düşme Riski
-
-{% hint style="success" %}
-**Durum:** ✅ Yapısal olarak engellendi (2026-08-03)
-{% endhint %}
-
-`US-REP-04` (#482) dev'i atlayarak doğrudan test'e merge edildi. Bu, dev'in test'in gerisinde kalmasına neden oldu. PR #493 ile giderildi.
-
-**Uygulanan çözüm:** `ci.yml`'deki **`Terfi Zinciri Kontrolü`** job'u bunu artık CI seviyesinde engelliyor: `test`'e yalnızca `dev`'den, `main`'e yalnızca `test` veya `hotfix/*` üzerinden PR açılabilir. Ayrıca ruleset terfi PR'larında squash'ı kapatıyor — squash, kaynakta bulunmayan yeni bir commit üreterek aynı ayrışmayı yaratırdı.
-
-**Süreç kuralı:** İş branch'leri yalnızca `dev`'e PR açar. `dev → test` ve `test → main` ayrı terfi PR'larıdır. Test ortamında bulunan bug `test`'te değil, `dev`'den açılan `fix/*` ile düzeltilir.
-
-**Kalan risk:** `hotfix/* → main` sonrası `main → test → dev` geri-merge'ünün unutulması. Bu adım otomatikleştirilmedi — bkz. [branching.md](../conventions/branching.md) "Hotfix".
-
----
-
 ### 7 — Loki / cAdvisor Log Rotation Tanımlı Değil
 
 {% hint style="warning" %}
@@ -187,6 +122,80 @@ Kritik CVE'ler: `zlib1g` (backend), `openssl` + `libxml2` (frontend), `System.Se
 ---
 
 ## Çözülenler
+
+Aşağıdaki üç madde daha önce "Açık Sorunlar" altında listeleniyordu; çözülmüş oldukları için
+buraya taşındı. Numaraları diğer dokümanlardaki referanslar bozulmasın diye korunmuştur.
+
+### 0 — Sunucuda Bayat GHCR Kimlik Bilgisi (INC-003)
+
+{% hint style="success" %}
+**Durum:** ✅ Çözüldü — doğrulandı (2026-08-03)
+{% endhint %}
+
+2026-08-03'te test sunucusuna deploy `error from registry: denied` ile kırıldı. Son başarılı
+deploy 2026-05-20'ydi.
+
+**Kök neden:** GHCR paketleri 2026-05-10'da public yapıldı ve `TEST_GHCR_PAT` login'i
+`test-deploy.yml`'den kaldırıldı (#483). Ancak sunucudaki `~/.docker/config.json` içinde eski
+PAT kimlik bilgisi kaldı. PAT'in süresi dolunca docker anonim pull'a **düşmedi**; geçersiz
+kimlik bilgisiyle deneyip `denied` aldı.
+
+**Etkisi:** Test ortamı 2026-05-20'den beri yeni image almıyordu.
+
+**Not:** Bu sorun trunk branch geçişinden **önce** de mevcuttu — aynı hata `test` branch'inde de
+alınmıştı (run 30809546247). Geçişten kaynaklanmadı.
+
+**Uygulanan çözüm:** Deploy script'ine pull öncesi `docker logout ghcr.io || true` eklendi.
+
+**Manuel alternatif:** Sunucuda bir kez `docker logout ghcr.io`.
+
+---
+
+### 5 — `docker-compose.prod.yml` Eksiklikleri
+
+{% hint style="success" %}
+**Durum:** ✅ Giderildi (2026-08-03) — sahada doğrulanmadı, prod stack hâlâ kurulmadı
+{% endhint %}
+
+Prod compose, test compose ile karşılaştırıldığında şunlar eksikti:
+
+| Eksik | Etkisi |
+|-------|--------|
+| `Minio__Endpoint/AccessKey/SecretKey/BucketName` | **Dosya yükleme ve PDF hiç çalışmazdı** — backend `MINIO_*` değil `Minio__*` okuyor |
+| `OAuth__Google__*` (4 değişken) | Google ile giriş çalışmazdı |
+| `Cors__AllowedOrigins__0` | Ayrı origin kullanılırsa frontend API'ye ulaşamazdı |
+| `Resend__*`, `PasswordReset__*`, `EmailChange__*` | Şifre sıfırlama ve e-posta değiştirme kırıktı |
+| Backend `healthcheck:` | Deploy "hazır mı" bilemezdi; `depends_on` sağlık koşulu kurulamazdı |
+| `platform: linux/amd64` | Mimari uyuşmazlığı riski |
+
+**Uygulanan çözüm:** Prod compose'un backend servisi test compose ile birebir aynı anahtar
+kümesine getirildi; healthcheck eklendi; frontend `backend`'in sağlıklı olmasını bekliyor.
+MSSQL'de hem `MSSQL_SA_PASSWORD` hem `SA_PASSWORD` set ediliyor (2022 image'ı ilkini bekler),
+healthcheck `MSSQL_SA_PASSWORD` kullanıyor. Bağlantı dizesi artık compose içinde kuruluyor —
+parola `.env.prod`'da tek yerde duruyor. `.env.prod.example` yeni değişkenlerle tamamlandı.
+
+**Kalan iş:** Prod stack hiç ayağa kaldırılmadığı için bu yapılandırma **çalışır hâlde
+görülmedi**. İlk deploy'da doğrulanmalı. Bkz. madde 2 ve [devops-backlog.md](devops-backlog.md) 2.1.
+
+---
+
+### 6 — `dev` Branch'inin Test'in Gerisine Düşme Riski
+
+{% hint style="success" %}
+**Durum:** ✅ Yapısal olarak engellendi (2026-08-03)
+{% endhint %}
+
+`US-REP-04` (#482) dev'i atlayarak doğrudan test'e merge edildi. Bu, dev'in test'in gerisinde kalmasına neden oldu. PR #493 ile giderildi.
+
+**Uygulanan çözüm:** `ci.yml`'deki **`Terfi Zinciri Kontrolü`** job'u bunu artık CI seviyesinde engelliyor: `test`'e yalnızca `dev`'den, `main`'e yalnızca `test` veya `hotfix/*` üzerinden PR açılabilir. Ayrıca ruleset terfi PR'larında squash'ı kapatıyor — squash, kaynakta bulunmayan yeni bir commit üreterek aynı ayrışmayı yaratırdı.
+
+**Süreç kuralı:** İş branch'leri yalnızca `dev`'e PR açar. `dev → test` ve `test → main` ayrı terfi PR'larıdır. Test ortamında bulunan bug `test`'te değil, `dev`'den açılan `fix/*` ile düzeltilir.
+
+**Kalan risk:** `hotfix/* → main` sonrası `main → test → dev` geri-merge'ünün unutulması. Bu adım otomatikleştirilmedi — bkz. [branching.md](../conventions/branching.md) "Hotfix".
+
+---
+
+### Kısa Kayıtlar
 
 | Tarih | Sorun | Çözüm |
 |-------|-------|-------|

--- a/docs/devops/secret-management.md
+++ b/docs/devops/secret-management.md
@@ -1,6 +1,6 @@
 # Secret Yönetimi
 
-**Son güncelleme:** 2026-04-25 · **Durum:** Aktif · **Görev:** US-D23-S
+**Son güncelleme:** 2026-08-13 · **Durum:** Aktif · **Görev:** US-D23-S
 
 Bu doküman repoya girmemesi gereken secret'ları, ortam dosyalarının konumunu, GHCR/CI-CD secret'larını ve bir secret ihlali durumunda izlenecek adımları açıklar.
 
@@ -101,18 +101,72 @@ ASP.NET Core ortam değişkenlerini `appsettings.json` üstüne otomatik uygular
 
 GitHub → Settings → Secrets and variables → Actions
 
-| Secret | Kullanım |
-|--------|---------|
-| `TEST_SSH_HOST` | Sunucu IP |
-| `TEST_SSH_PRIVATE_KEY` | SSH deploy key |
-| `JWT_SECRET` | JWT imzalama anahtarı |
-| `TEST_GHCR_PAT` | GHCR image pull (classic PAT, `read:packages`) |
-| `TEST_GHCR_USER` | PAT sahibi GitHub kullanıcı adı |
-| `VITE_API_BASE_URL` | Frontend build-time API URL |
-| `VITE_OAUTH_GOOGLE_URL` | Frontend build-time Google OAuth URL |
+### Sunucu erişimi
+
+| Secret | Nerede kullanılıyor | Ne işe yarar |
+|--------|---------------------|--------------|
+| `TEST_SSH_HOST` | `test-deploy.yml` (deploy + health check), `rollback.yml` | Test sunucusunun IP'si |
+| `TEST_SSH_PRIVATE_KEY` | `test-deploy.yml`, `rollback.yml` | Test sunucusuna SSH deploy key'i |
+| `PROD_SSH_HOST` | `rollback.yml` | Prod sunucusu IP'si — **henüz tanımlı değil**, prod stack kurulmadı |
+| `PROD_SSH_PRIVATE_KEY` | `rollback.yml` | Prod SSH deploy key'i — **henüz tanımlı değil** |
+
+### Geçici stack (runner içi doğrulama)
+
+Bu değerler `test-deploy.yml`'in `deploy` job'unda runner üzerinde ayağa kaldırılan geçici
+stack'e verilir. Hepsinin workflow'da CI fallback'i vardır; secret tanımlı değilse doğrulama
+yine de koşar.
+
+| Secret | Nerede kullanılıyor | Ne işe yarar |
+|--------|---------------------|--------------|
+| `TEST_MSSQL_SA_PASSWORD` | `test-deploy.yml` → `MSSQL_SA_PASSWORD` | Geçici MSSQL container'ının `sa` parolası |
+| `TEST_MINIO_ROOT_USER` | `test-deploy.yml` → `MINIO_ROOT_USER` | Geçici MinIO root kullanıcısı |
+| `TEST_MINIO_ROOT_PASSWORD` | `test-deploy.yml` → `MINIO_ROOT_PASSWORD` | Geçici MinIO root parolası |
+| `SEED_DEFAULT_ADMIN_PASSWORD` | `test-deploy.yml` → `Seed__DefaultAdminPassword` | Seed edilen varsayılan admin kullanıcısının parolası |
+| `JWT_SECRET` | `test-deploy.yml` | JWT imzalama anahtarı (en az 32 karakter) |
+| `RESEND_API_KEY` | `test-deploy.yml` | Resend e-posta API anahtarı |
+| `RESEND_FROM_EMAIL` | `test-deploy.yml` | Gönderici e-posta adresi |
+| `RESEND_FROM_NAME` | `test-deploy.yml` | Gönderici adı |
+| `PASSWORD_RESET_FRONTEND_URL` | `test-deploy.yml` | Şifre sıfırlama linkinin frontend adresi |
+| `EMAIL_CHANGE_FRONTEND_CONFIRM_URL` | `test-deploy.yml` | E-posta değişikliği onay linkinin frontend adresi |
 
 {% hint style="info" %}
-`TEST_GHCR_PAT` classic PAT olmalıdır. Fine-grained token GHCR ile çalışmaz.
+Sunucudaki gerçek çalışma değerleri bu secret'lardan değil,
+`/opt/cargo-pilot/infra/env/.env.test` dosyasından gelir. CI secret'ları yalnızca geçici
+doğrulama stack'ini besler.
+{% endhint %}
+
+### Frontend build-time (VITE)
+
+| Secret | Nerede kullanılıyor | Ne işe yarar |
+|--------|---------------------|--------------|
+| `VITE_API_BASE_URL` | `test-deploy.yml` (`build` + `deploy` job'larının frontend build-arg'ı) | Frontend'in çağıracağı API kök adresi |
+| `VITE_OAUTH_GOOGLE_URL` | `test-deploy.yml` frontend build-arg | Google OAuth başlatma URL'si |
+| `VITE_OAUTH_MICROSOFT_URL` | `test-deploy.yml` frontend build-arg | Microsoft OAuth başlatma URL'si |
+
+{% hint style="warning" %}
+`VITE_*` değerleri **secret sınıfı değildir.** Vite bunları build sırasında bundle'a gömer;
+değerler hem tarayıcıya inen JS'te hem de public GHCR imajının içinde görünür. Bunları repo
+**variable**'ına taşımak önerilir — secret olarak tutmak yanlış bir gizlilik beklentisi yaratır.
+{% endhint %}
+
+### Otomasyon
+
+| Secret | Nerede kullanılıyor | Ne işe yarar |
+|--------|---------------------|--------------|
+| `PROMOTION_PAT` | `promote.yml` (Terfi workflow'u) | Terfi PR'ını merge eder. `GITHUB_TOKEN` ile yapılan merge hedef daldaki push-tetiklemeli workflow'ları (deploy, sürüm etiketi) tetiklemediği için ayrı bir PAT zorunludur |
+| `GITHUB_TOKEN` | `test-deploy.yml`, `ci.yml`, `promote.yml`, `release-tag.yml`, `cache-cleanup.yml`, `sync-base-images.yml` | GitHub tarafından otomatik sağlanır; GHCR login ve API çağrıları için kullanılır. Manuel tanımlanmaz |
+
+### Kaldırılan secret'lar
+
+| Secret | Durum |
+|--------|-------|
+| `TEST_GHCR_PAT` | ❌ Kaldırıldı. Package'lar public yapıldığında PAT login `test-deploy.yml`'den çıkarıldı (#483, 2026-05-10); workflow artık GHCR'a `secrets.GITHUB_TOKEN` ile giriyor. Secret 2026-08-13'te repodan silindi |
+| `TEST_GHCR_USER` | ❌ Kaldırıldı — aynı gerekçe, 2026-08-13'te repodan silindi |
+
+{% hint style="info" %}
+**GitHub Environment'ları (2026-08-13):** Repoda `test` ve `prod` environment'ları oluşturuldu;
+`prod` required-reviewer onayı ile korunuyor. SSH secret'larının repo seviyesinden ilgili
+environment seviyesine taşınması önerilir — **henüz yapılmadı**, secret'lar hâlâ repo seviyesinde.
 {% endhint %}
 
 ---

--- a/docs/devops/server-access.md
+++ b/docs/devops/server-access.md
@@ -1,6 +1,6 @@
 # Sunucu Erişim & Ağ Yapılandırması
 
-**Son güncelleme:** 2026-05-17 · **Durum:** Aktif
+**Son güncelleme:** 2026-08-13 · **Durum:** Aktif
 
 Bu doküman sunucuya SSH erişimini, güvenlik duvarı/fail2ban yapılandırmasını, nginx reverse proxy kurallarını ve monitoring stack başlatma adımlarını açıklar.
 
@@ -237,5 +237,16 @@ GitHub repository → Settings → Secrets:
 
 | Secret | Değer |
 |--------|-------|
-| `SSH_HOST` | `104.247.163.42` |
-| `SSH_PRIVATE_KEY` | github-actions key'inin private kısmı |
+| `TEST_SSH_HOST` | `104.247.163.42` |
+| `TEST_SSH_PRIVATE_KEY` | github-actions key'inin private kısmı |
+
+Bu adlar `test-deploy.yml` ve `rollback.yml` içinde birebir bu şekilde kullanılır. Secret'ların
+tam listesi için bkz. [Secret Yönetimi](secret-management.md).
+
+{% hint style="info" %}
+**2026-08-13 denetimi:** Repoda `test` ve `prod` GitHub Environment'ları oluşturuldu; `prod`
+required-reviewer koruması altındadır. SSH secret'larının repo seviyesinden environment
+seviyesine taşınması önerilir — böylece `prod` erişimi onay kapısının arkasına alınır. **Bu
+taşıma henüz yapılmadı;** secret değerleri okunamadığı için environment'a yeniden girilmesi
+gerekiyor.
+{% endhint %}


### PR DESCRIPTION
## Özet

DevOps denetiminin "etki orta / efor düşük" hücresindeki doküman ve güvenlik kalemleri. Denetimde 12 dosyada bayatlık/çelişki tespit edilmişti; bu PR bunların tamamını kapatıyor.

**Yeni: `.github/SECURITY.md`** — Public repoda güvenlik açığı bildirim kanalı yoktu. Kanal olarak **GitHub private vulnerability reporting** seçildi (repo ayarından etkinleştirildi); e-posta adresi bilinçli olarak yayınlanmadı. İçerik: desteklenen sürümler, `/security/advisories/new` doğrudan linki, 72 saat yanıt taahhüdü, kapsam (test ortamına DoS/yük testi yapılmaması notuyla), etkin otomatik taramalar.

**`CLAUDE.md` (kök)** — Dosyanın tüm markdown'ı ters bölü ile escape'lenmişti (`\#`, `\##`, `\-`); 248 satırın 107'si `\` ile başlıyordu, ham `#` ile başlayan satır **0** idi — yani projenin ana talimat dosyası hiçbir yerde render edilemiyordu. 111 escape temizlendi, fazla boş satırlar normalize edildi (248 → 135 satır). **İçerik birebir korundu**: escape'siz kelime sayısı önce/sonra 1037 = 1037, satır bazlı diff identical.

**Bağlam dokümanları** — `project-snapshot.md`: test ortamı kaynağı `main push` → `test push` (dosya kendi içinde çelişiyordu), "backend test projesi yok" iddiası düzeltildi (Engine.Tests + Infrastructure.Tests mevcut ve CI koşturuyor), ruleset onay bilgisi `1 onay` → `zorunlu review yok` (2026-08-08 kararı), workflow listesine `promote.yml` ve `codeql.yml` eklendi. `kod-taramasi-2026-08.md`: tarihli tarama raporu olduğu için bulgu silinmedi, "2026-08-13 itibarıyla geçerli değil" notu düşüldü. `doc-map.md`: dosya/satır sayıları yeniden ölçüldü (37 / ~8.650 → **41 / 10.125**), `branching.md` 274 → 298, eksik dokümanlar indekse eklendi. `SUMMARY.md`: koordinat dokümanları, denetim raporu ve SECURITY.md eklendi. `CONTRIBUTING.md`: backend kalite kapısı `dotnet build` → `dotnet build` + `dotnet test`.

**DevOps dokümanları** — `deployment.md`: bayat CI/CD tablosu kaldırıldı, çift bakımı bitirmek için `branching.md`'nin Branch—Ortam tablosuna devredildi + deploy'un yalnızca `test` push'unda olduğu uyarısı. `secret-management.md`: secret tablosu 7 satırdan kategorili tam envantere çıkarıldı (sunucu erişimi / geçici stack / VITE / otomasyon / kaldırılanlar); `VITE_*` değerlerinin secret sınıfı olmadığı uyarısı eklendi. `server-access.md`: secret adları `SSH_HOST` → `TEST_SSH_HOST` düzeltildi + environment notu. `known-issues.md`: "Açık Sorunlar" altında duran 3 çözülmüş madde "Çözülenler"e taşındı; **madde numaraları bilinçli korundu** (4 doküman bunlara numarayla atıf yapıyor). `developer-setup.md`: `global.json` konumu, monorepo yolları ve "CI'da 8.0.419 pinli" iddiası düzeltildi (CI `8.0.x` kullanıyor).

**`devops-audit-raporu.md`** repoya eklendi — indeksler (doc-map, SUMMARY) bu dosyaya atıf yaptığı için takipli olması gerekiyor.

## İlgili User Story / Issue

DevOps denetim raporu — öncelik matrisi, etki orta / efor düşük hücresi.

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)
- [x] 📝 Doküman / güvenlik politikası (chore)

## Test Edildi mi?

- [x] Manuel test yapıldı — CLAUDE.md içerik korunumu kelime sayısı + diff ile doğrulandı; `secret-management.md`'de listelenen 19 secret adının tamamı `grep secrets\.` çıktısıyla birebir eşleştirildi (uydurma yok); doc-map satır sayıları `wc -l` ile yeniden ölçüldü; her iddia kaynak `dosya:satır` ile doğrulandı.

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/commits.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

- Repo ayarlarında (bu PR'dan bağımsız): private vulnerability reporting açıldı; ölü `TEST_GHCR_PAT` ve `TEST_GHCR_USER` secret'ları silindi (8 → 6).
- **LICENSE bilinçli olarak eklenmedi** — repo taahhüdü netleşene kadar ertelendi.
- `server-access.md`'deki sunucu IP'si / port tablosu / geliştirici isimleri kapsam dışı bırakıldı: dosyadan silmek git geçmişinden kaldırmadığı için ayrı bir karar konusu.
- Koordinat terminolojisi çelişkisi (`depth` vs `length`) bu PR'a alınmadı — `COORDINATE_AUDIT.md` kod değişikliğiyle birlikte ele alınmasını şart koşuyor.
