### PR TITLE
Dalga 1: yedekleme ve rollback script'leri sertleştirildi (D-18, D-21, D-22, D-23, D-25)

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: ''
+      skip_backup:
+        description: 'DB yedeği alınamazsa yine de devam et (VERİ KAYBI RİSKİ)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -60,7 +65,13 @@ jobs:
           script: |
             set -e
             TARGET="${{ github.event.inputs.target_ref }}"
-            /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET}"
+            # rollback.sh yedek alınamazsa varsayılan olarak durur; bayrak yalnız
+            # operatör bunu UI'da bilinçli olarak işaretlediğinde geçilir.
+            if [ "${{ github.event.inputs.skip_backup }}" = "true" ]; then
+              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET}" --skip-backup
+            else
+              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET}"
+            fi
 
       - name: Prod sunucusuna rollback yap
         if: github.event.inputs.environment == 'prod'
@@ -72,7 +83,13 @@ jobs:
           script: |
             set -e
             TARGET="${{ github.event.inputs.target_ref }}"
-            /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET}"
+            # rollback.sh yedek alınamazsa varsayılan olarak durur; bayrak yalnız
+            # operatör bunu UI'da bilinçli olarak işaretlediğinde geçilir.
+            if [ "${{ github.event.inputs.skip_backup }}" = "true" ]; then
+              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET}" --skip-backup
+            else
+              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET}"
+            fi
 
       - name: Rollback özeti
         if: always()
@@ -80,5 +97,6 @@ jobs:
           echo "## Rollback Özeti" >> $GITHUB_STEP_SUMMARY
           echo "- **Ortam**: ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Hedef**: ${{ github.event.inputs.target_ref || '(önceki tag)' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Yedek atlandı**: ${{ github.event.inputs.skip_backup }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Tetikleyen**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Zaman**: $(date -u '+%Y-%m-%d %H:%M UTC')" >> $GITHUB_STEP_SUMMARY

--- a/infra/scripts/backup-db.sh
+++ b/infra/scripts/backup-db.sh
@@ -9,6 +9,11 @@
 
 set -euo pipefail
 
+# Yedek dosyalari tum musteri verisini icerir. Varsayilan umask ile dizin 755,
+# .bak 644 olur; host'taki her kullanici okuyabilir. 077 ile bu script'in
+# urettigi her sey sahibine ozel (dizin 700, dosya 600) yaratilir.
+umask 077
+
 ENVIRONMENT="${1:-prod}"
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 BACKUP_DIR="/opt/cargo-pilot/backups/mssql/${ENVIRONMENT}"
@@ -50,6 +55,9 @@ fi
 export SQLCMDPASSWORD="${SA_PASSWORD}"
 
 mkdir -p "${BACKUP_DIR}"
+# umask yalnizca yeni yaratilanlari kapsar; onceki kosumlardan kalan gevsek
+# izinli dizinleri de her calismada duzeltiyoruz.
+chmod 700 "${BACKUP_DIR}"
 
 BACKUP_FILE="${BACKUP_DIR}/${DATABASE}_${TIMESTAMP}.bak"
 
@@ -66,6 +74,8 @@ docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
 
 # Container'dan host'a kopyala
 docker cp "${CONTAINER}:/var/opt/mssql/backup/${DATABASE}_${TIMESTAMP}.bak" "${BACKUP_FILE}"
+# `docker cp` dosya iznini kaynaktan tasiyabilir; umask'e guvenmeyip acikca daraltiyoruz.
+chmod 600 "${BACKUP_FILE}"
 
 # Container içindeki geçici yedeği temizle
 docker exec "${CONTAINER}" rm -f "/var/opt/mssql/backup/${DATABASE}_${TIMESTAMP}.bak"

--- a/infra/scripts/backup-db.sh
+++ b/infra/scripts/backup-db.sh
@@ -4,6 +4,10 @@
 # Kullanım:
 #   ./backup-db.sh [ortam]        ortam: prod (varsayılan) | test
 #
+# Ortam başına birden fazla veritabanı yedeklenir (aşağıdaki DATABASES dizisi).
+# Liste `BACKUP_DATABASES` ile ezilebilir (boşlukla ayrılmış):
+#   BACKUP_DATABASES="CargoPilotTest MUSTERI_ERP" ./backup-db.sh test
+#
 # Cron örneği (her gece 02:00):
 #   0 2 * * * /opt/cargo-pilot/infra/scripts/backup-db.sh prod >> /var/log/cargo-pilot/backup.log 2>&1
 
@@ -19,18 +23,32 @@ TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 BACKUP_DIR="/opt/cargo-pilot/backups/mssql/${ENVIRONMENT}"
 RETENTION_DAYS=7
 
