### PR TITLE
claude code yerel çalışma alanı gitignore'a eklendi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,8 +118,10 @@ minio-data/
 *.ldf
 *.bak
 
-# Claude Code local settings (içinde hassas token olabilir)
-.claude/settings.local.json
+# Claude Code yerel çalışma alanı: ayarlar (hassas token içerebilir),
+# ajan worktree'leri ve oturum artıkları. Paylaşılması gereken bir yapılandırma
+# eklenirse `!.claude/<dosya>` ile tek tek istisna tanımlanabilir.
+.claude/
 
 # Serena (yerel LSP/MCP aracı yapılandırması ve önbelleği)
 .serena/


### PR DESCRIPTION
## `.claude/` dizini yok sayılıyor

`.gitignore` yalnız `.claude/settings.local.json`'ı dışlıyordu. Ancak dizinde başka yerel artıklar da
birikiyor — özellikle **ajan worktree'leri** (`.claude/worktrees/agent-*`), her biri deponun tam bir
kopyası.

Somut etki: bu dizin izlendiği sürece `grep -rn` gibi depo geneli aramalar worktree kopyalarını da
tarayıp yanıltıcı sonuç veriyor. Bu turda gerçekten yaşandı — bir doküman taraması
`.claude/worktrees/agent-.../CLAUDE.md` dosyasını "repoda hâlâ duran bayat not" diye raporladı.

```diff
-# Claude Code local settings (içinde hassas token olabilir)
-.claude/settings.local.json
+# Claude Code yerel çalışma alanı: ayarlar (hassas token içerebilir),
+# ajan worktree'leri ve oturum artıkları. Paylaşılması gereken bir yapılandırma
+# eklenirse `!.claude/<dosya>` ile tek tek istisna tanımlanabilir.
+.claude/
```

Şu an dizinden hiçbir dosya izlenmiyordu, dolayısıyla `git rm --cached` gerekmedi.
İleride paylaşılması gereken bir Claude yapılandırması olursa negatif kuralla istisna tanımlanabilir.
