### PR TITLE
Dalga 2b: deploy kesintisi kısaltıldı, otomatik geri alma ve rollback runbook eklendi (D-24, D-26, D-27, D-28)

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -457,7 +457,27 @@ jobs:
             # Konteyner yoksa (ilk deploy) boş kalır ve geri alma denenmez.
             PREV_IMAGE_REF="$(docker inspect --format '{{.Config.Image}}' cargo-pilot-backend-test 2>/dev/null || true)"
             PREV_IMAGE_TAG="${PREV_IMAGE_REF##*:}"
-            echo "==> Geri alma çıpası: PREV_IMAGE_TAG=${PREV_IMAGE_TAG:-<yok>}"
+
+            # Çıpa doğrulaması: `.Config.Image` digest biçiminde
+            # (ghcr.io/...@sha256:abc...) veya tag'siz dönebilir. Bu durumlarda
+            # `##*:` geçerli bir tag değil, sha hex'i ya da tüm referans üretir.
+            # Geri alma böyle bir değerle denenirse `up` var olmayan bir image
+            # arar ve ortam bugünküne göre DAHA KÖTÜ duruma düşer. Şüpheliyse
+            # çıpa boşaltılır: geri alma atlanır, davranış mevcut hâle eşitlenir.
+            case "$PREV_IMAGE_REF" in
+              *@*)      PREV_IMAGE_TAG="" ;;   # digest referansı, tag yok
+              *:*)      : ;;                   # ref:tag — beklenen biçim
+              *)        PREV_IMAGE_TAG="" ;;   # hiç ':' yok, tag belirtilmemiş
+            esac
+            case "$PREV_IMAGE_TAG" in
+              ""|*/*|*" "*) PREV_IMAGE_TAG="" ;;  # boş, yol parçası ya da boşluk içeriyor
+            esac
+
+            if [ -z "$PREV_IMAGE_TAG" ]; then
+              echo "==> Geri alma çıpası: <yok> (ref='${PREV_IMAGE_REF:-<bos>}' — geri alma atlanacak)"
+            else
+              echo "==> Geri alma çıpası: PREV_IMAGE_TAG=${PREV_IMAGE_TAG}"
+            fi
 
             echo "==> Image'lar GHCR'dan çekiliyor (tag: ${IMAGE_TAG})..."
             IMAGE_TAG="${IMAGE_TAG}" docker compose \

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -470,9 +470,6 @@ jobs:
               --env-file infra/env/.env.test \
               up -d --no-build --remove-orphans
 
-            echo "==> Kullanılmayan eski image'lar temizleniyor..."
-            docker image prune -f
-
             echo "==> Backend health (loopback) bekleniyor..."
             for i in $(seq 1 20); do
               curl -sf http://127.0.0.1:8081/health >/dev/null && break
@@ -480,3 +477,9 @@ jobs:
               sleep 5
             done
             echo "Backend loopback health OK."
+
+            # Prune yalnız health doğrulandıktan SONRA çalışır: aksi hâlde bir önceki
+            # sürümün image'ı (aynı tag yeniden push edildiyse dangling'e düşer)
+            # silinir ve geri dönüş için GHCR'dan tekrar pull gerekir.
+            echo "==> Kullanılmayan eski image'lar temizleniyor..."
+            docker image prune -f

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -452,6 +452,13 @@ jobs:
             echo "==> Bayat GHCR kimlik bilgisi temizleniyor..."
             docker logout ghcr.io >/dev/null 2>&1 || true
 
+            # Geri alma çıpası: hâlihazırda çalışan backend konteynerinin image
+            # referansından mevcut tag türetilir (ör. ghcr.io/...:test-abc1234 -> test-abc1234).
+            # Konteyner yoksa (ilk deploy) boş kalır ve geri alma denenmez.
+            PREV_IMAGE_REF="$(docker inspect --format '{{.Config.Image}}' cargo-pilot-backend-test 2>/dev/null || true)"
+            PREV_IMAGE_TAG="${PREV_IMAGE_REF##*:}"
+            echo "==> Geri alma çıpası: PREV_IMAGE_TAG=${PREV_IMAGE_TAG:-<yok>}"
+
             echo "==> Image'lar GHCR'dan çekiliyor (tag: ${IMAGE_TAG})..."
             IMAGE_TAG="${IMAGE_TAG}" docker compose \
               -f infra/compose/docker-compose.test.yml \
@@ -471,11 +478,37 @@ jobs:
               up -d --no-build --remove-orphans
 
             echo "==> Backend health (loopback) bekleniyor..."
+            HEALTH_OK=0
             for i in $(seq 1 20); do
-              curl -sf http://127.0.0.1:8081/health >/dev/null && break
-              if [ "$i" = "20" ]; then echo "Backend loopback health basarisiz"; exit 1; fi
+              if curl -sf http://127.0.0.1:8081/health >/dev/null; then HEALTH_OK=1; break; fi
               sleep 5
             done
+
+            # Health düşerse bir önceki image tag'ine tek seferlik geri dönülür.
+            # Geri alma sonucundan bağımsız olarak job kırmızı bırakılır (exit 1):
+            # başarılı bir geri alma "deploy başarılı" anlamına gelmez.
+            # Geri almanın kendisi için ikinci bir geri alma denenmez -> döngü yok.
+            if [ "${HEALTH_OK}" != "1" ]; then
+              echo "Backend loopback health basarisiz (tag: ${IMAGE_TAG})."
+              if [ -n "${PREV_IMAGE_TAG}" ] && [ "${PREV_IMAGE_TAG}" != "${IMAGE_TAG}" ]; then
+                echo "==> Otomatik geri alma: ${PREV_IMAGE_TAG}"
+                IMAGE_TAG="${PREV_IMAGE_TAG}" docker compose \
+                  -f infra/compose/docker-compose.test.yml \
+                  --env-file infra/env/.env.test \
+                  up -d --no-build --remove-orphans || echo "Geri alma komutu hata verdi."
+                for i in $(seq 1 12); do
+                  if curl -sf http://127.0.0.1:8081/health >/dev/null; then
+                    echo "Geri alma tamamlandi, backend ${PREV_IMAGE_TAG} ile saglikli."
+                    break
+                  fi
+                  sleep 5
+                done
+              else
+                echo "Geri donulecek onceki image yok; stack oldugu gibi birakildi."
+              fi
+              echo "Deploy basarisiz."
+              exit 1
+            fi
             echo "Backend loopback health OK."
 
             # Prune yalnız health doğrulandıktan SONRA çalışır: aksi hâlde bir önceki

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -458,17 +458,17 @@ jobs:
               --env-file infra/env/.env.test \
               pull backend frontend
 
-            echo "==> Eski stack temizleniyor..."
-            docker compose \
-              -f infra/compose/docker-compose.test.yml \
-              --env-file infra/env/.env.test \
-              down --remove-orphans 2>/dev/null || true
-
-            echo "==> Stack ayağa kaldırılıyor (tag: ${IMAGE_TAG})..."
+            # Tüm stack'i `down` etmek mssql ve minio'yu da kapatıyordu; deploy edilen
+            # yalnız backend/frontend olduğu hâlde her deploy 2-3 dk kesinti üretiyordu.
+            # `up -d` yalnız image digest'i veya servis tanımı değişen konteynerleri
+            # yeniden yaratır: backend + frontend yeni tag'e geçer, mssql/minio/ağ/volume
+            # dokunulmadan ayakta kalır. `--remove-orphans` semantiği korunuyor —
+            # compose dosyasından çıkarılmış servislerin artık konteynerleri yine silinir.
+            echo "==> Stack güncelleniyor (tag: ${IMAGE_TAG})..."
             IMAGE_TAG="${IMAGE_TAG}" docker compose \
               -f infra/compose/docker-compose.test.yml \
               --env-file infra/env/.env.test \
-              up -d --no-build
+              up -d --no-build --remove-orphans
 
             echo "==> Kullanılmayan eski image'lar temizleniyor..."
             docker image prune -f

--- a/docs/devops/rollback-runbook.md
+++ b/docs/devops/rollback-runbook.md
@@ -1,0 +1,199 @@
+# Rollback Runbook
+
+**Son güncelleme:** 2026-08-16 · **Durum:** Aktif
+
+Bu doküman bir deploy'un geri alınması gerektiğinde izlenecek adımları tanımlar.
+Kod geri alma ile veritabanı geri alma **aynı şey değildir**; en kritik nokta budur.
+
+> ⚠️ **Temel kısıt:** `DbInitializer.MigrateAsync()` yalnız ileri yönlüdür. `rollback.sh`
+> yalnız **kodu ve image'ı** eski sürüme döndürür, **DB şemasını geri almaz.**
+> Şema geri alınacaksa tek yol yedekten dönüştür (§4).
+
+---
+
+## 1. Ne zaman rollback edilir
+
+| Durum | Aksiyon |
+|---|---|
+| Deploy sonrası backend health düşük, sunucu bozuk image ile çalışıyor | Otomatik geri alma devreye girer (§2). Girmemişse §3. |
+| Deploy başarılı ama uygulama işlevsel olarak bozuk (5xx, kritik akış çalışmıyor) | Manuel rollback (§3) |
+| Migration uygulandı ve veri bozuyor | **Önce §4** (yedekten dönüş), sonra §3 |
+| Yalnız bir konfigürasyon/env hatası | Rollback etme; env'i düzeltip `up -d` yeterli |
+| Frontend'de görsel/kozmetik hata | Rollback etme; ileri yönlü düzeltme (fix-forward) tercih edilir |
+
+**Karar kuralı:** Sorun **veri bütünlüğüne** dokunuyorsa rollback; yalnız davranışa
+dokunuyorsa fix-forward genelde daha ucuzdur. Rollback her zaman migration riski taşır.
+
+---
+
+## 2. Otomatik geri alma (test ortamı, deploy sırasında)
+
+`.github/workflows/test-deploy.yml` → `deploy-test-server` job'u:
+
+1. Pull'dan **önce** çalışan `cargo-pilot-backend-test` konteynerinin image referansından
+   mevcut tag saklanır (geri alma çıpası).
+2. Yeni image çekilir, `up -d --no-build --remove-orphans` ile stack güncellenir.
+3. Sunucu içinden `http://127.0.0.1:8081/health` loopback probu ile en fazla 100 sn beklenir.
+4. Health düşerse çıpa tag'i ile **tek seferlik** `up -d` çalıştırılıp önceki image'a dönülür.
+5. Geri alma başarılı olsa bile **job kırmızı bırakılır.**
+
+**Sınırları — bunları bilerek kullanın:**
+- Yalnız **image**'ı geri alır. `git checkout test` adımı geri alınmaz; sunucudaki çalışma
+  ağacı yeni commit'te kalır. Bu, compose dosyası veya `.env.test` değiştiyse önemlidir.
+- **DB migration'ını geri almaz.** Yeni sürüm migration uyguladıysa eski image yeni şemaya
+  karşı çalışır. Uyumsuzsa geri alma da health veremez → §4.
+- İlk deploy'da (önceki konteyner yok) veya tag aynıysa geri alma denenmez.
+- Prod'da bu mekanizma **yoktur**; prod deploy pipeline'ı henüz yok.
+
+---
+
+## 3. Manuel rollback
+
+### 3a. Workflow üzerinden (tercih edilen)
+
+GitHub Actions → **Rollback** workflow → `Run workflow`:
+- `environment`: `test` | `prod`
+- `target_ref`: hedef tag/SHA (boş bırakılırsa bir önceki `v*` tag'ine dönülür)
+
+### 3b. Sunucudan doğrudan
+
+```bash
+ssh root@<sunucu>
+cd /opt/cargo-pilot
+./infra/scripts/rollback.sh test v1.2.3      # veya: ./infra/scripts/rollback.sh prod
+```
+
+`rollback.sh` sırası:
+1. Rollback öncesi DB yedeği (`backup-db.sh`)
+2. `git fetch --tags` + hedef ref'e `checkout`
+3. **Image'ları GHCR'dan çek** (test ortamı)
+4. `down --remove-orphans`
+5. `up -d` (test: `--no-build`, prod: `--build`)
+6. Health kontrolü — düşerse çıkış kodu 1
+
+Adım 3'ün adım 4'ten **önce** olması bilinçlidir: image çekilemezse (GHCR erişimi yok,
+tag yok) ortam hiç kapatılmamış olur ve elde kalır.
+
+### 3c. Rollback sonrası doğrulama
+
+```bash
+docker compose -f infra/compose/docker-compose.test.yml ps
+curl -sf http://127.0.0.1:8081/health
+docker compose -f infra/compose/docker-compose.test.yml logs --tail=100 backend
+```
+
+Beklenen: tüm servisler `Up`, health 200, backend loglarında migration hatası yok.
+
+---
+
+## 4. Migration geri alınamıyorsa
+
+Bu bölüm **her rollback'te değil**, yalnız yeni sürüm DB şemasını değiştirmişse geçerlidir.
+
+**Önce tespit et:** Rollback edilecek aralıkta migration var mı?
+
+```bash
+cd /opt/cargo-pilot
+git diff --name-only <hedef-ref>..HEAD -- apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/
+```
+
+Çıktı boşsa şema değişmemiştir → §3 tek başına yeterli, bu bölümü atla.
+
+**Çıktı boş değilse — şema değişmiştir. Seçenekler:**
+
+| Migration türü | Geri alınabilir mi | Yapılacak |
+|---|---|---|
+| Yalnız ekleme (yeni tablo/kolon, nullable) | Genelde gerek yok | Eski sürüm fazla kolonu görmez; §3 yeterli. Doğrula. |
+| Kolon/tablo silme veya yeniden adlandırma | **Hayır** | Yedekten dönüş (§4a) zorunlu |
+| Veri dönüştüren migration (backfill, tip değişimi) | **Hayır** | Yedekten dönüş (§4a) zorunlu |
+
+### 4a. Yedekten dönüş adımları
+
+1. **Uygulamayı durdur** — geri yükleme sırasında yazma olmamalı:
+   ```bash
+   docker compose -f infra/compose/docker-compose.test.yml stop backend
+   ```
+2. **Kullanılacak yedeği seç ve doğrula:**
+   ```bash
+   ls -lt /opt/cargo-pilot/backups/mssql/test/
+   ./infra/scripts/verify-backup.sh test
+   ```
+   Deploy'dan **önce** alınmış bir yedek seçin. `rollback.sh` kendi başlangıcında da bir
+   yedek alır — o yedek **bozuk şemayı içerir**, geri dönüş için onu kullanmayın.
+3. **Geri yükle:**
+   ```bash
+   ./infra/scripts/restore-db.sh test /opt/cargo-pilot/backups/mssql/test/<dosya>.bak
+   ```
+4. **Kodu eski sürüme al** (§3) — şema ile image sürümü uyumlu olmalı.
+5. **Backend'i başlat ve doğrula:**
+   ```bash
+   docker compose -f infra/compose/docker-compose.test.yml up -d backend
+   curl -sf http://127.0.0.1:8081/health
+   ```
+6. **Veri kaybını hesapla ve kaydet:** son yedek ile olay anı arasındaki yazmalar kayıptır.
+   Bu aralığı olay kaydına yazın.
+
+### 4b. Yedek yoksa
+
+Yedek yoksa şema geri alınamaz. Bu durumda tek seçenek **ileri yönlü düzeltme**:
+sorunu gideren yeni bir migration yazıp normal deploy akışıyla göndermek.
+Rollback denemeyin — eski image yeni şemayla çalışmaz ve ortamı daha da bozarsınız.
+
+---
+
+## 5. `skip_backup` / `--skip-backup` ne zaman kullanılır
+
+`rollback.sh` normalde rollback'ten önce DB yedeği alır ve yedek alınamazsa durur.
+Kaçış yolu `--skip-backup` bayrağı (ya da `SKIP_BACKUP=1`), workflow tarafında
+`skip_backup` input'udur.
+
+> **Not:** Bu kaçış yolu script sertleştirme çalışmasıyla (backlog D-25) birlikte geliyor.
+> Elinizdeki `rollback.sh` sürümünde `--skip-backup` yoksa yedek adımı yalnız uyarı verip
+> devam ediyordur; aşağıdaki "kullanma" maddeleri o durumda **daha da** bağlayıcıdır.
+
+**Kullan:**
+- Yedek alma adımı takılıyor ve **kesinti maliyeti veri riskinden yüksek** (disk dolu,
+  MSSQL yanıt vermiyor, ortam zaten yazma alamıyor).
+- Rollback edilen ortam **test** ve içindeki veri feda edilebilir.
+- Zaten elde deploy öncesinden **taze ve doğrulanmış** bir yedek var.
+
+**Kullanma:**
+- Prod'da, elde deploy öncesi doğrulanmış bir yedek yokken. Bu durumda yedek hatasını
+  çözmek rollback'i geciktirmekten daha ucuzdur.
+- Migration içeren bir rollback'te (§4) — geri dönüş noktanız kalmaz.
+
+Kullanıldığında karar log'a yazılır. Olay sonrası incelemede "yedek var mıydı" sorusu
+bu satırdan cevaplanır; kararı olay kaydına da düşün.
+
+---
+
+## 6. Tatbikat prosedürü
+
+Rollback bugüne kadar **hiç gerçek koşulda denenmedi** (backlog D-29). İlk kez gerçek bir
+olayda denenmesi kabul edilebilir bir risk değil. Tatbikat çeyrekte bir, **test ortamında**,
+planlı bir pencerede yapılır.
+
+**Ön koşullar:** test ortamında en az iki farklı sürüm tag'i, taze ve `verify-backup.sh` ile
+doğrulanmış bir yedek, tatbikat penceresinde test ortamını kullanan kimse olmaması.
+
+**Senaryolar:**
+
+| # | Senaryo | Beklenen sonuç |
+|---|---|---|
+| 1 | Migration'sız sürüm arasında `rollback.sh test <onceki-tag>` | Health OK, veri değişmez |
+| 2 | Bilerek bozuk bir image ile deploy | Otomatik geri alma devreye girer, job kırmızı, ortam eski image'da sağlıklı |
+| 3 | GHCR erişimi engelli (`docker logout` + geçersiz tag) | Pull hatası, **stack ayakta kalır** (§3, adım 3-4 sırası) |
+| 4 | Migration'lı sürümden yedekten dönüş (§4a) | Şema eski hâline döner, backend eski image ile kalkar |
+
+**Her tatbikat için kaydedilecekler:** başlangıç/bitiş zamanı, ölçülen kesinti süresi,
+takılan adım, doküman ile gerçek davranış arasındaki fark, sonuç (başarılı/başarısız).
+Doküman ile gerçek arasında fark çıkarsa bu runbook aynı gün güncellenir.
+
+---
+
+## İlgili dokümanlar
+
+- [`deployment.md`](deployment.md) — deploy akışı ve ortam adresleri
+- [`devops-backlog.md`](devops-backlog.md) — D-24, D-26, D-27, D-28, D-29
+- [`server-access.md`](server-access.md) — sunucu erişimi, yedek cron'ları
+- [`known-issues.md`](known-issues.md) — bilinen açık sorunlar

--- a/infra/scripts/rollback.sh
+++ b/infra/scripts/rollback.sh
@@ -59,11 +59,8 @@ echo "[$(date)] Kod ${TARGET_REF} sürümüne getiriliyor..."
 git fetch --tags origin
 git checkout "${TARGET_REF}"
 
-# Stack'i yeniden başlat
-echo "[$(date)] Stack yeniden başlatılıyor..."
-docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
-    down --remove-orphans
-
+# Image'lar ortam KAPATILMADAN ÖNCE çekilir. Aksi hâlde GHCR erişilemezse ya da
+# tag yoksa stack zaten kapanmış olur ve ortam elde kalır.
 if [[ "${ENVIRONMENT}" == "test" ]]; then
     # Test ortamı: GHCR'dan immutable tag ile çek (--build yapılmaz)
     # Türetme release-tag.yml ile birebir aynı olmalı: sürüm tag'i main'deki merge
@@ -79,6 +76,14 @@ if [[ "${ENVIRONMENT}" == "test" ]]; then
     echo "[$(date)] GHCR'dan image çekiliyor: IMAGE_TAG=${IMAGE_TAG}"
     IMAGE_TAG="${IMAGE_TAG}" docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
         pull backend frontend
+fi
+
+# Stack'i yeniden başlat
+echo "[$(date)] Stack yeniden başlatılıyor..."
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
+    down --remove-orphans
+
+if [[ "${ENVIRONMENT}" == "test" ]]; then
     IMAGE_TAG="${IMAGE_TAG}" docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
         up -d --no-build
 else


### PR DESCRIPTION
## Dalga 2b — Deploy kesintisi, otomatik geri alma, rollback runbook

[Dokuz Dalga](https://claude.ai/code/artifact/843c86a5-42c4-478f-92cf-cc4351a13d5e) Dalga 2b.
Dört bulgu, aynı deploy bloğunu paylaştıkları için tek PR.

### D-26 · Her deploy'da 2-3 dk kesinti 🟠

`down --remove-orphans` + `up` yerine tek `up -d --no-build --remove-orphans`.

Deploy'da değişen tek şey `IMAGE_TAG` ve o da yalnız `backend` (`compose.test.yml:6`) ve
`frontend` (`:62`) `image:` satırlarında geçiyor → Compose yalnız bu ikisini yeniden yaratır;
`mssql`, `minio`, ağ ve volume'lar **ayakta kalır**. Eskiden `down` hepsini kapatıyordu.

`--remove-orphans` bayrağı düşürülmedi, `down`'dan `up`'a taşındı.

### D-28 · `prune` health check'ten önce çalışıyordu 🟡

Prune artık `:518`, health `:480`. **Dürüst not:** `prune -f` yalnız dangling image siler; immutable
`test-<sha>` yolunda etkisi zaten yoktu, hareketli `:test` tag'i yolunda gerçek. Asıl değeri
D-27'nin ön koşulu olması — geri dönülecek image diskte kalmalı.

### D-27 · Health düşerse otomatik geri alma 🟠

Pull'dan **önce** çıpa alınıyor:
`docker inspect --format '{{.Config.Image}}' cargo-pilot-backend-test`
Health düşerse o tag ile tek `up`, ve **sonuç ne olursa olsun `exit 1`**.

**Tasarım gerekçesi:** geri alma bir onarım değil, hasar sınırlaması. "Sessizce yeşil" dönmek bozuk
commit'i `test`'e gömerdi. İkinci bir geri alma denemesi yok → döngü riski yok.

`set -e` altında stub'lu 4 senaryo koşturuldu: fail+çıpa var · ilk deploy (çıpa yok) · aynı tag ·
başarılı deploy. Hepsi beklendiği gibi.

### D-24 · Rollback runbook'u 🟠

`rollback.sh`: `pull` (`:78`) artık `down`'dan (`:84`) **önce**. `set -euo pipefail` sayesinde pull
patlarsa stack hiç kapanmıyor — eskiden ortam kapanır, sonra imaj çekilemezse elde hiçbir şey kalmazdı.

Yeni `docs/devops/rollback-runbook.md` (199 satır, **kod değişikliği yok**): karar tablosu, otomatik
geri almanın sınırları, manuel adımlar, migration geri alınamıyorsa yedekten dönüş, `skip_backup`
kuralları, 4 senaryoluk tatbikat prosedürü.

Kod rollback'i DB şemasını geri almıyor (`DbInitializer.MigrateAsync()` yalnız ileri yönlü) —
operatörün ne yapacağının yazılı olması bu yüzden gerekiyordu.

---

### K2 korunumu — doğrulandı

Bu PR `test-deploy.yml`'in deploy bloğunu yeniden yazıyor, yani #991'in kodunun üstüne geliyor.
İkisi de yerinde:

```
loopback health (127.0.0.1)                    2 isabet  (:483 ve :500 — geri alma probu da loopback)
needs: [migration-check, build, deploy]        :418, if: :423
dış IP health check                            0 isabet
```

Diff'teki tüm satırlar `:456-518` aralığında; K2'nin satırlarına değmiyor. `rollback.yml`
dokunulmadı (Dalga 2a'nın işi).

### Dalga 1 ile birlikte doğrulandı

Dal, Dalga 1 (#1012) `dev`'e girmeden önce açıldı ve aynı `rollback.sh`'ye dokunuyor. Birleşme
sonucu ayrıca sınandı — Dalga 1'in katkısı **kayboluyor mu diye**:

```
--skip-backup / SKIP_BACKUP        10 isabet (korunuyor)
pull → down sırası                 pull:127 → down:133 (2b'nin düzeltmesi geçerli)
bash -n / YAML                     OK / geçerli
```

Çakışma yok, iki düzeltme birbirini bozmuyor.

### ⚠️ Gerçek `test` push'u olmadan doğrulanamayanlar

Raporda 8 madde; en önemlileri:
- **Kesinti süresi ~10-20 sn bir *tahmin***, ölçüm değil
- Hangi servislerin `Recreated` olduğu — sunucudaki `.env.test` görülemiyor
- **D-27 çıpasının formatı:** `.Config.Image` digest dönerse `##*:` yanlış tag üretir. İlk deploy'da
  `==> Geri alma çıpası:` satırı log'dan kontrol edilmeli
- Geri almanın kendisi (tatbikat işi, D-29)
- `rollback.sh` hiç çalıştırılmadı

`shellcheck` bu makinede kurulu değil; `bash -n` ve YAML `safe_load` ile doğrulandı.

3 dosya, +258/−18, 5 atomic commit.
