### PR TITLE
e2e job'undaki 7 action SHA'ya pinlendi (38/45 → 45/45)

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -311,20 +311,20 @@ jobs:
 
     steps:
       - name: Kodu al
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Docker Buildx kur
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: GHCR'a giriş yap
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Backend image build (e2e için)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: ./apps/backend
           file: ./apps/backend/Dockerfile
@@ -337,7 +337,7 @@ jobs:
           cache-from: type=gha,scope=backend-test
 
       - name: Frontend image build (e2e için)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: ./apps/frontend
           file: ./apps/frontend/Dockerfile
@@ -351,7 +351,7 @@ jobs:
           cache-from: type=gha,scope=frontend-test
 
       - name: Node.js kur
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -394,7 +394,7 @@ jobs:
 
       - name: Playwright raporunu yükle
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: apps/frontend/playwright-report


### PR DESCRIPTION
## E2E job'undaki 7 action SHA'ya pinlendi

Denetim raporu **"32/32 action SHA-pinli"** diyordu. Doküman tazelemesi sırasında yeniden sayıldığında gerçek oran **38/45** çıktı: `test-deploy.yml`'in e2e job'undaki 7 `uses:` satırı mutable tag'deydi.

O job denetimden **sonra** eklendiği için ilk pinleme turunun (#942) kapsamına hiç girmemiş.

### Pinlenen satırlar

| Satır | Action | SHA | Sürüm |
|---|---|---|---|
| 314 | `actions/checkout` | `11d5960a…` | v4.4.0 |
| 317 | `docker/setup-buildx-action` | `8d2750c6…` | v3.12.0 |
| 320 | `docker/login-action` | `c94ce9fb…` | v3.7.0 |
| 327 | `docker/build-push-action` | `ca052bb5…` | v5.4.0 |
| 340 | `docker/build-push-action` | `ca052bb5…` | v5.4.0 |
| 354 | `actions/setup-node` | `49933ea5…` | v4.4.0 |
| 397 | `actions/upload-artifact` | `ea165f8d…` | v4.6.2 |

### Bilinçli karar: sürüm yükseltilmedi

Deponun geri kalanı bu action'ları daha yeni majörlerde pinliyor (`checkout` v7.0.1, `build-push-action` v7.3.0, `setup-node` v7.0.0, `setup-buildx-action` v4.2.0, `login-action` v4.6.0). E2E job'u ise v3/v4/v5'te.

**Bu PR yalnızca pinler, yükseltmez.** Her satır *bugün o mutable tag'in işaret ettiği* commit'e sabitlendi, yani davranış birebir korunuyor. Üç majör atlayan bir yükseltmeyi (`checkout` v4 → v7 gibi) sessizce bu PR'a sıkıştırmak, pinlemenin kendisini doğrulanamaz hâle getirirdi.

Yükseltme artık kontrollü yapılabilir: satırlar `@sha # vX.Y.Z` biçiminde olduğu için **Dependabot bunları yönetmeye başlayacak** ve sürüm atlamalarını ayrı, gözden geçirilebilir PR'lar hâlinde önerecek. Pinlemenin asıl kazancı da bu.

Doğrulama sırasında bir tutarlılık teyidi çıktı: `actions/upload-artifact@v4` bugün tam olarak deponun başka yerlerinde zaten kullanılan SHA'ya (`ea165f8d…` # v4.6.2) çözülüyor.

### Doğrulama

```
grep 'uses:' test-deploy.yml | grep -v '@<40-hex>'   → 0 satır
yaml.safe_load(test-deploy.yml)                      → geçerli
depo geneli:                                          45 / 45 pinli
```

Tek dosya, 7 satır. Tetikleyici, job adı veya adım sırası değişmedi.