-# Ortama göre değişkenler
+# Ortama göre değişkenler.
+# DATABASES dizisinin İLK elemanı birincil (uygulama) veritabanıdır: yoksa hata,
+# yedeklenemezse çıkış kodu 1. Sonraki elemanlar ek veritabanlarıdır; sunucuda
+# yoklarsa uyarıyla atlanır — varlıkları ortama göre değişebilir, yokluğu
+# uygulama yedeğini bloke etmemeli.
 if [[ "${ENVIRONMENT}" == "prod" ]]; then
     CONTAINER="cargo-pilot-mssql-prod"
     ENV_FILE="/opt/cargo-pilot/infra/env/.env.prod"
-    DATABASE="CargoPilot"
+    DATABASES=("CargoPilot")
 elif [[ "${ENVIRONMENT}" == "test" ]]; then
     CONTAINER="cargo-pilot-mssql-test"
     ENV_FILE="/opt/cargo-pilot/infra/env/.env.test"
-    DATABASE="CargoPilotTest"
+    # DIVIZYON: müşteri ERP veritabanı, 2026-05-16'da aynı container'a elle
+    # restore edildi (docs/devops/server-access.md "ERP Veritabanı (DIVIZYON)").
+    # Kaynağı bir .bak dosyası; yedeklenmezse geri getirilemez.
+    DATABASES=("CargoPilotTest" "DIVIZYON")
 else
     echo "[ERROR] Geçersiz ortam: ${ENVIRONMENT}. 'prod' veya 'test' kullanın."
     exit 1
+fi
+
+# Müşteri ERP veritabanının adı kuruluma göre değişir; listeyi dışarıdan ezmek
+# için script'i düzenlemek gerekmesin.
+if [[ -n "${BACKUP_DATABASES:-}" ]]; then
+    read -r -a DATABASES <<< "${BACKUP_DATABASES}"
+    echo "[$(date)] Veritabanı listesi BACKUP_DATABASES ile ezildi: ${DATABASES[*]}"
 fi
 
 # Env dosyasından SA şifresini oku
@@ -59,33 +77,109 @@ mkdir -p "${BACKUP_DIR}"
 # izinli dizinleri de her calismada duzeltiyoruz.
 chmod 700 "${BACKUP_DIR}"
 
-BACKUP_FILE="${BACKUP_DIR}/${DATABASE}_${TIMESTAMP}.bak"
+# Veritabanı container'da var mı?
+#   0 = var · 1 = yok · 2 = sorgulanamadı (container kapalı, parola yanlış vb.)
+# "yok" ile "sorgulayamadım" ayrımı önemli: ikincisi sessizce atlanacak bir durum
+# değil, hatadır.
+db_exists() {
+    local database="$1" answer
+    answer=$(docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
+        /opt/mssql-tools18/bin/sqlcmd \
+        -S localhost -U sa -C -h -1 \
+        -Q "SET NOCOUNT ON; SELECT CASE WHEN DB_ID('${database}') IS NULL THEN 0 ELSE 1 END;" \
+        2>/dev/null | tr -d ' \r\n' || true)
+    case "${answer}" in
+        1) return 0 ;;
+        0) return 1 ;;
+        *) return 2 ;;
+    esac
+}
 
-echo "[$(date)] Yedek başlatılıyor: ${DATABASE} → ${BACKUP_FILE}"
+# Tek bir veritabanının yedeğini alır. `set -e` fonksiyon koşul bağlamında
+# çağrıldığında askıya alındığı için her kritik adım açıkça `|| return 1` ile
+# korunur; aksi halde başarısız BACKUP'tan sonra kopyalamaya devam edilirdi.
+backup_one() {
+    local database="$1"
+    local remote_file="/var/opt/mssql/backup/${database}_${TIMESTAMP}.bak"
+    local backup_file="${BACKUP_DIR}/${database}_${TIMESTAMP}.bak"
+    local backup_size
 
-# Container içinde yedek klasörü oluştur ve BACKUP al
+    echo "[$(date)] Yedek başlatılıyor: ${database} → ${backup_file}"
+
+    # CHECKSUM: yedeğe sayfa checksum'ları yazar; verify-backup.sh bozulmayı bununla yakalar.
+    docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
+        /opt/mssql-tools18/bin/sqlcmd \
+        -S localhost -U sa -C \
+        -Q "BACKUP DATABASE [${database}] TO DISK = N'${remote_file}' WITH NOFORMAT, INIT, CHECKSUM, STATS=10" \
+        || { echo "[ERROR] BACKUP DATABASE başarısız: ${database}"; return 1; }
+
+    # Container'dan host'a kopyala
+    if ! docker cp "${CONTAINER}:${remote_file}" "${backup_file}"; then
+        echo "[ERROR] Yedek host'a kopyalanamadı: ${database}"
+        docker exec "${CONTAINER}" rm -f "${remote_file}" >/dev/null 2>&1 || true
+        return 1
+    fi
+    # `docker cp` dosya iznini kaynaktan taşıyabilir; umask'e güvenmeyip açıkça daraltıyoruz.
+    chmod 600 "${backup_file}"
+
+    # Container içindeki geçici yedeği temizle
+    docker exec "${CONTAINER}" rm -f "${remote_file}" || true
+
+    backup_size=$(du -sh "${backup_file}" | cut -f1)
+    echo "[$(date)] Yedek tamamlandı: ${backup_file} (${backup_size})"
+}
+
+# Container içinde yedek klasörünü hazırla
 docker exec "${CONTAINER}" mkdir -p /var/opt/mssql/backup
 
