### PR TITLE
Dependabot ignore kurallarına framework major'ları eklendi

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,18 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-router*"
         update-types: ["version-update:semver-major"]
+      # Framework major'ları planlı geçiş işidir; CLAUDE.md React 18'i sabitliyor.
+      # Tekil PR olarak gelirse her hafta yeniden açılır — planlandığında bu kural kaldırılır.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   # ── NuGet / backend ─────────────────────────────────────────
   - package-ecosystem: "nuget"
@@ -47,6 +59,14 @@ updates:
       nuget-minor-patch:
         applies-to: version-updates
         update-types: ["minor", "patch"]
+    ignore:
+      # Tüm projeler net8.0 hedefliyor. Microsoft.* paketlerinin major sürümü
+      # .NET sürümüyle hizalıdır; 9.x/10.x paketleri net8.0 ile eşleşmez.
+      # .NET yükseltmesi yapıldığında bu kural kaldırılır.
+      - dependency-name: "Microsoft.*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "System.*"
+        update-types: ["version-update:semver-major"]
 
   # ── Docker ──────────────────────────────────────────────────
   - package-ecosystem: "docker"
@@ -57,6 +77,11 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     labels: ["dependencies", "docker"]
+    ignore:
+      # Node major'ı tek başına yükseltilemez: ci.yml'deki node-version ile
+      # birlikte gitmeli, yoksa CI ve imaj farklı sürümde kalır.
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"
     directory: "/apps/backend"


### PR DESCRIPTION
## Özet

Dependabot'un ilk taraması 12 PR açtı ve config'in bir eksiğini ortaya çıkardı: framework seviyesindeki major'lar filtrelenmiyordu. Bunlar merge edilemeyecek ama her hafta yeniden açılacak PR'lar üretir. Üç ignore kuralı eklendi:

**NuGet — `Microsoft.*` ve `System.*` major'ları.** Altı projenin tamamı `net8.0` hedefliyor (`grep TargetFramework` ile doğrulandı). Microsoft paketlerinin major sürümü .NET sürümüyle hizalıdır; Dependabot `Microsoft.AspNetCore.DataProtection` için `8.0.25 → 10.0.11`, `Microsoft.Bcl.Memory` için `9.0.14 → 10.0.11` önerdi — ikisi de net8.0 hedefiyle eşleşmiyor. .NET yükseltmesi yapıldığında kural kaldırılacak.

**npm — `react`, `react-dom`, `@types/react*`, `typescript` major'ları.** Mevcut: React 18.3.1, TypeScript 5.9.3. `CLAUDE.md` stack'i "React 18" olarak sabitliyor; Dependabot React 19 ve TypeScript 7 önerdi. İkisi de planlı geçiş işi, haftalık bağımlılık turunun konusu değil.

**Docker — `node` major.** Dependabot `node:20-slim → node:26-slim` önerdi, ama `ci.yml` `node-version: '20'` kullanıyor. Tek başına merge edilirse CI ile imaj farklı major'da kalırdı; ikisi birlikte yükseltilmeli.

Kurallar kalıcı yasak değil — her birinin yanına kaldırma koşulu yorum olarak yazıldı.

## İlgili User Story / Issue

DevOps denetim raporu — Dependabot kurulumu (PR #942) sonrası ilk tarama bulgusu.

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)
- [x] 🔧 Altyapı / CI-CD (infra)

## Test Edildi mi?

- [x] Manuel test yapıldı — `yaml.safe_load` geçiyor, 5 ekosistem girdisi korunuyor; hedef sürümler `TargetFramework`, `ci.yml:77` ve `package.json` okunarak doğrulandı.

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/commits.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

`github-actions` ekosistemine bilinçli olarak major ignore'u eklenmedi: action major'ları genelde runner runtime değişimidir ve CI onları fiilen kullanarak doğrular (PR #950'de 10 major update ile CI tam yeşil).
