### PR TITLE
Terfi: test → main (Dependabot ikinci turu + ASP.NET hizalı ignore kuralları)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,6 +82,12 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "System.*"
         update-types: ["version-update:semver-major"]
+      # Serilog.AspNetCore ve Swashbuckle sürümleri ASP.NET Core sürümüne hizalıdır
+      # (Serilog.AspNetCore 10.x -> .NET 10, Swashbuckle 10.x -> .NET 10).
+      - dependency-name: "Serilog.AspNetCore"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Swashbuckle.*"
+        update-types: ["version-update:semver-major"]
 
   # ── Docker ──────────────────────────────────────────────────
   - package-ecosystem: "docker"

--- a/apps/backend/CargoPilot.Engine.Tests/CargoPilot.Engine.Tests.csproj
+++ b/apps/backend/CargoPilot.Engine.Tests/CargoPilot.Engine.Tests.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/CargoPilot.Infrastructure.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -42,7 +42,7 @@
         "clsx": "^2.1.1",
         "cobe": "^2.0.1",
         "date-fns": "^4.4.0",
-        "framer-motion": "^12.38.0",
+        "framer-motion": "^12.43.0",
         "gsap": "^3.15.0",
         "i18next": "^26.3.6",
         "lucide-react": "^1.31.0",
@@ -63,7 +63,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^25.6.0",
+        "@types/node": "^25.9.5",
         "@types/react": "^18.3.28",
         "@types/react-dom": "^18.3.7",
         "@types/three": "^0.162.0",
@@ -2824,13 +2824,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/offscreencanvas": {
@@ -4960,13 +4960,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
-      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
+      "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.38.0",
-        "motion-utils": "^12.36.0",
+        "motion-dom": "^12.43.0",
+        "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -6036,18 +6036,18 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
-      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "version": "12.43.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
+      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^12.36.0"
+        "motion-utils": "^12.39.0"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.36.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
-      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -7523,9 +7523,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -29,7 +29,7 @@
   "license": "ISC",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "^25.6.0",
+    "@types/node": "^25.9.5",
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",
     "@types/three": "^0.162.0",
@@ -85,7 +85,7 @@
     "clsx": "^2.1.1",
     "cobe": "^2.0.1",
     "date-fns": "^4.4.0",
-    "framer-motion": "^12.38.0",
+    "framer-motion": "^12.43.0",
     "gsap": "^3.15.0",
     "i18next": "^26.3.6",
     "lucide-react": "^1.31.0",


### PR DESCRIPTION
## Özet

Dependabot ikinci turu ve yapılandırma tamamlamaları. Test ortamına deploy edildi, health check geçti.

- **#977** framer-motion 12.43 + @types/node 25.9 (minor'lar) — ignore kurallarının doğru çalıştığının kanıtı.
- **#981** xunit.runner.visualstudio 2.8.2 → 3.1.5; test sayısı CI log'undan doğrulandı (20 + 33 = 53).
- **#982** `Serilog.AspNetCore` ve `Swashbuckle.*` için major ignore — sürümlemeleri ASP.NET Core'a hizalı, projeler `net8.0` hedefliyor.

Kapatılanlar: #978 (Serilog 10.x), #979/#980 (Swashbuckle 10.x + Microsoft.OpenApi 2.x — CI'ı fiilen kırdı).

## Değişiklik Tipi

- [x] 🔧 Terfi (test → main)

## Test Edildi mi?

- [x] Manuel test yapıldı — test ortamına deploy edildi ve health check geçti; backend 53, frontend 166 test.

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları [commit kurallarına](docs/conventions/commits.md) uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

Bu terfi ile `Serilog.*` ve `Swashbuckle.*` ignore kuralları da yürürlüğe girecek — Dependabot yapılandırmayı varsayılan daldan okur.