-# CHECKSUM: yedeğe sayfa checksum'ları yazar; verify-backup.sh bozulmayı bununla yakalar.
-docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
-    /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -C \
-    -Q "BACKUP DATABASE [${DATABASE}] TO DISK = N'/var/opt/mssql/backup/${DATABASE}_${TIMESTAMP}.bak' WITH NOFORMAT, INIT, CHECKSUM, STATS=10"
+SUCCEEDED=()
+SKIPPED=()
+FAILED=()
 
-# Container'dan host'a kopyala
-docker cp "${CONTAINER}:/var/opt/mssql/backup/${DATABASE}_${TIMESTAMP}.bak" "${BACKUP_FILE}"
-# `docker cp` dosya iznini kaynaktan tasiyabilir; umask'e guvenmeyip acikca daraltiyoruz.
-chmod 600 "${BACKUP_FILE}"
+for index in "${!DATABASES[@]}"; do
+    database="${DATABASES[${index}]}"
 
-# Container içindeki geçici yedeği temizle
-docker exec "${CONTAINER}" rm -f "/var/opt/mssql/backup/${DATABASE}_${TIMESTAMP}.bak"
+    exists_status=0
+    db_exists "${database}" || exists_status=$?
 
-# Dosya boyutunu logla
-BACKUP_SIZE=$(du -sh "${BACKUP_FILE}" | cut -f1)
-echo "[$(date)] Yedek tamamlandı: ${BACKUP_FILE} (${BACKUP_SIZE})"
+    if [[ "${exists_status}" -eq 2 ]]; then
+        echo "[ERROR] ${CONTAINER} sorgulanamadı (${database}). Container ayakta mı, parola doğru mu?"
+        exit 1
+    fi
+
+    if [[ "${exists_status}" -eq 1 ]]; then
+        if [[ "${index}" -eq 0 ]]; then
+            # Birincil veritabanının yokluğu yapılandırma hatasıdır; sessizce geçilemez.
+            echo "[ERROR] Birincil veritabanı ${CONTAINER} içinde bulunamadı: ${database}"
+            exit 1
+        fi
+        echo "[WARN] Veritabanı ${CONTAINER} içinde yok, atlanıyor: ${database}"
+        SKIPPED+=("${database}")
+        continue
+    fi
+
+    if backup_one "${database}"; then
+        SUCCEEDED+=("${database}")
+    else
+        FAILED+=("${database}")
+    fi
+done
+
+echo "[$(date)] Özet — başarılı: ${#SUCCEEDED[@]} · atlanan: ${#SKIPPED[@]} · başarısız: ${#FAILED[@]}"
+if [[ "${#SKIPPED[@]}" -gt 0 ]]; then
+    echo "[$(date)]   Atlanan  : ${SKIPPED[*]}"
+fi
 
 # Eski yedekleri temizle
 echo "[$(date)] ${RETENTION_DAYS} günden eski yedekler temizleniyor..."
 find "${BACKUP_DIR}" -name "*.bak" -mtime +${RETENTION_DAYS} -delete
 REMAINING=$(find "${BACKUP_DIR}" -name "*.bak" | wc -l)
 echo "[$(date)] Kalan yedek sayısı: ${REMAINING}"
+
+# Çıkış kodu en sonda veriliyor ki tek bir veritabanının hatası diğerlerinin
+# yedeğini ve temizliği engellemesin. Kod yine de 1: cron log'u ve rollback.sh
+# bu koda bakıyor, kısmi başarı "başarılı" sayılmamalı.
+if [[ "${#FAILED[@]}" -gt 0 ]]; then
+    echo "[ERROR] Yedeği alınamayan veritabanı(lar): ${FAILED[*]}"
+    exit 1
+fi

--- a/infra/scripts/backup-db.sh
+++ b/infra/scripts/backup-db.sh
@@ -33,7 +33,11 @@ if [[ ! -f "${ENV_FILE}" ]]; then
     echo "[ERROR] Env dosyası bulunamadı: ${ENV_FILE}"
     exit 1
 fi
-SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'")
+# `|| true` şart: `set -euo pipefail` altında grep eşleşme bulamazsa (satır yoksa)
+# pipeline 1 döner ve script tam bu atama satırında, hiçbir mesaj basmadan ölür.
+# Aşağıdaki anlamlı hata bloğuna hiç gelinmez. `|| true` ile boş değer atanır,
+# hatayı `if [[ -z ]]` kontrolü açıkça raporlar.
+SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'" || true)
 
 if [[ -z "${SA_PASSWORD}" ]]; then
     echo "[ERROR] MSSQL_SA_PASSWORD env dosyasında bulunamadı."

