### PR TITLE
Serilog ve Swashbuckle için major ignore eklendi

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,6 +82,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "System.*"
         update-types: ["version-update:semver-major"]
+      # Serilog.AspNetCore ve Swashbuckle sürümleri ASP.NET Core sürümüne hizalıdır
+      # (Serilog.AspNetCore 10.x -> .NET 10, Swashbuckle 10.x -> .NET 10).
+      - dependency-name: "Serilog.AspNetCore"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Swashbuckle.*"
+        update-types: ["version-update:semver-major"]
 
   # ── Docker ──────────────────────────────────────────────────
   - package-ecosystem: "docker"


### PR DESCRIPTION
## Özet

Dependabot ikinci turunda `net8.0` hedefiyle uyumsuz iki paket ailesi daha ortaya çıktı; ikisi de ignore listesine eklendi.

**`Serilog.AspNetCore` 8.0.3 → 10.0.0.** Bu paketin sürümlemesi ASP.NET Core sürümüne hizalıdır (8.x → .NET 8, 10.x → .NET 10). CI'da build yeşil görünüyordu, ancak yeşil build hedef framework uyumluluğunun garantisi değil — altı projenin tamamı `net8.0` hedefliyor.

**`Swashbuckle.AspNetCore` 7.3.2 → 10.2.3 (+ `Microsoft.OpenApi` 1.6.29 → 2.7.5).** Bu ikisi CI'ı fiilen kırdı:

```
error CS0234: 'Models' does not exist in the namespace 'Microsoft.OpenApi'
error CS0535: 'AuthorizeOperationFilter' does not implement 'IOperationFilter.Apply(OpenApiOperation, OperationFilterContext)'
```

`Microsoft.OpenApi` 2.x namespace düzenini değiştirdi ve `IOperationFilter.Apply` imzası farklılaştı. Yükseltme, `CargoPilot.WebAPI/Swagger/AuthorizeOperationFilter.cs` ve `DependencyInjection.cs`'in yeniden yazılmasını gerektiriyor — planlı bir iş, haftalık bağımlılık turunun konusu değil.

Not: `Microsoft.OpenApi` zaten `Microsoft.*` major ignore kuralı kapsamındaydı ancak PR'lar yine açıldı; sebebi çok-paketli PR'lar olması — `Swashbuckle.AspNetCore` o zaman listede olmadığı için PR açıldı ve `Microsoft.OpenApi` yanında sürüklendi. `Swashbuckle.*` kuralı bu kapıyı da kapatıyor.

## İlgili User Story / Issue

DevOps denetim raporu — Dependabot ikinci turu; PR #978, #979, #980 kapatıldı.

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)
- [x] 🔧 Altyapı / CI-CD (infra)

## Test Edildi mi?

- [x] Manuel test yapıldı — `yaml.safe_load` geçiyor, 5 ekosistem girdisi korunuyor. Swashbuckle/OpenApi uyumsuzluğu PR #979'un gerçek CI hatasıyla kanıtlandı; `TargetFramework` değerleri `net8.0` olarak doğrulandı.

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/commits.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

Kurallar `main`'e terfi edilene kadar yürürlüğe girmez — Dependabot yapılandırmayı varsayılan daldan okur.
