### PR TITLE
Tailwind, framer-motion ve node tipleri için major ignore eklendi

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,17 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      # Tailwind v4 yapılandırma modelini tümden değiştiriyor (CSS-first config,
+      # PostCSS eklentisi ayrıldı); CLAUDE.md stack'i Tailwind v3 olarak sabitliyor.
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
+      # framer-motion major'ları animasyon API'sini değiştiriyor; 3D ve panel
+      # geçişleri manuel QA istiyor.
+      - dependency-name: "framer-motion"
+        update-types: ["version-update:semver-major"]
+      # @types/node major'ı Node major'ını takip eder; CI ve Dockerfile Node 20'de.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # ── NuGet / backend ─────────────────────────────────────────
   - package-ecosystem: "nuget"


### PR DESCRIPTION
## Özet

Dependabot ikinci turda üç major daha önerdi; hepsi planlı geçiş işi olduğu için ignore listesine eklendi:

- **`tailwindcss` 3.4.19 → 4.3.3** — v4 yapılandırma modelini tümden değiştiriyor (CSS-first config, PostCSS eklentisinin ayrılması, `@tailwind` direktiflerinin kalkması). `CLAUDE.md` stack'i "Tailwind CSS v3" olarak sabitliyor.
- **`framer-motion` 12.38.0 → 13.0.0** — animasyon API'si değişiyor; panel geçişleri ve 3D sahne etkileşimleri manuel QA istiyor.
- **`@types/node` 25.6.0 → 26.2.0** — `@types/node` major'ı Node major'ını takip eder; CI (`ci.yml`) ve `Dockerfile` Node 20 kullanıyor. Node yükseltmesi backlog madde 11'de, tipler onunla birlikte gitmeli.

## Önemli bağlam — kuralların ne zaman etkili olacağı

Bu turda ortaya çıkan kök neden: **Dependabot yapılandırmasını varsayılan daldan (`main`) okur.** `target-branch: dev` yalnızca PR'ların *nereye açılacağını* belirler; kuralların kendisi `main`'den gelir.

`main`'de şu an yalnızca ilk config (#942) var — 4 ignore kuralı. #963 (framework major'ları), #964 (three semver-minor) ve bu PR henüz terfi edilmediği için Dependabot bunları görmüyor. `react-dom` 19'un ignore kuralına rağmen iki kez gelmesinin (#968, #971) sebebi buydu.

Bu yüzden bu PR merge edildikten sonra **terfi zinciri koşturulmalı** (`dev → test → main`); kurallar ancak `main`'e ulaştığında yürürlüğe girer.

## İlgili User Story / Issue

DevOps denetim raporu — Dependabot ikinci turu; PR #963, #964 devamı.

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)
- [x] 🔧 Altyapı / CI-CD (infra)

## Test Edildi mi?

- [x] Manuel test yapıldı — `yaml.safe_load` geçiyor, 5 ekosistem girdisi korunuyor. `main`'deki config'in eski hali GitHub API ile doğrulandı (yalnız 4 ignore kuralı içeriyor).

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/commits.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

Terfi sonrası açık kalan bayat Dependabot PR'ları (#966, #969, #970, #971, #972, #973) kapatılmalı: hepsi eski base'e göre hesaplandı ve bir kısmı paketleri geriye alıyor (#966 FluentValidation'ı 12.1.1 → 11.12.0). Dependabot bir sonraki haftalık turda güncel base ve güncel kurallarla temiz PR'lar açacak.