--- a/infra/scripts/restore-db.sh
+++ b/infra/scripts/restore-db.sh
@@ -38,7 +38,11 @@ if [[ ! -f "${ENV_FILE}" ]]; then
     echo "[ERROR] Env dosyası bulunamadı: ${ENV_FILE}"
     exit 1
 fi
-SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'")
+# `|| true` şart: `set -euo pipefail` altında grep eşleşme bulamazsa (satır yoksa)
+# pipeline 1 döner ve script tam bu atama satırında, hiçbir mesaj basmadan ölür.
+# Aşağıdaki anlamlı hata bloğuna hiç gelinmez. `|| true` ile boş değer atanır,
+# hatayı `if [[ -z ]]` kontrolü açıkça raporlar.
+SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'" || true)
 
 if [[ -z "${SA_PASSWORD}" ]]; then
     echo "[ERROR] MSSQL_SA_PASSWORD env dosyasında bulunamadı."

--- a/infra/scripts/restore-db.sh
+++ b/infra/scripts/restore-db.sh
@@ -54,15 +54,23 @@ fi
 # `docker exec -e SQLCMDPASSWORD` (değersiz form) değeri bu kabuktan devralır.
 export SQLCMDPASSWORD="${SA_PASSWORD}"
 
-# Yedek dosyası belirtilmemişse en son yedeği bul
+# Yedek dosyası belirtilmemişse en son yedeği bul.
+# Arama hedef veritabanının adıyla sınırlı: backup-db.sh artık aynı dizine birden
+# fazla veritabanının yedeğini yazıyor (ör. test'te DIVIZYON). Filtre olmasaydı
+# "en son yedek" başka bir veritabanının .bak'ı olabilir ve yanlış veri
+# CargoPilot üzerine geri yüklenirdi.
 if [[ -z "${BACKUP_FILE}" ]]; then
-    BACKUP_FILE=$(find "${BACKUP_DIR}" -name "*.bak" -printf '%T@ %p\n' 2>/dev/null \
+    BACKUP_FILE=$(find "${BACKUP_DIR}" -name "${DATABASE}_*.bak" -printf '%T@ %p\n' 2>/dev/null \
         | sort -n | tail -1 | cut -d' ' -f2-)
     if [[ -z "${BACKUP_FILE}" ]]; then
-        echo "[ERROR] ${BACKUP_DIR} dizininde yedek dosyası bulunamadı."
+        echo "[ERROR] ${BACKUP_DIR} dizininde ${DATABASE} yedeği bulunamadı."
         exit 1
     fi
     echo "[$(date)] En son yedek seçildi: ${BACKUP_FILE}"
+elif [[ "$(basename "${BACKUP_FILE}")" != "${DATABASE}_"* ]]; then
+    # Elle verilen dosya başka bir veritabanına ait görünüyor. Bilinçli bir işlem
+    # olabilir (ör. DIVIZYON.bak'ı elle yükleme), o yüzden engellemiyoruz.
+    echo "[WARN] Dosya adı hedef veritabanıyla eşleşmiyor: $(basename "${BACKUP_FILE}") → ${DATABASE}"
 fi
 
 # Yedek dosyası var mı?

--- a/infra/scripts/rollback.sh
+++ b/infra/scripts/rollback.sh
@@ -91,7 +91,16 @@ fi
 echo "[$(date)] Sağlık kontrolü bekleniyor (60s)..."
 sleep 20
 
-BACKEND_PORT=$(grep -E '^BACKEND_PORT=' "${ENV_FILE}" | cut -d= -f2 | tr -d '"')
+# `|| true` şart: `set -euo pipefail` altında grep eşleşme bulamazsa pipeline 1 döner
+# ve script tam burada, stack yeniden başlatıldıktan sonra sessizce ölür — operatör
+# rollback'in nerede kaldığını göremez. Boş değeri aşağıda açıkça raporluyoruz.
+BACKEND_PORT=$(grep -E '^BACKEND_PORT=' "${ENV_FILE}" | cut -d= -f2 | tr -d '"' || true)
+if [[ -z "${BACKEND_PORT}" ]]; then
+    echo "[ERROR] BACKEND_PORT ${ENV_FILE} içinde bulunamadı — sağlık kontrolü yapılamıyor."
+    echo "        Stack ${TARGET_REF} sürümüyle başlatıldı; durumu elle doğrulayın."
+    exit 1
+fi
+
 for i in $(seq 1 8); do
     if curl -sf "http://localhost:${BACKEND_PORT}/health" > /dev/null 2>&1; then
         echo "[$(date)] Rollback başarılı — backend sağlıklı (${TARGET_REF})"

--- a/infra/scripts/rollback.sh
+++ b/infra/scripts/rollback.sh
@@ -2,22 +2,40 @@
 # rollback.sh — Önceki başarılı deploy'a geri döner.
 #
 # Kullanım:
-#   ./rollback.sh [ortam] [git-ref]
+#   ./rollback.sh [ortam] [git-ref] [--skip-backup]
 #
-#   ortam   : prod | test (varsayılan: prod)
-#   git-ref : geri dönülecek tag veya commit SHA
-#             belirtilmezse bir önceki tag'e döner
+#   ortam        : prod | test (varsayılan: prod)
+#   git-ref      : geri dönülecek tag veya commit SHA
+#                  belirtilmezse bir önceki tag'e döner
+#   --skip-backup: rollback öncesi DB yedeği alınamazsa yine de devam et
+#                  (eşdeğeri: SKIP_BACKUP=1 ortam değişkeni)
 #
 # Örnekler:
 #   ./rollback.sh prod                  # prod'da önceki tag'e dön
 #   ./rollback.sh prod v1.2.3           # prod'da belirli tag'e dön
 #   ./rollback.sh test abc1234          # test'te belirli commit'e dön
+#   ./rollback.sh prod v1.2.3 --skip-backup   # yedek alınamıyor, yine de dön
 
 set -euo pipefail
 
-ENVIRONMENT="${1:-prod}"
-TARGET_REF="${2:-}"
 DEPLOY_DIR="/opt/cargo-pilot"
+
+# Bayrak, konumdan bağımsız okunur; mevcut çağrılar (`rollback.sh test "${TARGET}"`,
+# TARGET boş olabilir) aynen çalışmaya devam eder.
+SKIP_BACKUP="${SKIP_BACKUP:-0}"
+POSITIONAL=()
+for arg in "$@"; do
+    case "${arg}" in
+        --skip-backup) SKIP_BACKUP=1 ;;
+        *) POSITIONAL+=("${arg}") ;;
+    esac
+done
+
+ENVIRONMENT="${POSITIONAL[0]:-prod}"
+TARGET_REF="${POSITIONAL[1]:-}"
+
+# Boş pozisyonel argüman (workflow hedef ref'i boş geçebilir) varsayılana düşsün.
+ENVIRONMENT="${ENVIRONMENT:-prod}"
 
 if [[ "${ENVIRONMENT}" == "prod" ]]; then
     COMPOSE_FILE="${DEPLOY_DIR}/infra/compose/docker-compose.prod.yml"
