### PR TITLE
Dalga 2a: rollback workflow girdileri env üzerinden geçiriliyor (D-14)

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -40,63 +40,80 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # Kullanıcı girdileri shell gövdesine `${{ }}` ile enterpole edilmez; `env:`
+      # üzerinden değişken olarak geçilir ve shell içinde tırnaklanmış okunur.
       - name: Hedef ref'i doğrula
+        env:
+          TARGET_ENV: ${{ github.event.inputs.environment }}
+          TARGET_REF: ${{ github.event.inputs.target_ref }}
         run: |
-          TARGET="${{ github.event.inputs.target_ref }}"
-          ENV="${{ github.event.inputs.environment }}"
-          echo "Ortam  : ${ENV}"
-          echo "Hedef  : ${TARGET:-'(önceki tag)'}"
+          echo "Ortam  : ${TARGET_ENV}"
+          echo "Hedef  : ${TARGET_REF:-'(önceki tag)'}"
 
-          if [[ -n "${TARGET}" ]]; then
-            if ! git rev-parse --verify "${TARGET}" > /dev/null 2>&1; then
-              echo "::error::Geçersiz ref: ${TARGET}"
+          if [[ -n "${TARGET_REF}" ]]; then
+            if ! git rev-parse --verify "${TARGET_REF}" > /dev/null 2>&1; then
+              echo "::error::Geçersiz ref: ${TARGET_REF}"
               exit 1
             fi
-            echo "Doğrulanan ref: $(git rev-parse --short ${TARGET})"
+            echo "Doğrulanan ref: $(git rev-parse --short "${TARGET_REF}")"
           fi
 
       - name: Test sunucusuna rollback yap
         if: github.event.inputs.environment == 'test'
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          TARGET_REF: ${{ github.event.inputs.target_ref }}
+          SKIP_BACKUP: ${{ github.event.inputs.skip_backup }}
         with:
           host: ${{ secrets.TEST_SSH_HOST }}
           username: root
           key: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
+          # ssh-action, `envs` ile listelenen değişkenleri uzak kabuğa tırnaklayıp
+          # kaçışlayarak aktarır; değerler script metnine gömülmez.
+          envs: TARGET_REF,SKIP_BACKUP
           script: |
             set -e
-            TARGET="${{ github.event.inputs.target_ref }}"
             # rollback.sh yedek alınamazsa varsayılan olarak durur; bayrak yalnız
             # operatör bunu UI'da bilinçli olarak işaretlediğinde geçilir.
-            if [ "${{ github.event.inputs.skip_backup }}" = "true" ]; then
-              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET}" --skip-backup
+            if [ "${SKIP_BACKUP}" = "true" ]; then
+              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET_REF}" --skip-backup
             else
-              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET}"
+              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET_REF}"
             fi
 
       - name: Prod sunucusuna rollback yap
         if: github.event.inputs.environment == 'prod'
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          TARGET_REF: ${{ github.event.inputs.target_ref }}
+          SKIP_BACKUP: ${{ github.event.inputs.skip_backup }}
         with:
           host: ${{ secrets.PROD_SSH_HOST }}
           username: root
           key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          # ssh-action, `envs` ile listelenen değişkenleri uzak kabuğa tırnaklayıp
+          # kaçışlayarak aktarır; değerler script metnine gömülmez.
+          envs: TARGET_REF,SKIP_BACKUP
           script: |
             set -e
-            TARGET="${{ github.event.inputs.target_ref }}"
             # rollback.sh yedek alınamazsa varsayılan olarak durur; bayrak yalnız
             # operatör bunu UI'da bilinçli olarak işaretlediğinde geçilir.
-            if [ "${{ github.event.inputs.skip_backup }}" = "true" ]; then
-              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET}" --skip-backup
+            if [ "${SKIP_BACKUP}" = "true" ]; then
+              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET_REF}" --skip-backup
             else
-              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET}"
+              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET_REF}"
             fi
 
       - name: Rollback özeti
         if: always()
+        env:
+          TARGET_ENV: ${{ github.event.inputs.environment }}
+          TARGET_REF: ${{ github.event.inputs.target_ref }}
+          SKIP_BACKUP: ${{ github.event.inputs.skip_backup }}
         run: |
           echo "## Rollback Özeti" >> $GITHUB_STEP_SUMMARY
