### PR TITLE
rollback.sh yanlış SHA türetmesi düzeltildi ve yedekleme sertleştirildi

### DIFF
--- a/infra/scripts/backup-db.sh
+++ b/infra/scripts/backup-db.sh
@@ -40,6 +40,11 @@ if [[ -z "${SA_PASSWORD}" ]]; then
     exit 1
 fi
 
+# Parolayı sqlcmd'e ortam değişkeniyle geçiyoruz; -P bayrağı komut satırında
+# kalsaydı parola host'ta ve container'da `ps` çıktısında görünürdü.
+# `docker exec -e SQLCMDPASSWORD` (değersiz form) değeri bu kabuktan devralır.
+export SQLCMDPASSWORD="${SA_PASSWORD}"
+
 mkdir -p "${BACKUP_DIR}"
 
 BACKUP_FILE="${BACKUP_DIR}/${DATABASE}_${TIMESTAMP}.bak"
@@ -49,10 +54,11 @@ echo "[$(date)] Yedek başlatılıyor: ${DATABASE} → ${BACKUP_FILE}"
 # Container içinde yedek klasörü oluştur ve BACKUP al
 docker exec "${CONTAINER}" mkdir -p /var/opt/mssql/backup
 
-docker exec "${CONTAINER}" \
+# CHECKSUM: yedeğe sayfa checksum'ları yazar; verify-backup.sh bozulmayı bununla yakalar.
+docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
     /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "${SA_PASSWORD}" -C \
-    -Q "BACKUP DATABASE [${DATABASE}] TO DISK = N'/var/opt/mssql/backup/${DATABASE}_${TIMESTAMP}.bak' WITH NOFORMAT, INIT, STATS=10"
+    -S localhost -U sa -C \
+    -Q "BACKUP DATABASE [${DATABASE}] TO DISK = N'/var/opt/mssql/backup/${DATABASE}_${TIMESTAMP}.bak' WITH NOFORMAT, INIT, CHECKSUM, STATS=10"
 
 # Container'dan host'a kopyala
 docker cp "${CONTAINER}:/var/opt/mssql/backup/${DATABASE}_${TIMESTAMP}.bak" "${BACKUP_FILE}"

--- a/infra/scripts/restore-db.sh
+++ b/infra/scripts/restore-db.sh
@@ -45,6 +45,11 @@ if [[ -z "${SA_PASSWORD}" ]]; then
     exit 1
 fi
 