@@ -49,10 +67,41 @@ fi
 echo "[$(date)] Rollback başlatılıyor: ${ENVIRONMENT} → ${TARGET_REF}"
 
 # Yedek al (rollback öncesi güvenlik)
-echo "[$(date)] Rollback öncesi DB yedeği alınıyor..."
-"${DEPLOY_DIR}/infra/scripts/backup-db.sh" "${ENVIRONMENT}" || {
-    echo "[WARN] Yedek alınamadı, devam ediliyor..."
-}
+#
+# Tasarım kararı: yedek alınamazsa VARSAYILAN DAVRANIŞ DURMAKTIR.
+# Rollback, şema ve veriye dokunan geri dönülemez bir işlemdir; güvenlik ağı
+# yokken devam etmek, kurtarmaya çalıştığımız olayı veri kaybına çevirebilir.
+# Eski davranış (uyarı basıp devam) bu riski sessizce alıyordu.
+#
+# Ancak rollback bir ACİL DURUM aracıdır: yedek altyapısının kendisi bozukken
+# (disk dolu, MSSQL kapalı) sert durmak operatörü kilitleyebilir. Bu yüzden
+# bilinçli bir kaçış yolu bırakılıyor: `--skip-backup` / `SKIP_BACKUP=1`.
+# Bayrak yalnız operatörün açıkça verdiği durumda geçerlidir ve log'a çok
+# görünür bir uyarı basar — kararın kayıt altına alınması amaçlı.
+if [[ "${SKIP_BACKUP}" == "1" ]]; then
+    echo "==============================================================="
+    echo "[UYARI] YEDEK ADIMI ATLANDI (--skip-backup / SKIP_BACKUP=1)"
+    echo "[UYARI] Rollback, DB yedeği OLMADAN yapılıyor: ${ENVIRONMENT}"
+    echo "[UYARI] Veri kaybı geri alınamaz. Bu bilinçli bir operatör kararıdır."
+    echo "[UYARI] Zaman: $(date)"
+    echo "==============================================================="
+else
+    echo "[$(date)] Rollback öncesi DB yedeği alınıyor..."
+    if ! "${DEPLOY_DIR}/infra/scripts/backup-db.sh" "${ENVIRONMENT}"; then
+        echo "==============================================================="
+        echo "[ERROR] Rollback öncesi DB yedeği ALINAMADI — rollback durduruldu."
+        echo "[ERROR] Ortam: ${ENVIRONMENT} · Hedef: ${TARGET_REF}"
+        echo ""
+        echo "Önce yedeklemenin neden başarısız olduğunu inceleyin:"
+        echo "  bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh ${ENVIRONMENT}"
+        echo ""
+        echo "Yedek alınamıyor ve rollback ertelenemiyorsa, veri kaybı riskini"
+        echo "bilerek kabul ederek şu şekilde tekrar çalıştırın:"
+        echo "  ${DEPLOY_DIR}/infra/scripts/rollback.sh ${ENVIRONMENT} ${TARGET_REF} --skip-backup"
+        echo "==============================================================="
+        exit 1
+    fi
+fi
 
 # Kodu hedef ref'e çek
 echo "[$(date)] Kod ${TARGET_REF} sürümüne getiriliyor..."

