### PR TITLE
e2e sahte ERP satır kodları seed ile eşleştirildi

### DIFF
--- a/apps/frontend/e2e/erp-canli-senaryolar.spec.ts
+++ b/apps/frontend/e2e/erp-canli-senaryolar.spec.ts
@@ -75,12 +75,13 @@ test.describe('ERP canlı senaryoları', () => {
 
     await page
       .getByPlaceholder('Ürün adı, SKU, ERP ID veya barkod ile ara...')
-      .fill(FAKE_ERP_ROWS.box.sku);
-    // Bağlantı her senaryoda yeniden kurulduğu için aynı ERP kodu birden fazla
-    // taslak kaydına karşılık gelebilir; ilk satır üzerinden ilerlenir.
-    await expect(page.getByRole('cell', { name: FAKE_ERP_ROWS.box.sku }).first()).toBeVisible();
+      .fill(FAKE_ERP_ROWS.transferred.sku);
+    // Stok kodu hem SKU hem ERP ID sütununda görünür; ilk hücre üzerinden ilerlenir.
+    await expect(
+      page.getByRole('cell', { name: FAKE_ERP_ROWS.transferred.sku }).first(),
+    ).toBeVisible();
 
-    await page.getByLabel(`${FAKE_ERP_ROWS.box.name} satırını seç`).first().check();
+    await page.getByLabel(`${FAKE_ERP_ROWS.transferred.name} satırını seç`).first().check();
     await page.getByRole('button', { name: 'Ürünlere Aktar' }).click();
 
     const dialog = page.getByRole('dialog');

--- a/apps/frontend/e2e/erp-sync-smoke.spec.ts
+++ b/apps/frontend/e2e/erp-sync-smoke.spec.ts
@@ -34,10 +34,11 @@ test.describe('ERP çekim zinciri (smoke)', () => {
 
     await page
       .getByPlaceholder('Ürün adı, SKU, ERP ID veya barkod ile ara...')
-      .fill(FAKE_ERP_ROWS.box.sku);
+      .fill(FAKE_ERP_ROWS.pending.sku);
 
-    // Bağlantı her senaryoda yeniden kurulduğu için aynı ERP kodu birden fazla
-    // taslak kaydına karşılık gelebilir; varlık kontrolü ilk satır üzerinden yapılır.
-    await expect(page.getByRole('cell', { name: FAKE_ERP_ROWS.box.sku }).first()).toBeVisible();
+    // Stok kodu hem SKU hem ERP ID sütununda görünür; ilk hücre üzerinden bakılır.
+    await expect(
+      page.getByRole('cell', { name: FAKE_ERP_ROWS.pending.sku }).first(),
+    ).toBeVisible();
   });
 });

