### PR TITLE
CORS geri dönüş yolu güvenlik maddesi backloga eklendi

### DIFF
--- a/docs/devops/devops-backlog.md
+++ b/docs/devops/devops-backlog.md
@@ -23,6 +23,7 @@ Bu doküman DevOps ekibinin açık ve tamamlanmış iyileştirme maddelerini ön
 | 11 | Node.js 20 → 22 geçişi | 🟢 Düşük | ⚠️ Açık |
 | 12 | xlsx → exceljs geçişi (Dependabot izlenebilirliği) | 🟡 Orta | ⚠️ Açık |
 | 13 | three.js r162 → r185 yükseltmesi (3D QA'li) | 🟡 Orta | ⚠️ Açık |
+| 14 | CORS `AllowAnyOrigin()` geri dönüş yolu — fail-fast'e çevrilmeli | 🟠 Güvenlik | ⚠️ Açık |
 
 ---
 
@@ -258,6 +259,43 @@ Bu, **derleyicinin yakalayabildiği tek sorun**; r163→r185 aralığı TypeScri
 **Önerilen yöntem:** tek seferde r185'e atlamak yerine ara sürümlerde (r170, r178) durup sahneyi
 görsel olarak doğrulamak; her adımda bir plan yükleyip 3D görüntüleyicide kontrol etmek.
 3D/canvas değişiklikleri için `CLAUDE.md` snapshot benzeri doğrulama veya manuel QA şart koşuyor.
+
+---
+
+### 5.2 CORS `AllowAnyOrigin()` Geri Dönüş Yolu
+
+{% hint style="danger" %}
+**⚠️ Açık — Güvenlik** · Tespit: 2026-08-13 (SonarAnalyzer 10.32 yükseltmesi, PR #955)
+{% endhint %}
+
+`apps/backend/CargoPilot.WebAPI/DependencyInjection.cs` içinde CORS yapılandırması şu şekilde:
+
+```csharp
+if (corsOrigins.Length > 0)
+    builder.WithOrigins(corsOrigins!).AllowCredentials();
+else
+    builder.AllowAnyOrigin();   // S5122 — pragma ile susturuldu
+```
+
+`CORS_ALLOWED_ORIGIN_*` değişkenleri tanımlı değilse API **tüm origin'lere açılır**. Analyzer
+yükseltmesi bunu S5122 olarak yakaladı; bağımlılık PR'ında çalışma zamanı davranışı
+değiştirilmemesi için `#pragma warning disable` ile susturuldu ve buraya taşındı.
+
+**Risk:** Kuralın güvenliği bir *varsayıma* dayanıyor — "dağıtım ortamlarında origin listesi her
+zaman verilir". Bu bir garanti değil; prod stack kurulurken (madde 1-2) env dosyası eksik
+hazırlanırsa API sessizce herkese açık başlar ve hiçbir uyarı üretmez.
+
+**Önerilen çözüm:** Geri dönüş yolunu ortama duyarlı hale getir — `Development` dışında origin
+listesi boşsa uygulama **başlatmayı reddetsin** (fail-fast), yalnızca development'ta
+`AllowAnyOrigin()` kalsın. Böylece pragma da kaldırılabilir.
+
+**Aynı PR'da susturulan, incelenmiş ve kabul edilmiş diğer kurallar** (bunlar için aksiyon
+gerekmiyor, kayıt amaçlı):
+
+- `AuthController` S2092 ×3 — `Secure = !_env.IsDevelopment()`; kod zaten doğru, analyzer
+  ifadeyi statik olarak çözemiyor. Sabit `true` yazmak lokal HTTP geliştirmeyi kırardı.
+- `MinioHealthCheck` S5332 — küme içi ağda MinIO sağlık ucuna düz HTTP; istek konteyner
+  ağından dışarı çıkmıyor.
 
 ---
 


### PR DESCRIPTION
## Özet

PR #955 (nuget grup güncellemesi) SonarAnalyzer'ı 10.22 → 10.32'ye çıkardı ve yeni kurallar üç güvenlik uyarısını hata olarak yükseltti. Bağımlılık PR'ında çalışma zamanı davranışı değiştirilmemesi için üçü de gerekçeli `#pragma` ile susturuldu. Bunlardan **biri gerçek bir risk taşıyor** ve takip edilmesi için backlog'a madde 14 olarak eklendi (kategori 5.2'de detay).

**S5122 — CORS `AllowAnyOrigin()` geri dönüş yolu.** `CORS_ALLOWED_ORIGIN_*` tanımlı değilse API tüm origin'lere açılıyor. Susturmanın gerekçesi "dağıtım ortamlarında origin listesi her zaman verilir" varsayımı; bu bir garanti değil. Prod stack kurulurken (backlog madde 1-2) env dosyası eksik hazırlanırsa API sessizce herkese açık başlar ve hiçbir uyarı üretmez. Önerilen çözüm: `Development` dışında origin listesi boşsa fail-fast — böylece pragma da kaldırılabilir.

Diğer iki susturma incelendi ve **aksiyon gerektirmiyor**, kayıt amaçlı yazıldı: `AuthController` S2092 (`Secure = !_env.IsDevelopment()` zaten doğru, analyzer ifadeyi statik çözemiyor) ve `MinioHealthCheck` S5332 (küme içi HTTP, istek konteyner ağından çıkmıyor).

## İlgili User Story / Issue

DevOps denetim raporu — Dependabot ilk turu; PR #955.

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)
- [x] 📝 Doküman (chore)

## Test Edildi mi?

- [x] Manuel test yapıldı — doküman değişikliği; kod alıntısı ve pragma konumları `DependencyInjection.cs` üzerinden doğrulandı.

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/commits.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

Susturulan bir kuralın kayda geçmemesi, denetimin bulduğu "sessiz kabul" desenini yeniden üretirdi — madde 14 bunu önlüyor.