--- a/infra/scripts/setup-backup-cron.sh
+++ b/infra/scripts/setup-backup-cron.sh
@@ -13,6 +13,10 @@ mkdir -p "${LOG_DIR}"
 mkdir -p "${BACKUP_DIR}/mssql/prod"
 mkdir -p "${BACKUP_DIR}/mssql/test"
 
+# Yedek dizinleri tüm müşteri verisini barındırır; host'taki diğer kullanıcılara
+# kapalı olmalı (backup-db.sh de her koşumda aynı izni uygular).
+chmod 700 "${BACKUP_DIR}" "${BACKUP_DIR}/mssql" "${BACKUP_DIR}/mssql/prod" "${BACKUP_DIR}/mssql/test"
+
 # Scriptleri çalıştırılabilir yap
 chmod +x "${DEPLOY_DIR}/infra/scripts/backup-db.sh"
 chmod +x "${DEPLOY_DIR}/infra/scripts/rollback.sh"

--- a/infra/scripts/setup-backup-cron.sh
+++ b/infra/scripts/setup-backup-cron.sh
@@ -39,30 +39,61 @@ ${entry}"
     fi
 }
 
+# Bir ortamın cron'u yalnızca o ortam sunucuda gerçekten varsa kurulur.
+# backup-db.sh / verify-backup.sh ilk iş olarak .env.<ortam> dosyasını okur ve
+# yoksa hata verir. Prod stack henüz deploy edilmediği için (.env.prod yok)
+# kurulan prod cron'ları her gece hata basıyor ve alarm yorgunluğu üretiyordu —
+# gerçek bir yedekleme arızasını gizleyecek gürültü. Bu yüzden ortam hazır
+# değilse cron kurulmaz; ama sessizce değil, açık bir mesajla atlanır.
+ortam_hazir() {
+    [[ -f "${DEPLOY_DIR}/infra/env/.env.$1" ]]
+}
+
+ortam_atlandi() {
+    local environment="$1"
+    echo "[ATLANDI] ${environment} ortamı hazır değil: ${DEPLOY_DIR}/infra/env/.env.${environment} yok."
+    echo "          ${environment} cron'ları KURULMADI (kurulsalardı her gece hata basarlardı)."
+    echo "          Ortam deploy edildikten sonra bu script'i tekrar çalıştırın."
+    if echo "${CRON_CONTENT}" | grep -qF "backup-db.sh ${environment}"; then
+        echo "[UYARI]  crontab'da ${environment} girdisi ZATEN VAR ama ortam hazır değil."
+        echo "         Bu girdi şu anda her gece hata basıyor; 'crontab -e' ile elle kaldırın."
+    fi
+}
+
 # Cron satırlarında `bash ` öneki ikinci savunma hattıdır: repo'dan gelen dosyada
 # execute biti düşerse yedekleme sessizce "permission denied" ile durmaz.
 
-# Prod DB — her gece 02:00
-add_cron \
-    "0 2 * * * bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh prod >> ${LOG_DIR}/backup-prod.log 2>&1" \
-    "Cargo Pilot - Prod DB yedek"
+if ortam_hazir prod; then
+    # Prod DB — her gece 02:00
+    add_cron \
+        "0 2 * * * bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh prod >> ${LOG_DIR}/backup-prod.log 2>&1" \
+        "Cargo Pilot - Prod DB yedek"
 
-# Test DB — her gece 03:00
-add_cron \
-    "0 3 * * * bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh test >> ${LOG_DIR}/backup-test.log 2>&1" \
-    "Cargo Pilot - Test DB yedek"
+    # Prod yedek doğrulaması — her Pazar 04:00
+    add_cron \
+        "0 4 * * 0 bash ${DEPLOY_DIR}/infra/scripts/verify-backup.sh prod >> ${LOG_DIR}/verify-backup.log 2>&1" \
+        "Cargo Pilot - Prod yedek doğrulama"
+else
+    ortam_atlandi prod
+fi
 
