### PR TITLE
Gecelik algoritma koşusu yapılandırılmamışken kırmızı yanmıyor

### DIFF
--- a/.github/workflows/algorithm-suite.yml
+++ b/.github/workflows/algorithm-suite.yml
@@ -144,8 +144,13 @@ jobs:
 
       # Referans yalnızca GEÇEN koşuyla güncellenir. Gerileyen bir koşuyu referans
       # yapmak, gerilemeyi yeni normal hâline getirir ve kapı bir daha ötmez.
+      #
+      # `configured` koşulu şart: koşu adımı atlandığında `exit-code` boş kalır ve
+      # ifade motoru boş dizeyi sayıya çevirdiği için `'' == '0'` DOĞRU döner. Tek
+      # başına exit-code'a bakmak, yapılandırılmamış her gecelik koşuda bu adımı
+      # çalıştırıp var olmayan raporu kopyalatıyor ve işi kırmızıya düşürüyordu.
       - name: Referansı güncelle
-        if: steps.suite.outputs.exit-code == '0'
+        if: steps.config.outputs.configured == 'true' && steps.suite.outputs.exit-code == '0'
         run: |
           mkdir -p "$BASELINE_DIR"
           cp "${APP_DIR}/${{ steps.suite.outputs.report-path }}" "$BASELINE_FILE"


### PR DESCRIPTION
Gecelik `Algoritma Regresyon Koşusu` iki gecedir başarısız: 2026-08-17T03:04 ve 2026-08-18T02:59, ikisi de `schedule` tetiklemesi.

## Sebep

`ALGO_SUITE_API_URL/EMAIL/PASSWORD` tanımlı değil, dolayısıyla `Yapılandırmayı doğrula` adımı `configured=false` yazıyor ve koşu adımı doğru şekilde atlanıyor. Workflow bu durumda **başarılı** bitmek üzere yazılmış; kendi yorumu bunu söylüyor:

> Kimlik bilgileri tanımlı değilse iş sessizce ve BAŞARILI biter. Zamanlanmış bir iş, yapılandırılmamış olduğu için her gece kırmızı yanmamalı.

Ama `Referansı güncelle` adımında yalnız `steps.suite.outputs.exit-code == 0` koşulu vardı. Koşu adımı atlandığı için `exit-code` boş kalıyor ve ifade motoru boş dizeyi sayıya çevirdiği için **` == 0` DOĞRU dönüyor**. Adım çalışıyor, var olmayan raporu kopyalamaya çalışıyor ve `exit 1` veriyor.

Koşum adımlarının durumu bunu doğruluyor:

| Adım | Sonuç |
|---|---|
| Yapılandırmayı doğrula | success |
| Bağımlılıkları yükle | skipped |
| Referans koşuyu geri yükle | skipped |
| Koşuyu çalıştır | skipped |
| Raporu yükle | skipped |
| **Referansı güncelle** | **failure** |
| Sonucu değerlendir | skipped |

`Raporu yükle` adımı aynı tuzağa düşmüyor çünkü karşılaştırması `!= ` — boş dize ile boş dize arasında sayıya çevirme olmuyor.

## Değişiklik

Adıma `configured` koruması eklendi. Tuzağın kendisi yorum olarak yazıldı; koşul sadeleştirilmek istendiğinde tekrar düşülmesin.

## Doğrulama

- `yaml.safe_load` ile ayrıştırıldı, dokuz adımın koşulları tek tek okundu.
- Bu iş yalnız `workflow_dispatch` ve `schedule` ile tetikleniyor; PR üzerinde koşmuyor. Gerçek doğrulama bir sonraki gecelik koşumda görülecek — beklenen sonuç: adım `skipped`, iş `success`.

Secretlar tanımlandığında koşu asıl işini yapmaya başlar; bu PR o kararı içermiyor.