### PR TITLE
Port maruziyeti kapatıldı ve deploy sağlık doğrulamasını bekliyor

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -496,17 +496,10 @@ jobs:
             echo "==> Kullanılmayan eski image'lar temizleniyor..."
             docker image prune -f
 
-      - name: Test backend health check
-        run: |
-          echo "Test backend'in ayağa kalkması bekleniyor..."
-          sleep 20
-          for i in $(seq 1 10); do
-            if curl -sf http://${{ secrets.TEST_SSH_HOST }}:8081/health; then
-              echo "Test backend hazır."
-              exit 0
-            fi
-            echo "Deneme $i/10..."
-            sleep 10
-          done
-          echo "::error::Test backend health check başarısız oldu."
-          exit 1
+            echo "==> Backend health (loopback) bekleniyor..."
+            for i in $(seq 1 20); do
+              curl -sf http://127.0.0.1:8081/health >/dev/null && break
+              if [ "$i" = "20" ]; then echo "Backend loopback health basarisiz"; exit 1; fi
+              sleep 5
+            done
+            echo "Backend loopback health OK."

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -439,11 +439,12 @@ jobs:
     name: Deploy (Test Server)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [migration-check, build]
+    needs: [migration-check, build, deploy]
     if: |
       always() &&
       (needs.migration-check.result == 'success') &&
       (needs.build.result == 'success') &&
+      (needs.deploy.result == 'success') &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/test'
 

--- a/infra/compose/docker-compose.monitoring.prod.yml
+++ b/infra/compose/docker-compose.monitoring.prod.yml
@@ -63,7 +63,7 @@ services:
       - ../docker/prometheus/prometheus.prod.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data_prod:/prometheus
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     restart: unless-stopped
     networks:
       - cargo-pilot-prod
@@ -84,7 +84,7 @@ services:
       - ../docker/grafana/dashboards:/var/lib/grafana/dashboards:ro
       - grafana_data_prod:/var/lib/grafana
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     depends_on:
       - prometheus
       - loki

--- a/infra/compose/docker-compose.monitoring.test.yml
+++ b/infra/compose/docker-compose.monitoring.test.yml
@@ -63,7 +63,7 @@ services:
       - ../docker/prometheus/prometheus.test.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data_test:/prometheus
     ports:
-      - "9091:9090"
+      - "127.0.0.1:9091:9090"
     restart: unless-stopped
     networks:
       - cargo-pilot-test

--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -44,7 +44,7 @@ services:
       EmailChange__FrontendConfirmUrl: ${EMAIL_CHANGE_FRONTEND_CONFIRM_URL:-}
       EmailChange__TokenExpiryMinutes: ${EMAIL_CHANGE_TOKEN_EXPIRY_MINUTES:-60}
     ports:
-      - "${BACKEND_PORT}:8080"
+      - "127.0.0.1:${BACKEND_PORT}:8080"
     depends_on:
       mssql:
         condition: service_healthy
@@ -77,7 +77,7 @@ services:
     environment:
       NODE_ENV: production
     ports:
-      - "${FRONTEND_PORT}:80"
+      - "127.0.0.1:${FRONTEND_PORT}:80"
     depends_on:
       backend:
         condition: service_healthy
@@ -97,7 +97,7 @@ services:
       MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
       SA_PASSWORD: ${MSSQL_SA_PASSWORD}
     ports:
-      - "${MSSQL_PORT}:1433"
+      - "127.0.0.1:${MSSQL_PORT}:1433"
     volumes:
       - mssql_data_prod:/var/opt/mssql
     healthcheck:
@@ -119,8 +119,8 @@ services:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
     ports:
-      - "${MINIO_API_PORT}:9000"
-      - "${MINIO_CONSOLE_PORT}:9001"
+      - "127.0.0.1:${MINIO_API_PORT}:9000"
+      - "127.0.0.1:${MINIO_CONSOLE_PORT}:9001"
     volumes:
       - minio_data_prod:/data
     healthcheck:

--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -41,7 +41,7 @@ services:
       EmailChange__FrontendConfirmUrl: ${EMAIL_CHANGE_FRONTEND_CONFIRM_URL:-}
       EmailChange__TokenExpiryMinutes: ${EMAIL_CHANGE_TOKEN_EXPIRY_MINUTES:-60}
     ports:
-      - "${BACKEND_PORT}:8080"
+      - "127.0.0.1:${BACKEND_PORT}:8080"
     depends_on:
       mssql:
         condition: service_healthy
@@ -76,7 +76,7 @@ services:
     environment:
       NODE_ENV: production
     ports:
-      - "${FRONTEND_PORT}:80"
+      - "127.0.0.1:${FRONTEND_PORT}:80"
     depends_on:
       - backend
     restart: unless-stopped
@@ -94,7 +94,7 @@ services:
       MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
       SA_PASSWORD: ${MSSQL_SA_PASSWORD}
     ports:
-      - "${MSSQL_PORT}:1433"
+      - "127.0.0.1:${MSSQL_PORT}:1433"
     volumes:
       - mssql_data_test:/var/opt/mssql
     healthcheck:
@@ -172,8 +172,8 @@ services:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
     ports:
-      - "${MINIO_API_PORT}:9000"
-      - "${MINIO_CONSOLE_PORT}:9001"
+      - "127.0.0.1:${MINIO_API_PORT}:9000"
+      - "127.0.0.1:${MINIO_CONSOLE_PORT}:9001"
     volumes:
       - minio_data_test:/data
     healthcheck:


### PR DESCRIPTION
## Güvenlik sertleştirme — port maruziyeti ve deploy sırası

Test sunucusunda (104.247.163.42) canlı probla doğrulandı: 1434, 9002, 9003, 3001, 8081, 9091, 3002 ve 80
portları dışarıya **açık**. Bu PR, compose port bağlamalarını loopback'e çekerek maruziyeti kapatıyor
ve deploy'un sağlık doğrulamasını beklemesini sağlıyor.

### Yapılan

| # | Değişiklik | Dosya |
|---|---|---|
| 1 | Backend health kontrolü sunucu içinden loopback ile yapılıyor | `test-deploy.yml` |
| 2 | 13/14 compose port satırı `127.0.0.1:` ön ekine çekildi | 4 compose dosyası |
| 3 | `deploy-test-server` artık sağlık doğrulama job'unu bekliyor | `test-deploy.yml:442,447` |

**Commit sırası kritik:** health check'in loopback'e taşınması, port kapatmadan **önceki** commit.
Tersi olsaydı dış IP'den koşan health check port kapanır kapanmaz kırılırdı.

**CI-03 kapanıyor:** run 31703511441'de gerçek sunucu, sağlık doğrulama job'undan **100 saniye önce**
güncellenmişti. Artık `needs:` zinciri bunu engelliyor.

### Kapsam dışı bırakılanlar — gerekçeli

- `docker-compose.monitoring.test.yml:89` (Grafana 3002) — ikame erişim yolu olmadan kapatılırsa
  panolara erişim tamamen kesilir. 14 satırdan dokunulmayan tek satır bu.
- `docker-compose.test.yml:127` (`erp-mssql`) — profile-gated, sunucuda hiç çalışmıyor.
- **4 fallback parolanın temizliği ertelendi:** gereken 4 GitHub secret henüz tanımlı değil,
  şimdi uygulanırsa CI kırılır. Secret'lar tanımlandıktan sonra ayrı PR olarak gelecek.

### Doğrulama

5 YAML `yaml.safe_load` ile geçerli · `needs:` DAG'ı döngüsüz · `grep -c '127.0.0.1:'` → 13