-# Prod yedek doğrulaması — her Pazar 04:00
-add_cron \
-    "0 4 * * 0 bash ${DEPLOY_DIR}/infra/scripts/verify-backup.sh prod >> ${LOG_DIR}/verify-backup.log 2>&1" \
-    "Cargo Pilot - Prod yedek doğrulama"
+if ortam_hazir test; then
+    # Test DB — her gece 03:00
+    add_cron \
+        "0 3 * * * bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh test >> ${LOG_DIR}/backup-test.log 2>&1" \
+        "Cargo Pilot - Test DB yedek"
+else
+    ortam_atlandi test
+fi
 
 # Crontab'a yaz
 echo "${CRON_CONTENT}" | crontab -
 
 echo ""
 echo "Cron kurulumu tamamlandı:"
-crontab -l | grep -A1 "Cargo Pilot"
+# `|| true`: hiçbir ortam hazır değilse grep eşleşme bulamaz ve `set -e` altında
+# script tam burada, kurulum özetini basmadan hata koduyla ölürdü.
+crontab -l | grep -A1 "Cargo Pilot" || echo "(kurulu Cargo Pilot cron girdisi yok)"
 echo ""
 echo "Yedek dizini: ${BACKUP_DIR}"
 echo "Log dizini  : ${LOG_DIR}"

--- a/infra/scripts/verify-backup.sh
+++ b/infra/scripts/verify-backup.sh
@@ -39,7 +39,11 @@ if [[ ! -f "${ENV_FILE}" ]]; then
     echo "[ERROR] Env dosyası bulunamadı: ${ENV_FILE}"
     exit 1
 fi
-SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'")
+# `|| true` şart: `set -euo pipefail` altında grep eşleşme bulamazsa (satır yoksa)
+# pipeline 1 döner ve script tam bu atama satırında, hiçbir mesaj basmadan ölür.
+# Aşağıdaki anlamlı hata bloğuna hiç gelinmez. `|| true` ile boş değer atanır,
+# hatayı `if [[ -z ]]` kontrolü açıkça raporlar.
+SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'" || true)
 
 if [[ -z "${SA_PASSWORD}" ]]; then
     echo "[ERROR] MSSQL_SA_PASSWORD env dosyasında bulunamadı."

--- a/infra/scripts/verify-backup.sh
+++ b/infra/scripts/verify-backup.sh
@@ -26,9 +26,11 @@ BACKUP_DIR="${DEPLOY_DIR}/backups/mssql/${ENVIRONMENT}"
 if [[ "${ENVIRONMENT}" == "prod" ]]; then
     CONTAINER="cargo-pilot-mssql-prod"
     ENV_FILE="${DEPLOY_DIR}/infra/env/.env.prod"
+    DATABASE="CargoPilot"
 elif [[ "${ENVIRONMENT}" == "test" ]]; then
     CONTAINER="cargo-pilot-mssql-test"
     ENV_FILE="${DEPLOY_DIR}/infra/env/.env.test"
+    DATABASE="CargoPilotTest"
 else
     echo "[ERROR] Geçersiz ortam: ${ENVIRONMENT}. 'prod' veya 'test' kullanın."
     exit 1
@@ -55,12 +57,16 @@ fi
 # `docker exec -e SQLCMDPASSWORD` (değersiz form) değeri bu kabuktan devralır.
 export SQLCMDPASSWORD="${SA_PASSWORD}"
 
-# Yedek dosyası belirtilmemişse en son yedeği bul
+# Yedek dosyası belirtilmemişse en son yedeği bul.
+# Arama uygulama veritabanının adıyla sınırlı: backup-db.sh aynı dizine birden
+# fazla veritabanının yedeğini yazıyor (ör. test'te DIVIZYON). Filtresiz arama,
+# başka bir veritabanının yedeğini doğrulayıp uygulama yedeği sağlıklıymış gibi
+# rapor verebilirdi. Başka bir .bak'ı doğrulamak için dosya yolu argümanı verilir.
 if [[ -z "${BACKUP_FILE}" ]]; then
