### PR TITLE
audit/ çalışma dizini gitignore'a eklendi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,9 @@ minio-data/
 
 # Serena (yerel LSP/MCP aracı yapılandırması ve önbelleği)
 .serena/
+
+# Denetim çalışma alanı: yol haritası, faz planı ve ajanlara verilecek görev
+# brief'leri. Kalıcı kayıt değil — bir bulgu kalıcılaşacaksa `docs/devops/`
+# (backlog), `docs/adr/` (karar) veya bir issue'ya taşınır. Burada duran her şey
+# geçici koordinasyon malzemesidir ve depo geçmişine girmemelidir.
+audit/


### PR DESCRIPTION
Denetim çalışmasının yol haritası, faz planı ve ajanlara verilecek görev brief'leri `audit/` altında tutuluyor. Bunlar koordinasyon malzemesi — depo geçmişine girmemeli.

Kural yorumda yazılı: bir bulgu kalıcılaşacaksa `docs/devops/devops-backlog.md` (plan), `docs/adr/` (karar) veya bir issue'ya taşınır. `audit/` altında kalan hiçbir şey tek kaynak değildir.

`.claude/` ve `.serena/` ile aynı sınıf. Tek satır + gerekçe yorumu.