### PR TITLE
Dependabot: FluentAssertions lisans ve jsdom Node kısıtı için majör ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,12 @@ updates:
       # @types/node major'ı Node major'ını takip eder; CI ve Dockerfile Node 20'de.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+      # jsdom 30 Node ^22.22.2 || ^24.15.0 || >=26 istiyor; CI Node 20 kullanıyor
+      # (ci.yml:77,125 · test-deploy.yml:356 · algorithm-suite.yml:62).
+      # Node 20'de `webidl.util.markAsUncloneable` yok, tüm Vitest worker'ları düşüyor.
+      # CI Node sürümü yükseltildiğinde bu kural KALDIRILMALI. PR #1022 bu nedenle kapatıldı.
+      - dependency-name: "jsdom"
+        update-types: ["version-update:semver-major"]
 
   # ── NuGet / backend ─────────────────────────────────────────
   - package-ecosystem: "nuget"
@@ -87,6 +93,12 @@ updates:
       - dependency-name: "Serilog.AspNetCore"
         update-types: ["version-update:semver-major"]
       - dependency-name: "Swashbuckle.*"
+        update-types: ["version-update:semver-major"]
+      # FluentAssertions 8.0 ile Apache 2.0'dan Xceed Community License'a geçti:
+      # ticari kullanım geliştirici başına yıllık ücretli lisans gerektiriyor
+      # (bkz. docs/adr/ — lisans kararı alınırsa bu kural kaldırılır).
+      # 7.x son Apache lisanslı sürümdür. PR #1025 bu nedenle kapatıldı.
+      - dependency-name: "FluentAssertions"
         update-types: ["version-update:semver-major"]
 
   # ── Docker ──────────────────────────────────────────────────


### PR DESCRIPTION
## Dependabot: iki majör güncelleme kalıcı olarak ertelendi

Bu hafta 7 Dependabot PR'ı açıldı. Beşi merge edildi (#1021, #1023, #1024, #1026, #1028).
Kalan ikisi **merge edilemez** ve her hafta yeniden açılmamaları için ignore kuralı ekleniyor.

---

### 🔴 FluentAssertions 8.x — lisans değişikliği (PR #1025)

FluentAssertions **8.0 ile Apache 2.0'dan Xceed Community License'a geçti.** Ticari projelerde
kullanım artık **geliştirici başına yıllık ücretli lisans** gerektiriyor. Bu bir bağımlılık
güncellemesi değil, repoya giren bir **ticari yükümlülük**.

Kapsam: `CargoPilot.Application.Tests` (1 csproj), **24 `.cs` dosyası**.

CI'ın kırmızı olması ayrı ama ilgili bir sorun: v8 nullability açıklamalarını değiştirdiği için
`!` operatörleri gereksiz kaldı ve SonarAnalyzer **S8969** hata veriyor (`TreatWarningsAsErrors`
açık) — 7 test dosyasında düzeltme gerekiyordu. Yani lisans kabul edilse bile kod eforu var.

**7.x son Apache lisanslı sürümdür.** Bugün 6.12.2'de kalınıyor. Lisans satın alınırsa ya da
[AwesomeAssertions](https://github.com/AwesomeAssertions/AwesomeAssertions) (FluentAssertions 7'nin
Apache lisanslı çatalı) gibi bir alternatife geçilirse bu kural kaldırılmalı ve karar **ADR olarak**
kaydedilmeli.

### ❌ jsdom 30 — CI'ın Node sürümüyle uyumsuz (PR #1022)

```
jsdom@30.0.1  engines: { node: '^22.22.2 || ^24.15.0 || >=26.0.0' }
CI'daki Node: 20   (ci.yml:77,125 · test-deploy.yml:356 · algorithm-suite.yml:62)
```

Node 20'de `webidl.util.markAsUncloneable` yok; tüm Vitest worker'ları başlatılamadan düşüyor:

```
Error: [vitest-pool]: Failed to start forks worker for test files …
Caused by: TypeError: webidl.util.markAsUncloneable is not a function
  ❯ Object.<anonymous> node_modules/jsdom/lib/api.js:12:33
```

Bu, bilinen **Node sapmasının** (yerel v24, CI 20) ilk somut maliyeti. Kural geçicidir —
**CI Node sürümü yükseltildiğinde kaldırılmalı**, yorumda da böyle yazıyor.

---

### Yapılan

`.github/dependabot.yml`'e iki majör ignore kuralı, ikisi de **neden** ve **ne zaman kaldırılacağı**
yorumlarıyla:

| Ekosistem | Paket | Koşul |
|---|---|---|
| nuget | `FluentAssertions` | Lisans kararı alınırsa kaldırılır |
| npm | `jsdom` | CI Node ≥ 22 olduğunda kaldırılır |

Mevcut ignore kuralları deponun yerleşik deseniyle uyumlu (`Microsoft.*`, `System.*`, `three`,
`react-router*` vb. zaten majör-ignore'lu ve hepsinin gerekçesi yorumda yazılı).

YAML doğrulandı (`yaml.safe_load`, 5 ekosistem). Tek dosya.

**Not:** #1025 ve #1022 bu PR merge edildikten sonra gerekçeli yorumla kapatılacak.