-          echo "- **Ortam**: ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Hedef**: ${{ github.event.inputs.target_ref || '(önceki tag)' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Yedek atlandı**: ${{ github.event.inputs.skip_backup }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Tetikleyen**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Ortam**: ${TARGET_ENV}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Hedef**: ${TARGET_REF:-(önceki tag)}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Yedek atlandı**: ${SKIP_BACKUP}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tetikleyen**: ${GITHUB_ACTOR}" >> $GITHUB_STEP_SUMMARY
           echo "- **Zaman**: $(date -u '+%Y-%m-%d %H:%M UTC')" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Dalga 2a — `rollback.yml` shell injection (D-14) 🟠

[Dokuz Dalga](https://claude.ai/code/artifact/843c86a5-42c4-478f-92cf-cc4351a13d5e) Dalga 2a.
Tek bulgu, tek dosya.

`${{ github.event.inputs.* }}` ifadeleri **doğrudan shell gövdesine** enterpole ediliyordu ve bu
adımlar sunucuda **root olarak** koşuyor. `target_ref` alanına shell metakarakteri giren biri komut
çalıştırabilirdi.

Tırnaklama çözüm değil: `${{ }}` shell'e ulaşmadan **önce** genişletiliyor, yani metin doğrudan
script gövdesine yazılıyor. Doğru yöntem input'ları `env:` üzerinden geçirip shell içinde
`"$DEGISKEN"` kullanmak.

### Sonuç

| | Öncesi | Sonrası |
|---|---|---|
| Shell/script gövdesinde enterpolasyon | 9 | **0** |
| `env:` bloğunda | — | 9 |
| `if:` koşulunda (expression bağlamı, shell değil) | 2 | 2 |
| Job `name:` / `environment:` anahtarında | 2 | 2 |

Doğrulama YAML'i ayrıştırıp her adımın `run` / `with.script` / `with.command` gövdesini tek tek
tarayarak yapıldı — `grep` değil, yapısal kontrol.

### Teknik ayrıntı: `env:` tek başına yetmiyor

`appleboy/ssh-action` için runner ortamındaki değişkenler **uzak kabuğa geçmez**; ayrıca
`envs: TARGET_REF,SKIP_BACKUP` gerekiyor. Bu eklendi (2 ssh adımında da).

Güvenliği upstream kaynağından doğrulandı: `drone-ssh` değerleri `escapeArg()` ile POSIX tek-tırnak
kaçışından geçirip `export NAME='...'` olarak yolluyor — script metnine gömmüyor. Yani zincir
uçtan uca enterpolasyonsuz.

### Kapsam notu

Dalga 1 (#1012) bu dosyaya `skip_backup` boolean input'u eklemişti ve o da shell içinde
kullanılıyordu. `type: boolean` olduğu için GitHub değeri true/false ile sınırlıyor — enjekte
edilemezdi. Yine de **tutarlılık için** o üçü de aynı desene alındı; yarım bırakılsa sonraki
okuyucu hangisinin neden farklı olduğunu anlayamazdı.

### Davranış korunumu

Yerel shell simülasyonuyla koşturuldu: boş `target_ref` → "bir önceki tag" akışı · `${:-}` fallback'i ·
`skip_backup` dallanmasının 4 kombinasyonu · ortam seçimi (`if:` satırlarına hiç dokunulmadı) ·
`rollback.sh <env> "<ref>" [--skip-backup]` imzası — hepsi aynı.

`rollback.sh` bu PR'ın diff'inde **yok** (Dalga 2b'nin işi, çakışma yok).

### ⚠️ Runtime kanıtı yok ve olamaz

`rollback.yml` bugüne kadar **hiç çalıştırılmadı** (D-29). Kanıtların tamamı statik; özellikle
`envs:` aktarımı kaynak kodundan okundu, koşturulmadı. İlk gerçek rollback'te log'dan teyit edilmeli.
**Bu PR D-29'u kapatmaz.**

`actionlint` / `yamllint` bu makinede kurulu değil; YAML doğrulaması `yaml.safe_load` ile yapıldı.

Tek dosya, +37/−20.
