### PR TITLE
ERP E2E aktarım testi rotaya taşınan ekrana göre güncellendi

### DIFF
--- a/apps/frontend/e2e/erp-canli-senaryolar.spec.ts
+++ b/apps/frontend/e2e/erp-canli-senaryolar.spec.ts
@@ -84,10 +84,13 @@ test.describe('ERP canlı senaryoları', () => {
     await page.getByLabel(`${FAKE_ERP_ROWS.transferred.name} satırını seç`).first().check();
     await page.getByRole('button', { name: 'Ürünlere Aktar' }).click();
 
-    const dialog = page.getByRole('dialog');
-    await expect(dialog).toBeVisible();
+    // Aktarım ekranı modal değil, kendi rotası: ürün ve araç ekleme sayfalarıyla
+    // aynı kabuğu kullanıyor.
+    await expect(page).toHaveURL(/\/erp\/aktar$/);
+    const editor = page.getByRole('table');
+    await expect(editor).toBeVisible();
     // Satırda iki açılır liste var (Tip ve Yük Grubu); tip ilk sıradadır.
-    await expect(dialog.getByRole('combobox').first()).toHaveText('Koli');
+    await expect(editor.getByRole('combobox').first()).toHaveText('Koli');
   });
 
   // (4) Sunucuda FourHours kayıtlıysa senkronizasyon sekmesi Günlük göstermez.


### PR DESCRIPTION
"Ürünlere Aktar" artık modal açmıyor, /erp/aktar rotasına gidiyor. Test hâlâ diyalog beklediği için E2E Smoke (ERP) işi zaman aşımına düşüyordu.

Doğrulama rotaya ve ızgara tablosuna bağlandı; kontrol edilen davranış aynı: Box(2) kategorili taslak aktarım ekranında Koli olarak açılıyor.

## Özet

<!-- Bu PR ne yapıyor? Kısa ve net açıklayın. -->

## İlgili User Story / Issue

<!-- Örnek: US-105, #123 -->

## Değişiklik Tipi

- [ ] 🚀 Yeni özellik (feature)
- [ ] 🐛 Bug düzeltme (bugfix)

## Test Edildi mi?

- [ ] Manuel test yapıldı

## Ekran Görüntüleri

<!-- UI değişikliği içeren PR'larda zorunludur; önce/sonra görselleri ekleyin. UI değişikliği yoksa "UI değişikliği yok" yazın. -->

## Kontrol Listesi

- [ ] Kod standartlarına uygun
- [ ] Commit mesajları [commit kurallarına](docs/conventions/commits.md) uygun
- [ ] Linter hataları yok
- [ ] Self-review yapıldı
- [ ] Dokümantasyon güncellendi (gerekiyorsa)

## Ek Notlar

<!-- Reviewer'ların bilmesi gereken ek bilgiler -->