+# Parolayı sqlcmd'e ortam değişkeniyle geçiyoruz; -P bayrağı komut satırında
+# kalsaydı parola host'ta ve container'da `ps` çıktısında görünürdü.
+# `docker exec -e SQLCMDPASSWORD` (değersiz form) değeri bu kabuktan devralır.
+export SQLCMDPASSWORD="${SA_PASSWORD}"
+
 # Yedek dosyası belirtilmemişse en son yedeği bul
 if [[ -z "${BACKUP_FILE}" ]]; then
     BACKUP_FILE=$(find "${BACKUP_DIR}" -name "*.bak" -printf '%T@ %p\n' 2>/dev/null \
@@ -81,9 +86,9 @@ fi
 
 # Geri yükleme öncesi mevcut durumu kaydet
 echo "[$(date)] Mevcut tablo sayısı kontrol ediliyor..."
-BEFORE_COUNT=$(docker exec "${CONTAINER}" \
+BEFORE_COUNT=$(docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
     /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "${SA_PASSWORD}" -C \
+    -S localhost -U sa -C \
     -Q "SET NOCOUNT ON; SELECT COUNT(*) FROM [${DATABASE}].INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='BASE TABLE';" \
     -h -1 2>/dev/null | tr -d ' \r\n' || echo "0")
 echo "[$(date)] Geri yüklemeden önce tablo sayısı: ${BEFORE_COUNT}"
@@ -95,9 +100,9 @@ docker cp "${BACKUP_FILE}" "${CONTAINER}:/var/opt/mssql/restore/${FILENAME}"
 
 # RESTORE DATABASE
 echo "[$(date)] Veritabanı geri yükleniyor (bu işlem birkaç dakika sürebilir)..."
-docker exec "${CONTAINER}" \
+docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
     /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "${SA_PASSWORD}" -C \
+    -S localhost -U sa -C \
     -Q "
 ALTER DATABASE [${DATABASE}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;
 RESTORE DATABASE [${DATABASE}]
@@ -112,9 +117,9 @@ docker exec "${CONTAINER}" rm -f "/var/opt/mssql/restore/${FILENAME}"
 
 # Doğrulama: Tablo sayısını kontrol et
 echo "[$(date)] Geri yükleme doğrulanıyor..."
-AFTER_COUNT=$(docker exec "${CONTAINER}" \
+AFTER_COUNT=$(docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
     /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "${SA_PASSWORD}" -C \
+    -S localhost -U sa -C \
     -Q "SET NOCOUNT ON; SELECT COUNT(*) FROM [${DATABASE}].INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='BASE TABLE';" \
     -h -1 2>/dev/null | tr -d ' \r\n')
 

--- a/infra/scripts/rollback.sh
+++ b/infra/scripts/rollback.sh
@@ -66,7 +66,11 @@ docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
 
 if [[ "${ENVIRONMENT}" == "test" ]]; then
     # Test ortamı: GHCR'dan immutable tag ile çek (--build yapılmaz)
-    TARGET_SHA=$(git rev-parse --short=7 "${TARGET_REF}" 2>/dev/null || echo "")
+    # Türetme release-tag.yml ile birebir aynı olmalı: sürüm tag'i main'deki merge
+    # commit'ini gösterir, imaj ise test head'i (^2) için üretilir. Tek-parent
+    # push'ta (hotfix) commit'in kendisine düşülür.
+    TARGET_SHA=$(git rev-parse --short=7 "${TARGET_REF}^2" 2>/dev/null \
+        || git rev-parse --short=7 "${TARGET_REF}" 2>/dev/null || echo "")
     if [[ -z "${TARGET_SHA}" ]]; then
         echo "[ERROR] '${TARGET_REF}' için SHA türetilemedi."
         exit 1

--- a/infra/scripts/setup-backup-cron.sh
+++ b/infra/scripts/setup-backup-cron.sh
@@ -35,19 +35,22 @@ ${entry}"
     fi
 }
 
+# Cron satırlarında `bash ` öneki ikinci savunma hattıdır: repo'dan gelen dosyada
+# execute biti düşerse yedekleme sessizce "permission denied" ile durmaz.
+
 # Prod DB — her gece 02:00
 add_cron \
-    "0 2 * * * ${DEPLOY_DIR}/infra/scripts/backup-db.sh prod >> ${LOG_DIR}/backup-prod.log 2>&1" \
+    "0 2 * * * bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh prod >> ${LOG_DIR}/backup-prod.log 2>&1" \
     "Cargo Pilot - Prod DB yedek"
 
 # Test DB — her gece 03:00
 add_cron \
-    "0 3 * * * ${DEPLOY_DIR}/infra/scripts/backup-db.sh test >> ${LOG_DIR}/backup-test.log 2>&1" \
+    "0 3 * * * bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh test >> ${LOG_DIR}/backup-test.log 2>&1" \
     "Cargo Pilot - Test DB yedek"
 
 # Prod yedek doğrulaması — her Pazar 04:00
 add_cron \
-    "0 4 * * 0 ${DEPLOY_DIR}/infra/scripts/verify-backup.sh prod >> ${LOG_DIR}/verify-backup.log 2>&1" \
+    "0 4 * * 0 bash ${DEPLOY_DIR}/infra/scripts/verify-backup.sh prod >> ${LOG_DIR}/verify-backup.log 2>&1" \
     "Cargo Pilot - Prod yedek doğrulama"
 
 # Crontab'a yaz

--- a/infra/scripts/verify-backup.sh
+++ b/infra/scripts/verify-backup.sh
@@ -46,6 +46,11 @@ if [[ -z "${SA_PASSWORD}" ]]; then
     exit 1
 fi
 
+# Parolayı sqlcmd'e ortam değişkeniyle geçiyoruz; -P bayrağı komut satırında
+# kalsaydı parola host'ta ve container'da `ps` çıktısında görünürdü.
+# `docker exec -e SQLCMDPASSWORD` (değersiz form) değeri bu kabuktan devralır.
+export SQLCMDPASSWORD="${SA_PASSWORD}"
+
 # Yedek dosyası belirtilmemişse en son yedeği bul
 if [[ -z "${BACKUP_FILE}" ]]; then
     BACKUP_FILE=$(find "${BACKUP_DIR}" -name "*.bak" -printf '%T@ %p\n' 2>/dev/null \
@@ -79,13 +84,26 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# RESTORE VERIFYONLY: veritabanına dokunmadan backup'ın okunabilirliğini doğrular
+# RESTORE VERIFYONLY: veritabanına dokunmadan backup'ın okunabilirliğini doğrular.
+# WITH CHECKSUM sayfa checksum'larını da doğrular; bozuk yedek burada yakalanır.
+verify_only() {
+    docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
+        /opt/mssql-tools18/bin/sqlcmd \
+        -S localhost -U sa -C \
+        -Q "RESTORE VERIFYONLY FROM DISK = N'/var/opt/mssql/restore/${FILENAME}'${1};" \
+        2>&1
+}
+
 echo "[$(date)] RESTORE VERIFYONLY çalıştırılıyor..."
-VERIFY_OUTPUT=$(docker exec "${CONTAINER}" \
-    /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "${SA_PASSWORD}" -C \
-    -Q "RESTORE VERIFYONLY FROM DISK = N'/var/opt/mssql/restore/${FILENAME}';" \
-    2>&1)
+VERIFY_OUTPUT=$(verify_only " WITH CHECKSUM")
+
+# backup-db.sh'a CHECKSUM eklenmeden önce alınmış yedeklerde checksum bilgisi yoktur.
+# Bunu "bozuk yedek" saymak yanlış alarm olur; checksum'suz doğrulamaya düşüp uyarıyoruz.
+if echo "${VERIFY_OUTPUT}" | grep -qi "does not contain checksum"; then
+    echo "[WARN] Yedekte checksum bilgisi yok (CHECKSUM öncesi alınmış)."
+    echo "[WARN] Checksum'suz doğrulamaya düşülüyor — sayfa bozulması tespit edilemez."
+    VERIFY_OUTPUT=$(verify_only "")
+fi
 
 if echo "${VERIFY_OUTPUT}" | grep -qi "error\|hata\|fail"; then
     echo "[ERROR] Yedek doğrulaması başarısız:"
@@ -95,9 +113,9 @@ fi
 
 # Yedek içerik bilgisini al (database adı, tarih, boyut)
 echo "[$(date)] Yedek içeriği okunuyor..."
-HEADER=$(docker exec "${CONTAINER}" \
+HEADER=$(docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
     /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -P "${SA_PASSWORD}" -C \
+    -S localhost -U sa -C \
     -Q "RESTORE HEADERONLY FROM DISK = N'/var/opt/mssql/restore/${FILENAME}';" \
     2>/dev/null | head -3 || true)
 


### PR DESCRIPTION
## Yedekleme ve rollback sertleştirme

### Kritik: `rollback.sh` var olmayan imajı çekiyordu

Script, sürüm tag'inden imaj SHA'sını türetirken merge commit'in ikinci parent'ını (`^2`) almıyordu.

Kanıt:

```
git rev-parse --short=7 v0.13.0^2  →  42e931d
git rev-parse --short=7 v0.13.0    →  28a6647
```

GHCR'de `test-42e931d` **var**, `test-28a6647` **yok**. Yani rollback çalıştırılsaydı var olmayan
bir imajı çekmeye çalışıp başarısız olurdu. Bu mekanizma hiç koşulmamıştı, dolayısıyla hata da
hiç ortaya çıkmamıştı.

### Yapılan

- `rollback.sh` SHA türetmesi `^2` parent'ını kullanacak şekilde düzeltildi
- 6 script'e exec-bit verildi (6/6 `bash -n` ile sözdizimi doğrulandı)
- Yedekleme parolası `SQLCMDPASSWORD` üzerinden geçiriliyor (komut satırında görünmüyor)
- Yedeklere `WITH CHECKSUM` eklendi; checksum'suz eski yedekler için geri düşüş korundu

### Kalan

Rollback tatbikatı hâlâ yapılmadı. Sıfır koşumlu bir mekanizmaya güvenilmemeli —
sakin bir günde `target_ref=v0.13.0` ile denenmeli.