-    BACKUP_FILE=$(find "${BACKUP_DIR}" -name "*.bak" -printf '%T@ %p\n' 2>/dev/null \
+    BACKUP_FILE=$(find "${BACKUP_DIR}" -name "${DATABASE}_*.bak" -printf '%T@ %p\n' 2>/dev/null \
         | sort -n | tail -1 | cut -d' ' -f2-)
     if [[ -z "${BACKUP_FILE}" ]]; then
-        echo "[ERROR] ${BACKUP_DIR} dizininde yedek dosyası bulunamadı."
+        echo "[ERROR] ${BACKUP_DIR} dizininde ${DATABASE} yedeği bulunamadı."
         exit 1
     fi
     echo "[$(date)] En son yedek seçildi: ${BACKUP_FILE}"


### PR DESCRIPTION
## Dalga 1 — Yedekleme ve rollback script'lerinin sertleştirilmesi

[Dokuz Dalga yol haritası](https://claude.ai/code/artifact/843c86a5-42c4-478f-92cf-cc4351a13d5e)
Dalga 1. Beş bulgu, hepsi `infra/scripts/` altında, hepsi XS efor.

**Neyi açar:** D-25 → D-29 (rollback tatbikatı) ön koşullarından biri · D-18 → D-03 (MinIO yedeği)
için çok-DB döngü altyapısı.

---

### D-22 · "Anlamlı hata ver" kodu ölüydü 🟡

`set -euo pipefail` altında `grep` eşleşme bulamazsa **atama satırında ölünüyordu** — altındaki
hata bloğuna hiç gelinmiyordu. Yani parola okunamadığında operatöre çıktısız `exit 1` dönüyordu.

`$(grep … || true)` deseniyle üç dosyada düzeltildi. **Dördüncü bir örnek bulundu:**
`rollback.sh:94` (`BACKEND_PORT`) — orada hata bloğu hiç yoktu, eklendi.

| | Eski | Yeni |
|---|---|---|
| Parola okunamıyor | Çıktısız `exit 1` | Anlamlı mesaj + `exit 1` |

### D-23 · Yedek dosya izinleri 🟡

`.bak` dosyaları tüm müşteri verisini içeriyor ama varsayılan umask ile yazılıyordu.
`umask 077` + açık `chmod 700` (dizin) / `chmod 600` (dosya). `setup-backup-cron.sh`'ın oluşturduğu
dizinler de 700'e çekildi.

### D-18 · ERP veritabanı yedek kapsamı dışındaydı 🟠

**Doğrulama önce yapıldı:** `DIVIZYON`, `docker-compose.test.yml`'in **`mssql`** servisinde
(`cargo-pilot-mssql-test`) — kanıt `server-access.md:201,205` + `known-issues.md:225`.
`erp-mssql` servisi (profil `e2e`, DB `ERPTEST`) **başka bir şey**, bilinçli olarak kapsam dışı.

`DATABASE` → `DATABASES` dizisi + döngü. İkincil DB yoksa uyarıyla atlanır, birincil yoksa hata.
`BACKUP_DATABASES` ile ezilebilir. Mevcut çağrılar kırılmadı.

**Yakalanan yan etki:** aynı dizinde artık birden fazla DB'nin yedeği duracağı için
`restore-db.sh` / `verify-backup.sh`'ın "en son yedek" araması DB adıyla sınırlandı — aksi hâlde
`DIVIZYON` yedeği `CargoPilotTest` üzerine geri yüklenebilirdi.

### D-25 · Yedeksiz rollback sessizce devam ediyordu 🟠

Eskiden: `backup-db.sh … || { echo "[WARN] Yedek alınamadı, devam ediliyor..."; }`

**Tasarım kararı:** rollback bir acil durum aracı; yedek alınamadığında koşulsuz durmak gerçek bir
olayda operatörü kilitleyebilir. Bu yüzden **varsayılan dur**, ama `--skip-backup` / `SKIP_BACKUP=1`
ile bilinçli geçiş bırakıldı ve geçildiğinde çerçeveli, çok görünür bir uyarı basılıyor.

Rollback fiilen yalnız `rollback.yml`'den tetiklendiği için kaçış yolunun arayüzden erişilebilir
olması gerekiyordu → workflow'a `skip_backup` **boolean** input eklendi. İşaretlenmezse çağrı
birebir eskisi gibi.

### D-21 · Prod cron'ları her gece hata basıyordu 🟠

`.env.prod` sunucuda olmadığı için 3 cron her gece hata veriyordu → alarm yorgunluğu.
Ortam başına `.env.<ortam>` guard'ı eklendi. Atlama **sessiz değil**; ayrıca crontab'da eski prod
girdisi kalmışsa uyarı basılıyor. Prod hazır olunca 3 cron eskisi gibi kuruluyor.

---

### Doğrulama

```
bash -n              6/6 temiz
shellcheck           kurulu değil (raporda belirtildi)
sahte docker/crontab ile gerçek script koşumu:
  backup    7 senaryo    cron   4 senaryo    rollback argüman   6 senaryo
çağıranlar grep ile çıkarıldı — imza kırılmadı (`rollback.sh test ""` dahil)
rollback.yml         YAML geçerli
```

⚠️ **Yerelde uçtan uca koşturulamadı** — docker + mssql gerekiyor, sunucu erişimi yok. Doğrulama
statik + sahte komut koşumu düzeyinde. **Gerçek sınav sunucudaki ilk gece yedeğinde** olacak;
ilk koşum izlenmeli.

### Bilerek not düşülen

`rollback.yml`'de shell içi `${{ github.event.inputs… }}` sayısı **10 → 13** oldu. Yeni üçü
`skip_backup` ve `type: boolean` olduğu için GitHub değeri true/false ile sınırlıyor — enjekte
edilemez. Yine de bu, **D-14'ün (shell injection) yüzeyini büyütüyor**; Dalga 2'deki D-14 düzeltmesi
input'ları `env:` üzerinden geçirirken bu üçünü de kapsamalı.

`rollback.sh`'te D-14 aynı dosyada duruyor → Dalga 2a ile küçük çakışma riski var, sıra korunmalı.

6 dosya, +294/−53, 5 atomic commit.