--- a/apps/frontend/e2e/helpers/testConfig.ts
+++ b/apps/frontend/e2e/helpers/testConfig.ts
@@ -24,14 +24,22 @@ export const FAKE_ERP = {
 /** Hiçbir zaman çözülmeyen adres; "ERP ayakta değil" senaryosu için. */
 export const UNREACHABLE_ERP_SERVER = 'erp-yok.invalid,1433';
 
-/** Sahte ERP'de kayıtlı örnek satırlar (infra/docker/erp-mssql/init/01-netsis-seed.sql). */
+/**
+ * Sahte ERP'de kayıtlı örnek satırlar (infra/docker/erp-mssql/init/01-netsis-seed.sql).
+ * Seed gerçek Netsis stok kodlarını taklit eder; buradaki değerler oradaki satırlarla
+ * birebir aynı olmalıdır. Kullanılmayan satır burada tutulmaz: seed değiştiğinde
+ * sessizce bayatlayıp CI'da "satır bulunamadı" olarak patlıyordu.
+ *
+ * ERP kaynaklı taslakların tipi GRUP_KODU'ndan türetilmez; hepsi sabit "Koli" (Box)
+ * ile açılır ve kullanıcı aktarım ızgarasında değiştirir.
+ */
 export const FAKE_ERP_ROWS = {
-  /** GRUP_KODU = 'Box' → ItemCategory.Box(2) → arayüzde "Koli". */
-  box: { sku: 'E2E-BOX-001', name: 'E2E Koli - LED TV' },
-  /** GRUP_KODU = 'Drum' → ItemCategory.Drum(3) → arayüzde "Varil". */
-  drum: { sku: 'E2E-DRUM-001', name: 'E2E Varil - Kimyasal' },
-  /** EN/BOY/GENISLIK/BIRIM_AGIRLIK = 0 → "Eksik alan" rozeti. */
-  missing: { sku: 'E2E-MISSING-001', name: 'E2E Olcusu Eksik Parca' },
-  /** SATISKILIT = 'E' → hiç çekilmez. */
-  salesLocked: { sku: 'E2E-LOCKED-001', name: 'E2E Satisa Kapali Urun' },
+  /** Aktarım senaryosu bunu Ürünler'e taşır; taslak "Aktarılanlar" durumuna geçer. */
+  transferred: { sku: '600.02.0004', name: 'Buzdolabı No-Frost 480 L' },
+  /**
+   * Smoke senaryosu ayrı bir satır kullanır. Bağlantı kaldırılıp yeniden kurulduğunda
+   * aynı entegrasyon canlandığı için senkronizasyon mevcut taslağı "değişmedi" sayıp
+   * atlar; aktarılan satır bir daha "Bekleyenler" sekmesine dönmez.
+   */
+  pending: { sku: '153.01.0001' },
 } as const;


### PR DESCRIPTION
## Sorun

`dev → test` terfisinde e2e smoke iki senaryoda takıldı:

```
Locator: getByRole('cell', { name: 'E2E-BOX-001' })
Error: element(s) not found
```

## Kök neden

İki ayrı kayma var.

**1. Sabitler seed'den kopmuş.** `e2e/helpers/testConfig.ts` hâlâ `E2E-BOX-001`, `E2E-DRUM-001` gibi kodlara işaret ediyordu. Seed (`infra/docker/erp-mssql/init/01-netsis-seed.sql`) gerçek Netsis stok kodlarına (`153.*`, `320.*`, `600.*`) geçirildiğinde bu sabitler güncellenmedi. Sahte ERP'de o satırlar yok:

```
SELECT COUNT(*) FROM TBLSTSABIT WHERE STOK_KODU LIKE 'E2E%'  -->  0
```

Derleyici yakalayamadı: `tsconfig.json` `include: ["src"]` diyor, `e2e/` kapsam dışında. Yerelde de gözükmedi çünkü veritabanı kalıcı ve eski senkronizasyonlardan kalma `E2E-*` taslaklar duruyordu; CI `down -v` ile sıfırdan başlıyor.

**2. Smoke, aktarım senaryosunun taşıdığı satırı arıyordu.** Bağlantı kaldırılıp yeniden kurulduğunda artık aynı entegrasyon canlanıyor (kopya taslak düzeltmesi). Senkronizasyon mevcut taslağı "değişmedi" sayıp atlıyor, dolayısıyla `Ürünlere Aktar` ile Aktarılanlar'a geçen satır bir daha Bekleyenler'e dönmüyor. Önce her bağlanışta yeni entegrasyon açıldığı için taslaklar sıfırdan üretiliyor ve bu bağımlılık görünmüyordu.

## Değişiklik

- `transferred` → `600.02.0004` (aktarım senaryosu)
- `pending` → `153.01.0001` (smoke; başka senaryo taşımıyor)
- Kullanılmayan satır sabitleri kaldırıldı — sessizce bayatlayıp aynı hatayı üreten kaynak onlardı.

## Doğrulama

Sahte ERP'de her iki satırın varlığı ve `SATISKILIT` değerinin boş olduğu (yani çekildikleri) doğrulandı. e2e dosyaları tek seferlik `tsc` ile denetlendi.

Suite'i yerelde uçtan uca koşmadım: koşmak yerel ERP bağlantısını sahte kaynağa çevirip test taslakları üretiyor, geliştirme ortamını kirletiyordu. CI'daki e2e-smoke işi asıl doğrulama.

## Not

`e2e/` TypeScript denetimi dışında. Bu PR'a dahil etmedim — acil düzeltmeyi yapılandırma değişikliğiyle karıştırmak istemedim — ama ayrı bir iş olarak değer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)