### PR TITLE
Terfi: test → main (Dalga 1-2, ERP ekran uyumu, ADR pratiği, Dependabot turu)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,12 @@ updates:
       # @types/node major'ı Node major'ını takip eder; CI ve Dockerfile Node 20'de.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+      # jsdom 30 Node ^22.22.2 || ^24.15.0 || >=26 istiyor; CI Node 20 kullanıyor
+      # (ci.yml:77,125 · test-deploy.yml:356 · algorithm-suite.yml:62).
+      # Node 20'de `webidl.util.markAsUncloneable` yok, tüm Vitest worker'ları düşüyor.
+      # CI Node sürümü yükseltildiğinde bu kural KALDIRILMALI. PR #1022 bu nedenle kapatıldı.
+      - dependency-name: "jsdom"
+        update-types: ["version-update:semver-major"]
 
   # ── NuGet / backend ─────────────────────────────────────────
   - package-ecosystem: "nuget"
@@ -87,6 +93,12 @@ updates:
       - dependency-name: "Serilog.AspNetCore"
         update-types: ["version-update:semver-major"]
       - dependency-name: "Swashbuckle.*"
+        update-types: ["version-update:semver-major"]
+      # FluentAssertions 8.0 ile Apache 2.0'dan Xceed Community License'a geçti:
+      # ticari kullanım geliştirici başına yıllık ücretli lisans gerektiriyor
+      # (bkz. docs/adr/ — lisans kararı alınırsa bu kural kaldırılır).
+      # 7.x son Apache lisanslı sürümdür. PR #1025 bu nedenle kapatıldı.
+      - dependency-name: "FluentAssertions"
         update-types: ["version-update:semver-major"]
 
   # ── Docker ──────────────────────────────────────────────────

--- a/.github/workflows/algorithm-suite.yml
+++ b/.github/workflows/algorithm-suite.yml
@@ -144,8 +144,13 @@ jobs:
 
       # Referans yalnızca GEÇEN koşuyla güncellenir. Gerileyen bir koşuyu referans
       # yapmak, gerilemeyi yeni normal hâline getirir ve kapı bir daha ötmez.
+      #
+      # `configured` koşulu şart: koşu adımı atlandığında `exit-code` boş kalır ve
+      # ifade motoru boş dizeyi sayıya çevirdiği için `'' == '0'` DOĞRU döner. Tek
+      # başına exit-code'a bakmak, yapılandırılmamış her gecelik koşuda bu adımı
+      # çalıştırıp var olmayan raporu kopyalatıyor ve işi kırmızıya düşürüyordu.
       - name: Referansı güncelle
-        if: steps.suite.outputs.exit-code == '0'
+        if: steps.config.outputs.configured == 'true' && steps.suite.outputs.exit-code == '0'
         run: |
           mkdir -p "$BASELINE_DIR"
           cp "${APP_DIR}/${{ steps.suite.outputs.report-path }}" "$BASELINE_FILE"

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: ''
+      skip_backup:
+        description: 'DB yedeği alınamazsa yine de devam et (VERİ KAYBI RİSKİ)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -60,7 +65,13 @@ jobs:
           script: |
             set -e
             TARGET="${{ github.event.inputs.target_ref }}"
-            /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET}"
+            # rollback.sh yedek alınamazsa varsayılan olarak durur; bayrak yalnız
+            # operatör bunu UI'da bilinçli olarak işaretlediğinde geçilir.
+            if [ "${{ github.event.inputs.skip_backup }}" = "true" ]; then
+              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET}" --skip-backup
+            else
+              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET}"
+            fi
 
       - name: Prod sunucusuna rollback yap
         if: github.event.inputs.environment == 'prod'
@@ -72,7 +83,13 @@ jobs:
           script: |
             set -e
             TARGET="${{ github.event.inputs.target_ref }}"
-            /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET}"
+            # rollback.sh yedek alınamazsa varsayılan olarak durur; bayrak yalnız
+            # operatör bunu UI'da bilinçli olarak işaretlediğinde geçilir.
+            if [ "${{ github.event.inputs.skip_backup }}" = "true" ]; then
+              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET}" --skip-backup
+            else
+              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET}"
+            fi
 
       - name: Rollback özeti
         if: always()
@@ -80,5 +97,6 @@ jobs:
           echo "## Rollback Özeti" >> $GITHUB_STEP_SUMMARY
           echo "- **Ortam**: ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Hedef**: ${{ github.event.inputs.target_ref || '(önceki tag)' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Yedek atlandı**: ${{ github.event.inputs.skip_backup }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Tetikleyen**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Zaman**: $(date -u '+%Y-%m-%d %H:%M UTC')" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -40,63 +40,80 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # Kullanıcı girdileri shell gövdesine `${{ }}` ile enterpole edilmez; `env:`
+      # üzerinden değişken olarak geçilir ve shell içinde tırnaklanmış okunur.
       - name: Hedef ref'i doğrula
+        env:
+          TARGET_ENV: ${{ github.event.inputs.environment }}
+          TARGET_REF: ${{ github.event.inputs.target_ref }}
         run: |
-          TARGET="${{ github.event.inputs.target_ref }}"
-          ENV="${{ github.event.inputs.environment }}"
-          echo "Ortam  : ${ENV}"
-          echo "Hedef  : ${TARGET:-'(önceki tag)'}"
+          echo "Ortam  : ${TARGET_ENV}"
+          echo "Hedef  : ${TARGET_REF:-'(önceki tag)'}"
 
-          if [[ -n "${TARGET}" ]]; then
-            if ! git rev-parse --verify "${TARGET}" > /dev/null 2>&1; then
-              echo "::error::Geçersiz ref: ${TARGET}"
+          if [[ -n "${TARGET_REF}" ]]; then
+            if ! git rev-parse --verify "${TARGET_REF}" > /dev/null 2>&1; then
+              echo "::error::Geçersiz ref: ${TARGET_REF}"
               exit 1
             fi
-            echo "Doğrulanan ref: $(git rev-parse --short ${TARGET})"
+            echo "Doğrulanan ref: $(git rev-parse --short "${TARGET_REF}")"
           fi
 
       - name: Test sunucusuna rollback yap
         if: github.event.inputs.environment == 'test'
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          TARGET_REF: ${{ github.event.inputs.target_ref }}
+          SKIP_BACKUP: ${{ github.event.inputs.skip_backup }}
         with:
           host: ${{ secrets.TEST_SSH_HOST }}
           username: root
           key: ${{ secrets.TEST_SSH_PRIVATE_KEY }}
+          # ssh-action, `envs` ile listelenen değişkenleri uzak kabuğa tırnaklayıp
+          # kaçışlayarak aktarır; değerler script metnine gömülmez.
+          envs: TARGET_REF,SKIP_BACKUP
           script: |
             set -e
-            TARGET="${{ github.event.inputs.target_ref }}"
             # rollback.sh yedek alınamazsa varsayılan olarak durur; bayrak yalnız
             # operatör bunu UI'da bilinçli olarak işaretlediğinde geçilir.
-            if [ "${{ github.event.inputs.skip_backup }}" = "true" ]; then
-              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET}" --skip-backup
+            if [ "${SKIP_BACKUP}" = "true" ]; then
+              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET_REF}" --skip-backup
             else
-              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET}"
+              /opt/cargo-pilot/infra/scripts/rollback.sh test "${TARGET_REF}"
             fi
 
       - name: Prod sunucusuna rollback yap
         if: github.event.inputs.environment == 'prod'
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          TARGET_REF: ${{ github.event.inputs.target_ref }}
+          SKIP_BACKUP: ${{ github.event.inputs.skip_backup }}
         with:
           host: ${{ secrets.PROD_SSH_HOST }}
           username: root
           key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          # ssh-action, `envs` ile listelenen değişkenleri uzak kabuğa tırnaklayıp
+          # kaçışlayarak aktarır; değerler script metnine gömülmez.
+          envs: TARGET_REF,SKIP_BACKUP
           script: |
             set -e
-            TARGET="${{ github.event.inputs.target_ref }}"
             # rollback.sh yedek alınamazsa varsayılan olarak durur; bayrak yalnız
             # operatör bunu UI'da bilinçli olarak işaretlediğinde geçilir.
-            if [ "${{ github.event.inputs.skip_backup }}" = "true" ]; then
-              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET}" --skip-backup
+            if [ "${SKIP_BACKUP}" = "true" ]; then
+              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET_REF}" --skip-backup
             else
-              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET}"
+              /opt/cargo-pilot/infra/scripts/rollback.sh prod "${TARGET_REF}"
             fi
 
       - name: Rollback özeti
         if: always()
+        env:
+          TARGET_ENV: ${{ github.event.inputs.environment }}
+          TARGET_REF: ${{ github.event.inputs.target_ref }}
+          SKIP_BACKUP: ${{ github.event.inputs.skip_backup }}
         run: |
           echo "## Rollback Özeti" >> $GITHUB_STEP_SUMMARY
-          echo "- **Ortam**: ${{ github.event.inputs.environment }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Hedef**: ${{ github.event.inputs.target_ref || '(önceki tag)' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Yedek atlandı**: ${{ github.event.inputs.skip_backup }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Tetikleyen**: ${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Ortam**: ${TARGET_ENV}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Hedef**: ${TARGET_REF:-(önceki tag)}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Yedek atlandı**: ${SKIP_BACKUP}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tetikleyen**: ${GITHUB_ACTOR}" >> $GITHUB_STEP_SUMMARY
           echo "- **Zaman**: $(date -u '+%Y-%m-%d %H:%M UTC')" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -452,31 +452,87 @@ jobs:
             echo "==> Bayat GHCR kimlik bilgisi temizleniyor..."
             docker logout ghcr.io >/dev/null 2>&1 || true
 
+            # Geri alma çıpası: hâlihazırda çalışan backend konteynerinin image
+            # referansından mevcut tag türetilir (ör. ghcr.io/...:test-abc1234 -> test-abc1234).
+            # Konteyner yoksa (ilk deploy) boş kalır ve geri alma denenmez.
+            PREV_IMAGE_REF="$(docker inspect --format '{{.Config.Image}}' cargo-pilot-backend-test 2>/dev/null || true)"
+            PREV_IMAGE_TAG="${PREV_IMAGE_REF##*:}"
+
+            # Çıpa doğrulaması: `.Config.Image` digest biçiminde
+            # (ghcr.io/...@sha256:abc...) veya tag'siz dönebilir. Bu durumlarda
+            # `##*:` geçerli bir tag değil, sha hex'i ya da tüm referans üretir.
+            # Geri alma böyle bir değerle denenirse `up` var olmayan bir image
+            # arar ve ortam bugünküne göre DAHA KÖTÜ duruma düşer. Şüpheliyse
+            # çıpa boşaltılır: geri alma atlanır, davranış mevcut hâle eşitlenir.
+            case "$PREV_IMAGE_REF" in
+              *@*)      PREV_IMAGE_TAG="" ;;   # digest referansı, tag yok
+              *:*)      : ;;                   # ref:tag — beklenen biçim
+              *)        PREV_IMAGE_TAG="" ;;   # hiç ':' yok, tag belirtilmemiş
+            esac
+            case "$PREV_IMAGE_TAG" in
+              ""|*/*|*" "*) PREV_IMAGE_TAG="" ;;  # boş, yol parçası ya da boşluk içeriyor
+            esac
+
+            if [ -z "$PREV_IMAGE_TAG" ]; then
+              echo "==> Geri alma çıpası: <yok> (ref='${PREV_IMAGE_REF:-<bos>}' — geri alma atlanacak)"
+            else
+              echo "==> Geri alma çıpası: PREV_IMAGE_TAG=${PREV_IMAGE_TAG}"
+            fi
+
             echo "==> Image'lar GHCR'dan çekiliyor (tag: ${IMAGE_TAG})..."
             IMAGE_TAG="${IMAGE_TAG}" docker compose \
               -f infra/compose/docker-compose.test.yml \
               --env-file infra/env/.env.test \
               pull backend frontend
 
-            echo "==> Eski stack temizleniyor..."
-            docker compose \
-              -f infra/compose/docker-compose.test.yml \
-              --env-file infra/env/.env.test \
-              down --remove-orphans 2>/dev/null || true
-
-            echo "==> Stack ayağa kaldırılıyor (tag: ${IMAGE_TAG})..."
+            # Tüm stack'i `down` etmek mssql ve minio'yu da kapatıyordu; deploy edilen
+            # yalnız backend/frontend olduğu hâlde her deploy 2-3 dk kesinti üretiyordu.
+            # `up -d` yalnız image digest'i veya servis tanımı değişen konteynerleri
+            # yeniden yaratır: backend + frontend yeni tag'e geçer, mssql/minio/ağ/volume
+            # dokunulmadan ayakta kalır. `--remove-orphans` semantiği korunuyor —
+            # compose dosyasından çıkarılmış servislerin artık konteynerleri yine silinir.
+            echo "==> Stack güncelleniyor (tag: ${IMAGE_TAG})..."
             IMAGE_TAG="${IMAGE_TAG}" docker compose \
               -f infra/compose/docker-compose.test.yml \
               --env-file infra/env/.env.test \
-              up -d --no-build
-
-            echo "==> Kullanılmayan eski image'lar temizleniyor..."
-            docker image prune -f
+              up -d --no-build --remove-orphans
 
             echo "==> Backend health (loopback) bekleniyor..."
+            HEALTH_OK=0
             for i in $(seq 1 20); do
-              curl -sf http://127.0.0.1:8081/health >/dev/null && break
-              if [ "$i" = "20" ]; then echo "Backend loopback health basarisiz"; exit 1; fi
+              if curl -sf http://127.0.0.1:8081/health >/dev/null; then HEALTH_OK=1; break; fi
               sleep 5
             done
+
+            # Health düşerse bir önceki image tag'ine tek seferlik geri dönülür.
+            # Geri alma sonucundan bağımsız olarak job kırmızı bırakılır (exit 1):
+            # başarılı bir geri alma "deploy başarılı" anlamına gelmez.
+            # Geri almanın kendisi için ikinci bir geri alma denenmez -> döngü yok.
+            if [ "${HEALTH_OK}" != "1" ]; then
+              echo "Backend loopback health basarisiz (tag: ${IMAGE_TAG})."
+              if [ -n "${PREV_IMAGE_TAG}" ] && [ "${PREV_IMAGE_TAG}" != "${IMAGE_TAG}" ]; then
+                echo "==> Otomatik geri alma: ${PREV_IMAGE_TAG}"
+                IMAGE_TAG="${PREV_IMAGE_TAG}" docker compose \
+                  -f infra/compose/docker-compose.test.yml \
+                  --env-file infra/env/.env.test \
+                  up -d --no-build --remove-orphans || echo "Geri alma komutu hata verdi."
+                for i in $(seq 1 12); do
+                  if curl -sf http://127.0.0.1:8081/health >/dev/null; then
+                    echo "Geri alma tamamlandi, backend ${PREV_IMAGE_TAG} ile saglikli."
+                    break
+                  fi
+                  sleep 5
+                done
+              else
+                echo "Geri donulecek onceki image yok; stack oldugu gibi birakildi."
+              fi
+              echo "Deploy basarisiz."
+              exit 1
+            fi
             echo "Backend loopback health OK."
+
+            # Prune yalnız health doğrulandıktan SONRA çalışır: aksi hâlde bir önceki
+            # sürümün image'ı (aynı tag yeniden push edildiyse dangling'e düşer)
+            # silinir ve geri dönüş için GHCR'dan tekrar pull gerekir.
+            echo "==> Kullanılmayan eski image'lar temizleniyor..."
+            docker image prune -f

--- a/CLICKUP-YAPILACAK.md
+++ b/CLICKUP-YAPILACAK.md
@@ -1,0 +1,102 @@
+# ClickUp — ALG-01…07'yi üst görev + subtask yapısına taşıma
+
+**Durum:** BEKLİYOR — ClickUp rate limit. 2026-08-15 ~16:40 itibarıyla 1390 dk kaldı
+(`retryAfter: 83359 sn`). Okuma da yazma da kapalı. Tahmini açılış: **2026-08-16 ~15:50**.
+
+**Workspace:** `9018951661` · **Liste:** `901820298418` (Ürünleştirme & Sürüm)
+**Atanan:** `176577183` (Doğan Can YILDIZ) · **Statü:** `completed` · **Due:** `2026-08-13`
+
+---
+
+## Neden yeniden oluşturma gerekiyor
+
+`clickup_update_task` bir task'ın **üst görevini değiştiremiyor** (şemada `parent` alanı yok).
+`clickup_merge_tasks` ise kaynak task'ları **yok ediyor** ve subtask yapısı üretmiyor.
+Dolayısıyla tek yol: içeriği oku → subtask olarak yeniden oluştur → orijinali sil.
+
+⚠️ **Sıra kritik:** önce OKU, sonra oluştur, en son sil. Okumadan silme.
+
+---
+
+## Adım 1 — Açıklamaları çek (limit açılınca İLK bunu yap)
+
+Yedisinin de tam `markdown_description`'ı gerekiyor:
+
+```
+clickup_get_task(task_id=<id>, workspace_id=9018951661, include=["description"])
+```
+
+| Kod | task_id | Başlık | Öncelik | Etiketler |
+|---|---|---|---|---|
+| ALG-01 | `86eykmdbb` | Golden-master test altyapısı (CargoPilot.Engine.Tests) | urgent | algoritma, backend |
+| ALG-02 | `86eykmegx` | Optimizasyon motorunu Application katmanına taşı | urgent | algoritma, backend |
+| ALG-03 | `86eykmj9w` | PlacementValidator.cs — sert kısıtları ayır, kopyaları tek kaynağa indir | urgent | algoritma |
+| ALG-04 | `86eykmmwx` | LifoPlacement.cs — bölge mantığını ayır | high | algoritma |
+| ALG-05 | `86eykmqr2` | ItemOrdering + BalanceScoring + VolumeScoring, skor terim toplamına dönüşsün | high | algoritma |
+| ALG-06 | `86eykmrv2` | OptimizationModules bayrakları (dışa açılmaz) | normal | algoritma |
+| ALG-07 | `86eykmt1d` | Kırılganlığı (FragilityType) uçtan uca bağla | high | algoritma |
+
+Çekilen açıklamaları **birebir** koru — bunlar tarihsel kayıt, özetleme.
+
+## Adım 2 — Üst görevi aç
+
+**Ad:** `Optimizasyon motoru modülerleştirme (7 adımlı geçiş)`
+**Etiket:** algoritma, backend · **Öncelik:** urgent · **Statü:** completed · **Due:** 2026-08-13
+
+**Açıklama taslağı:**
+
+> 583 satırlık tek dosya, biri kapatılamaz altı modüle ayrıldı ve Infrastructure'dan Application
+> katmanına taşındı. Bölme biçimi arayüz/plugin değil, motorun doğrudan çağırdığı statik
+> fonksiyonlar — sıcak döngüye tek bir dolaylı çağrı bile eklenmedi.
+>
+> Bölmeden **önce** mevcut davranışı kilitleyen 16 anlık görüntü testi yazıldı. Yedi adımın
+> hiçbirinde bu görüntülerin biri bile kaymadı.
+>
+> Kaynak: [Optimizasyon Motoru Modül Mimarisi](https://claude.ai/code/artifact/786ee87f-0656-4634-b326-74c41b0d9174)
+> · [Algoritma Mimarisi Heyet Kararı](https://claude.ai/code/artifact/45f5bb25-12d1-4c05-ab45-73e05eb0a7c2)
+>
+> **PR:** #935 → #936 → #937 · **Motor testi:** 0 → 33
+>
+> Devamı: bu turda bulunan iki fizik hatası ayrı üst görevde
+> (Motor fizik hataları — denge takası ve LIFO bölge kısıtı, `86eyn1pdt`).
+
+## Adım 3 — Yedisini subtask olarak yeniden oluştur
+
+`clickup_create_task(parent=<üst görev id>, ...)` — başlık, öncelik, statü, atanan, due aynı;
+açıklama Adım 1'de çekilen metin. **Etiket subtask'ta gerekmiyorsa atlanabilir** (bu turda
+açtığım subtask'larda etiket kullanılmadı, üst görevde toplandı).
+
+## Adım 4 — Orijinal 7 task'ı sil
+
+Yalnız Adım 3'ün 7/7 başarılı olduğu doğrulandıktan SONRA:
+`86eykmdbb`, `86eykmegx`, `86eykmj9w`, `86eykmmwx`, `86eykmqr2`, `86eykmrv2`, `86eykmt1d`
+
+---
+
+## Aynı fırsatta bitirilecek yarım iş
+
+Bu turda düz açılan 8 kopyanın 4'ü silindi, **4'ü duruyor** (içerikleri zaten subtask olarak var,
+listede çift görünüyorlar). Limit açılınca bunlar da silinmeli:
+
+- `86eyn1gbr` — INFRA-03
+- `86eyn1gc7` — INFRA-04
+- `86eyn1gfg` — DOC-01
+- `86eyn1gfr` — Texture temizliği
+
+## Ayrıca önerilen (kullanıcı onayı bekliyor)
+
+- **F0-01** (`86eyjm8c3`, kapı yönü hataları — backend) + **F0-04** (`86eyk7hb6`, frontend kapı yönü
+  enum eşlemesi): aynı kusurun iki katmanı, tek üst görev altında toplanabilir.
+- **Birleştirilmemesi önerilen:** F0-03 (fantom bölge cezası) ile ALG-09 (LIFO bölge sert kısıtı) —
+  aynı konuya bakıyor ama farklı zamanlarda, farklı PR'larda çözülmüş iki ayrı hata.
+
+---
+
+## Bu turda tamamlanan yapı (referans)
+
+| Üst görev | id | Subtask'lar |
+|---|---|---|
+| Motor fizik hataları — denge takası ve LIFO bölge kısıtı | `86eyn1pdt` | ALG-08 `86eyn1pek` · ALG-09 `86eyn1pfb` · ALG-10 `86eyn1pgc` |
+| DevOps sertleştirme turu — port, cache, rollback | `86eyn1pgu` | INFRA-02 `86eyn1pj1` · INFRA-03 `86eyn1pka` · INFRA-04 `86eyn1pmv` |
+| Dokümantasyon tazeleme ve depo bakımı | `86eyn1pnu` | DOC-01 `86eyn1ppv` · Texture `86eyn1pr8` |
+</content>

--- a/DEVIR-NOTU.md
+++ b/DEVIR-NOTU.md
@@ -1,0 +1,275 @@
+# Devir Notu — Cargo Pilot DevOps + Algoritma Çalışması
+
+**Son güncelleme:** 2026-08-15 (akşam) · **Oturum 2:** `80a7c72a-5400-43ab-b82a-0f4876e1197e`
+**Durum:** **TAMAMLANDI.** 11 PR merge edildi, `dev → test` terfisi yapıldı, test sunucusuna deploy indi.
+
+Bu dosya işi başka bir oturumda sürdürmek içindir. Önce **§1 Ortam** ve **§2 Git durumu**'nu oku.
+
+> Oturum 1'in (`a648d5f4`) `discovery/*.md` keşif notları `/private/tmp` temizliğinde **kayboldu**.
+> Panel hakem kararları kurtarıldı (§6). Bu dosyadaki sayılar 2026-08-15'te yeniden ölçülmüştür.
+
+---
+
+## 0. Orijinal görev ve ilerleme
+
+| # | İstek | Durum |
+|---|---|---|
+| 1 | İki artifact raporunu incele | ✅ |
+| 2 | DevOps + algoritma tarafını incele, tüm md'leri oku | ✅ 47 md envanterlendi (iki turda) |
+| 3 | Çoklu model/subagent ile tartışarak ilerle, ana oturum orkestrasyon | ✅ 12 ajan koştu (Opus+Sonnet karma) |
+| 4 | Limit dolunca bekle, sıfırlanınca devam | ✅ |
+| 5 | Tüm md'leri güncelle — "bayat bilgi olsun istemiyorum" | ✅ **iki tur**: #993 (19 dosya) + #1007 (11 dosya) |
+| 6 | Grafik + sayısal ağırlıklı raporlar üret | ✅ 2 rapor (§10) |
+
+---
+
+## 1. Ortam
+
+- **.NET SDK 8.0.419**: `~/.dotnet` (PATH'te DEĞİL). Her komuttan önce:
+  ```bash
+  export PATH="$HOME/.dotnet:$PATH"; export DOTNET_CLI_TELEMETRY_OPTOUT=1; export DOTNET_NOLOGO=1
+  ```
+- ⚠️ `dotnet build CargoPilot.slnx` **çalışmıyor** (`MSB4068` — SDK 8.0.419 `.slnx` desteklemiyor).
+  Proje düzeyinde koş: `dotnet test apps/backend/CargoPilot.Engine.Tests`
+- `brew` yok. Node yerelde **v24.18.0**, CI'da **20** (bilinen sapma).
+- `gh` CLI yetkili. GHCR anonim token'ı ile tag listesi çekilebiliyor — **`?n=1000` şart**, yoksa yalnız ilk 100 tag gelir.
+- **Oturum 1'in Python-portu ölçümleri GEÇERSİZ.** Bu oturumun tüm algoritma sayıları gerçek `dotnet test` ile alındı.
+
+---
+
+## 2. Git durumu — 11 PR `dev`'e MERGE EDİLDİ ✅
+
+Hepsi **squash** ile (kural: `feat/fix/chore/infra → dev` squash). Merge sırası riske göre seçildi:
+düşük riskli doküman/temizlik önce, motor değişiklikleri en sonda temiz bir `dev` üzerine.
+
+| Sıra | PR | Dal | Konu | `dev` commit |
+|---|---|---|---|---|
+| 1 | [#993](https://github.com/Divizyon/cargo-pilot/pull/993) | `chore/dokuman-tazeleme` | 20 dosyadaki bayat bilgi | `dc9c8913` |
+| 2 | [#995](https://github.com/Divizyon/cargo-pilot/pull/995) | `chore/olu-texture-temizligi` | Ölü texture, dist 46→26 MB | `5635d8d9` |
+| 3 | [#994](https://github.com/Divizyon/cargo-pilot/pull/994) | `infra/yedekleme-rollback-sertlestirme` | rollback.sh SHA düzeltmesi | `29ffc8cd` |
+| 4 | [#992](https://github.com/Divizyon/cargo-pilot/pull/992) | `infra/ci-cache-ve-deploy-sirasi` | Cache bütçesi + çifte build | `79bd75a4` |
+| 5 | [#991](https://github.com/Divizyon/cargo-pilot/pull/991) | `infra/guvenlik-sertlestirme` | Port maruziyeti + deploy gate | `5f2f8ee6` |
+| 6 | [#989](https://github.com/Divizyon/cargo-pilot/pull/989) | `fix/OPT-01-…` | Denge takası destek doğrulaması | `72e9fdfa` |
+| 7 | [#990](https://github.com/Divizyon/cargo-pilot/pull/990) | `fix/OPT-02-…` | LIFO bölge sert kısıtı | `b12a2e0f` |
+
+**Merge sonrası `dev` doğrulaması (`b12a2e0f`):**
+`Engine.Tests` **61/61 yeşil** · `Infrastructure.Tests` **20/20 yeşil** · **snapshot kayması 0** ·
+çalışma ağacı temiz. İki motor düzeltmesi birbirini bozmadı.
+
+**Sonradan eklenen 4 PR:**
+
+| PR | Konu | `dev` commit |
+|---|---|---|
+| [#1002](https://github.com/Divizyon/cargo-pilot/pull/1002) | Bölge testi sınırları motorun kodundan okunuyor | `7b699f35` |
+| [#997](https://github.com/Divizyon/cargo-pilot/pull/997) | Koordinat standardı Z ekseni (KN-1) — başkasının PR'ı, `dev` ile uyumlulaştırıldı | `62be448f` |
+| [#1006](https://github.com/Divizyon/cargo-pilot/pull/1006) | `.claude/` gitignore'a | `829fb539` |
+| [#1007](https://github.com/Divizyon/cargo-pilot/pull/1007) | Doküman tazeleme **ikinci tur** | `d3033c6f` |
+
+⚠️ Araya başkalarının işi girdi: **#996** (algoritma test aracı), **#998** (içeriksiz `test→dev`),
+**#1004** (koordinat bekleyen kararlar + demo seed kaldırıldı). **#999** ve **#1000** içeriksiz oldukları
+için gerekçeyle kapatıldı. **#1005** (koordinat doküman senkronu) hâlâ AÇIK ve #1007 ile 6 dosyada
+örtüşüyor, 3'ünde çakışıyor — yazarına ne yapılacağı yorumla bildirildi.
+
+**#997 uyumlulaştırmasında yakalanan tuzak:** dalın `BalanceScoring.cs` sürümü
+`if (a.Height != b.Height)` içeriyordu — yani OPT-01'in düzelttiği hatanın yeniden adlandırılmış hâli.
+Çakışma çözümünde `dev`'in mantığı korundu; gözden kaçsaydı OPT-01 sessizce geri alınmış olacaktı.
+
+**Terfi:** `dev → test` (#1003) Terfi workflow'u ile yapıldı, **test sunucusuna deploy başarıyla indi**
+(`Deploy (Test Server): success`). `gh pr merge` terfi PR'larında çalışmaz — bkz. `branching.md`.
+
+**Not:** `docs/dokuman-tazeleme` dalı `chore/dokuman-tazeleme` olarak yeniden adlandırıldı —
+`branching.md` izin verilen türleri `feat/fix/chore/infra/hotfix` ile sınırlıyor, `docs/` yok.
+
+**Push sonrası çıkan tek hata (düzeltildi):** OPT-01 dalı `dev`'in 2 commit gerisindeydi; `dev`'in yeni
+ERP commit'leri `OptimizationItemInput`'tan `ImageUrl` alanını kaldırmıştı ve test girdisi onu
+kullanıyordu (`CS1739`). `dev` merge edildi, alan çıkarıldı, **59/59 yeşil, snapshot kayması 0**
+(commit `5f2b49eb`). Yerelde görülememesinin sebebi dalın eski `dev`'den açılmış olmasıydı.
+
+### Dal içerikleri
+
+| Dal | Commit'ler | İçerik | Net diff |
+|---|---|---|---|
+| `fix/OPT-01-denge-takas-destek-dogrulamasi` | `f9a4383d` test · `a7b4a53a` düzeltme | Denge takasında atlanan destek + taşıyıcı yönü doğrulaması | 7 dosya, +726/−38 |
+| `fix/OPT-02-lifo-bolge-sert-kisiti` | `3d074d2c` test · `af6ac08f` düzeltme | LIFO bölge kısıtı iki kademeli sert kısıt oldu | 3 dosya, +185/−1 |
+| `infra/guvenlik-sertlestirme` | `1e4d0f34` · `773f67e4` · `649f054a` | Loopback health check + 13/14 port `127.0.0.1` + deploy gate | 5 dosya, +22/−28 |
+| `infra/ci-cache-ve-deploy-sirasi` | `2d1992a7` | Cache yazıcısı susturuldu, `infra-images` bloğu kaldırıldı, çifte build tekilleştirildi | 3 dosya, +33/−38 |
+| `chore/dokuman-tazeleme` | 10 commit | 20 bayat md dosyasının düzeltilmesi (#993) | 19 dosya, +333/−74 |
+| `infra/yedekleme-rollback-sertlestirme` | `89b4b2bb` · `6f2925d0` | **Oturum 1'den** — rollback.sh `^2` SHA türetmesi + exec-bit + `WITH CHECKSUM` | — |
+| `chore/olu-texture-temizligi` | `94036039` | **Oturum 1'den** — 4 ölü texture; dist 46 MB → 26 MB | — |
+
+**Birleştirme sırası notu:** `infra/guvenlik-sertlestirme` ve `infra/ci-cache-ve-deploy-sirasi` ikisi de
+`test-deploy.yml`'e dokunuyor ama **farklı bölgelerine** — güvenlik 442/447/497-505 (`deploy-test-server` job'u),
+cache ~77-146 (`build` job'u). Çakışma yok, sıra serbest.
+
+`fix/OPT-02-...` `dev`'den dallandı, OPT-01'i **içermiyor**. İkisi bağımsız; ayrı ayrı alınabilir.
+
+**Proje kuralları:** iş dalları `dev`'den; izin verilen türler **yalnız** `feat/fix/chore/infra/hotfix`
+(`docs/` YOK — doküman işi `chore/`); commit mesajları Türkçe, sade, atomic;
+`feat→dev` squash, terfiler merge commit. **AI imzası / co-author trailer YASAK.**
+
+---
+
+## 3. Bu oturumda uygulanan 4 karar
+
+### K1 · OPT-01 — denge takasında atlanan destek doğrulaması 🔴→✅
+`BalanceScoring.ImproveBalance`, eşit yükseklikli kutu takaslarında (`if (a.H != b.H)`) destek kontrolünü
+atlıyordu → **fiziksel olarak geçersiz plan** ("kutu havada") kullanıcıya "denge iyileştirildi" diye sunuluyordu.
+
+| Ölçüm | Önce | Sonra |
+|---|---|---|
+| Engine testleri | 57 geçti / **2 kaldı** | **59 / 0** |
+| Snapshot kayması | — | **0** (16/16 golden yeşil) |
+| PERF 500 kutu WeightBalance | 20 562 ms | 29 453 ms (**1,43×**) |
+| Doluluk (3 kriter) | %58,4 | %58,4 — değişmedi |
+
+**Hata sentetik değildi:** `InvariantTests(Buyuk500_WeightBalance)` — 500 kutuluk gerçekçi planda 1 kutu
+havada kalıyordu (destek oranı 0,6667 < 0,80 eşiği). Bu bug üretimde plan üretiyordu.
+Yapılan: `a.H != b.H` kaldırıldı · `others` → `othersA`/`othersB` (a↔b kör noktası kapandı) ·
+`PlacementValidator.ViolatesLoadAbove` eklendi (erken çıkışlı O(n)).
+
+### K2 · Güvenlik sertleştirme — kısmi ✅
+13/14 compose port satırı `127.0.0.1`'e çekildi; istisna `docker-compose.monitoring.test.yml:89` (Grafana 3002,
+ikame erişim yolu yok). SSH içi loopback health check eklendi (**port kapatmadan ÖNCEKİ commit** — sıra kritikti).
+`deploy-test-server` artık sağlık doğrulama job'unu bekliyor (CI-03 kapandı).
+**Ertelendi:** 4 fallback parolanın temizliği — gereken 4 GitHub secret tanımlı değil, uygulanırsa CI kırılır.
+Secret adları, 9 satır numarası ve hazır diff `k2-guvenlik.md` raporunda.
+
+### K3 · Cache + çifte build ✅
+Cache **%96,5 dolu** (228 giriş, 9,652 GiB / 10 GiB). `infra-images` tek başına 1,983 GiB = bütçenin %20,5'i;
+kaldırılan adımla artık okunmayacak, ~7 günde organik düşecek. Net **−5 satır**.
+`ci.yml` başarı oranı **%58,8** ölçüldü (oturum 1'in %55,9'u çürütüldü; iki bağımsız ajan aynı sayıyı buldu).
+
+### K4 · OPT-02 — LIFO bölge cezası 🟠→✅
+Oturum 1'de hakem limitte düşmüştü; bu oturumda yeniden koşuldu ve **gerçek `dotnet test` ile ölçerek** karar verdi.
+
+Bölge cezası (2 000) yerçekiminden (1 000 000) **500× zayıftı** → zeminde yer varken bölge daima ihlal ediliyordu.
+**Kazanan çözüm: iki kademeli aday seçimi** — bölge içi geçerli aday varsa yalnız onlar; hiç yoksa bugünkü
+skorlamaya düş. **Katsayı 2 000'de KALDI.**
+
+| Ölçüm | Önce | Sonra |
+|---|---|---|
+| P1 bölge ihlali | 4/8 kutu | **0/8** |
+| P2 bölge ihlali | 2/5 kutu | **0/5** |
+| FillRate (P1 / P2) | 1,0 / 0,2125 | **aynı** — kapasite kaybı yok |
+| Snapshot kayması | — | **0 bayt** |
+| LIFO perf 500 kutu | 9 777 ms | **8 107 ms** (hızlandı) |
+
+**Çürütülen savunma:** "katsayıyı 2 000 000 yap" önerisi P1'i düzeltiyor ama P2'de **1/5 ihlal bırakıyor**
+— eşik kaydırması, garanti değil. Koşulsuz sert eleme de reddedildi: `Lifo_KumelemeKapali`'nin FillRate'ini
+0,5 → 0 yapardı.
+**Belirleyici dayanak:** `GroupZoneTests.cs:46` zaten kesin bölge içermesi iddia ediyor
+(`Z >= zoneStart && Z+Depth <= zoneEnd`) — kodun kendi testi sert kısıt bekliyor, üretim kodu yumuşak ceza
+uyguluyordu. Tutarsızlık.
+
+---
+
+## 4. 🔴 AÇIK GÜVENLİK KONUSU — kullanıcı aksiyonu gerekiyor
+
+Oturum 1'in paneli "SA parolası git geçmişinde" bulgusunu **çürütmüştü** ("yalnız artık var olmayan
+`.env.dev.example` içindeydi"). **Bu çürütme YANLIŞ.**
+
+Bağımsız `git log --all -p -S` kanıtı parolanın gerçekten commit edildiğini gösteriyor:
+- `apps/backend/CargoPilot.WebAPI/appsettings.Development.json` — `fe4c7a65` → `998e04ba`
+- `PRODUCTION_DEPLOYMENT_INFO.md` — `520da7ae`
+
+`docs/devops/known-issues.md` ve `docs/devops/devops-backlog.md`'deki **orijinal uyarı geçerlidir**.
+**Parola rotasyonu hâlâ gerekli.** Git geçmişinden temizlemek ayrı bir iş (history rewrite) ve
+push edilmiş geçmişi etkiler — kullanıcı kararı.
+
+---
+
+## 5. Taze ölçümler (2026-08-15) — oturum 1'in çürütülen sayıları
+
+| Konu | Oturum 1'de yazan | **Gerçek** |
+|---|---|---|
+| Motor boyutu | 927 → "düzeltilmiş" 915 satır | **`dev`'de 915 satır**, 7 dosya (261/240/207/91/71/28/17). 981 ve 986 ölçümleri OPT-01 çalışma ağacının anlarıdır — `dev` değil |
+| Cache doluluk | %107,8 → "düzeltilmiş" %100,35 | **%96,5** — 228 giriş, 9,652 GiB |
+| 7+ gün eski cache | 0 | `created_at`'e göre 5; **`cache-cleanup`'ın kullandığı `last_accessed_at`'e göre 0** → orijinal bulgu ayakta |
+| `ci.yml` başarı | %98,9 (denetim raporu) / %55,9 | **%58,8** (34 koşum) — pencereye göre %81'e kadar |
+| `test-deploy.yml` başarı | %100 | **%96,7** (29/30) |
+| Engine testleri | 33 | **35** attribute |
+| Frontend testleri | 166 test | 16 dosya / **~151** test-case (alt sınır) |
+| GHCR | 171 tag, 3 sürüm | **173 tag** (backend+frontend ayrı), 168 `test-*`, **4** sürüm |
+| Rollback kapsamı | "v0.11+ çalışır" | git'te **14** sürüm tag'i, GHCR'de yalnız **4**'ünün imajı → v0.1–v0.10 rollback İMKÂNSIZ |
+| CodeQL zorunlu check | "PR kapısında" | **değil** — 4 ruleset'in hiçbirinde |
+| Ruleset sayısı | 3 | **4** (`freeze` disabled) |
+| `contents: read` | 8/8 workflow | **7/8** (`promote.yml:55` `contents: write`, meşru) |
+| Açık dependabot PR / alert | — | **0 / 0** |
+| Repo md | 41 dosya / 10.125 satır | **45 / 11.056** (git-takipli, `dev`) — tazeleme sonrası 45 / 11.315 |
+
+Retention **YOK** — 168 `test-*` tag sınırsız birikiyor.
+Son 20 merge PR'ın **20/20'si review'suz**; 4 ruleset'in hepsinde `required_approving_review_count: 0`.
+Son 90 günde **568** commit. En uzun kırmızı seri: **12 ardışık**, `feat/ERP-toplu-iyilestirme`, `Frontend CI` işi.
+
+---
+
+## 6. Kurtarılan panel kararları (oturum 1)
+
+```
+~/.claude-divizyon/projects/-Users-dogancanyildiz-Dev-Divizyon-cargo-pilot/
+  a648d5f4-2481-47c8-a4a9-e524645b5ebc/subagents/workflows/wf_70be7dea-22a/journal.jsonl
+```
+49 satır; 18 `result` girdisi = 15 savunma + 3 hakem kararı. Hakem kararları `karar`,
+`uygulama_adimlari`, `kabul_kriterleri`, `yapilmayacaklar` alanları içeriyor, dosya:satır düzeyinde.
+Çıkarma scripti oturum 2'nin scratchpad'inde (`panel/e39.json` = K1, `e40` = K2, `e41` = K3).
+
+---
+
+## 7. Bilinen borç (bilinçli kapsam dışı bırakıldı)
+
+| ID | Borç | Yer |
+|---|---|---|
+| **OPT-14** | `item.UnloadingOrder ?? -1` sentinel'i GroupId kontrolü yapmıyor | `OptimizationEngine.cs:72` |
+| **OPT-10** | Bölge kısıtı yalnız `LoadingType.Rear` kapsıyor; 5 yükleme tipinin 4'ünde bölge hiç oluşmuyor | `LifoPlacement.cs:53` |
+| — | Eşit bölge bölme kusuru; bölge dar kaldığında yedek kademe devreye giriyor ve ihlal **raporlanmadan** sürüyor | `LifoPlacement.cs:66` |
+| — | Yedek kademeye düşen yerleşim hiçbir yere yazılmıyor — uyarı mekanizması gerekiyor (yeni `UnplacedReason` DEĞİL) | `OptimizationEngine.cs` |
+| — | `ViolatesLoadAbove` için kırılganlık / `MaxWeightOnTop` odaklı doğrudan takas testi yok | `PlacementValidator.cs` |
+| **OPT-05** | `FragilityType`'ın 10 üyesinden 9'u motorda etkisiz; kod yorumu tersini iddia ediyor | `ContaminationFilter.cs` |
+
+**0-efor ekler (kod değişikliği yok, repo ayarı):** CodeQL'i 3 aktif ruleset'e zorunlu check yap ·
+`apps/backend/.github/workflows/ci.yml` ölü workflow'unu sil (olmayan `develop` dalını hedefliyor).
+
+**YAPMA listesi (ölçüldü, değmez):** extreme-point projeksiyonu (4 senaryoda 0,00 puan kazanç) ·
+NuGet cache (cache bütçesi doluyken durumu kötüleştirir) · OPT-04 çoklu-başlangıç (OPT-03 çözülmeden 3-4× süre) ·
+bölge katsayısını 2 000 000 yapmak (P2'de ölçülerek yetersiz çıktı).
+
+---
+
+## 8. Kalan iş
+
+1. **Parola rotasyonu** — §4, kullanıcı aksiyonu. HÂLÂ AÇIK.
+2. **4 GitHub secret tanımı** — sonra K2'nin ertelenen parola temizliği uygulanabilir (`k2-guvenlik.md`'de hazır diff).
+3. **SHA pinleme boşluğu (YENİ):** `test-deploy.yml` e2e job'unda **7 action mutable tag'de**
+   (`:314,317,320,327,340,354,397`). Denetim raporunun "32/32 pinli" iddiası gerçekte **38/45**.
+   Denetimden sonra eklenen job olduğu için ilk pinleme turuna (#942) girmemiş.
+4. **0-efor repo ayarları** — CodeQL'i zorunlu check yap · ölü `apps/backend/.github/workflows/ci.yml`'i sil.
+5. **ClickUp yeniden yapılandırma** — rate limit nedeniyle yarım kaldı, bkz. `CLICKUP-YAPILACAK.md`.
+6. **Borç kalemleri** — §7.
+
+## 10. Üretilen raporlar
+
+| Rapor | Konu | URL |
+|---|---|---|
+| **Denetimin Denetimi** | DevOps: denetim iddiaları vs ölçüm, 3 düzeltme, doküman tazeleme | https://claude.ai/code/artifact/348c0bfb-3dfa-4a5e-8f6e-e5c8a37872a6 |
+| **Kutu Havada, Yük Ters** | Motor: OPT-01 + OPT-02, testle ispat, snapshot güvencesi | https://claude.ai/code/artifact/2c023693-3c38-4087-84ef-cc412c48656f |
+
+İkisi de grafik + sayısal ağırlıklı, kaynak veri `SCRATCH/out/` altındaki ölçüm dosyalarından.
+Kaynak HTML'ler: `out/rapor-devops.html`, `out/rapor-motor.html`.
+
+## 11. Ajan worktree'leri
+
+4 ajan izole `git worktree` kullandı: `.claude/worktrees/agent-*`. **Commit'ler dallarda güvende**,
+worktree'ler silinebilir:
+```bash
+git worktree list          # önce bak
+git worktree remove .claude/worktrees/agent-<id>
+```
+
+## 9. Yeni oturuma öneri
+
+Kullanıcı çoklu subagent + tartışma istiyor; ana oturum **orkestratör** kalmalı.
+Limit riskine karşı her fazı ayrı ajan grubu olarak koş. Hakem/karar ajanlarına **kod değiştirtme** —
+yalnız karar verdir, uygulamayı ayrı ajana yaptır; bu oturumda bu ayrım iyi işledi.
+Ajanlara verdiğin "düzeltme"leri körü körüne kabul ettirme: K3 ajanı benim cache düzeltmemi
+`last_accessed_at` ile sınayıp reddetti ve haklı çıktı.
+</content>

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -14,6 +14,21 @@
 * [Commit Kuralları](docs/conventions/commits.md)
 * [Koordinat Sistemi Standardı](docs/COORDINATE_STANDARD.md)
 * [Koordinat Uyum Raporu](docs/KOORDINAT-UYUM-RAPORU.md)
+* [ADR Kuralı](docs/conventions/adr.md)
+
+## 📐 Mimari Kararlar (ADR)
+
+* [ADR İndeksi ve Kuralları](docs/adr/README.md)
+* [ADR Şablonu](docs/adr/ADR-0000-sablon.md)
+* [ADR-0001 — ERP Bağlantı Mimarisi](docs/adr/ADR-0001-erp-baglanti-mimarisi.md)
+* [ADR-0002 — Optimizasyon Motorunun Modülerleştirilmesi](docs/adr/ADR-0002-optimizasyon-motoru-modulerlestirme.md)
+* [ADR-0003 — LIFO Bölge Kısıtı](docs/adr/ADR-0003-lifo-bolge-sert-kisiti.md)
+* [ADR-0004 — Denge Takasında Çift Yönlü Doğrulama](docs/adr/ADR-0004-denge-takasi-cift-yonlu-dogrulama.md)
+* [ADR-0005 — Modül Bayraklarının Dışa Kapalılığı](docs/adr/ADR-0005-modul-bayraklari-disa-kapali.md)
+* [ADR-0006 — Üç Dallı Terfi Modeli](docs/adr/ADR-0006-uc-dalli-terfi-modeli.md)
+* [ADR-0007 — Docker Build Cache Asimetrisi](docs/adr/ADR-0007-docker-build-cache-asimetrisi.md)
+* [ADR-0008 — SHA Pinleme Sürüm Yükseltmesinden Ayrılır](docs/adr/ADR-0008-sha-pinleme-surum-yukseltmeden-ayri.md)
+* [ADR-0009 — Otomatik Geri Alma Sessizce Başarılı Dönmez](docs/adr/ADR-0009-otomatik-geri-alma-sessizce-basarili-donmez.md)
 
 ## 🛠️ DevOps
 

--- a/apps/backend/CargoPilot.WebAPI/CargoPilot.WebAPI.csproj
+++ b/apps/backend/CargoPilot.WebAPI/CargoPilot.WebAPI.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.30" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.6.29" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.6.30" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />

--- a/apps/backend/docs/erp-integration/data-model.md
+++ b/apps/backend/docs/erp-integration/data-model.md
@@ -1,7 +1,8 @@
 # ERP Entegrasyon — Veri Modeli
 
 > Bu doküman kodun bugünkü halini anlatır. Bağlantı mimarisi kararları için
-> [adr-baglanti-mimarisi.md](./adr-baglanti-mimarisi.md) dosyasına bakın.
+> [ADR-0001 — ERP Bağlantı Mimarisi](../../../../docs/adr/ADR-0001-erp-baglanti-mimarisi.md)
+> dosyasına bakın.
 
 ## Integration
 | Alan | Tip | Not |

--- a/apps/backend/docs/erp-integration/erp-export-kontrati.md
+++ b/apps/backend/docs/erp-integration/erp-export-kontrati.md
@@ -88,4 +88,4 @@ aktarım keyfi seçim yapmadan durur ve neden operasyon loglarına yazılır.
 - Sipariş hangi cariye yazılacak: sabit tek cari mi, plan/müşteri başına mı? (Bugün tek sabit
   `Erp:CustomerCode`.)
 - Yazma yetkili SQL hesabı: okuma için salt-okunur hesap öneriliyor; aktarım açıldığında
-  bu iki tablo için yazma yetkisi gerekir (bkz. `adr-baglanti-mimarisi.md`).
+  bu iki tablo için yazma yetkisi gerekir (bkz. `docs/adr/ADR-0001-erp-baglanti-mimarisi.md`).

--- a/apps/backend/docs/erp-integration/erp-schema-divizyon.md
+++ b/apps/backend/docs/erp-integration/erp-schema-divizyon.md
@@ -8,7 +8,7 @@
 > Veritabanı adı müşteriye göre değişir; `DIVIZYON` yalnızca bu örnek yedeğin adıdır ve
 > kodda varsayılan olarak kullanılmaz — ERP ayarlarındaki "Veritabanı Adı" alanı esastır.
 > Bağlantı için salt-okunur (`db_datareader`) bir SQL login'i önerilir; ağ ön koşulları ve
-> login şablonu için [adr-baglanti-mimarisi.md](./adr-baglanti-mimarisi.md).
+> login şablonu için [ADR-0001 — ERP Bağlantı Mimarisi](../../../../docs/adr/ADR-0001-erp-baglanti-mimarisi.md).
 
 Kaynak: `DIVIZYON.bak` (SQL Server 2019, 4.35 MB)  
 Restore: `erp-schema-inspect` Docker container, port 1435  

--- a/apps/backend/tests/CargoPilot.Application.Tests/CargoPilot.Application.Tests.csproj
+++ b/apps/backend/tests/CargoPilot.Application.Tests/CargoPilot.Application.Tests.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="NSubstitute" Version="6.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/backend/tests/CargoPilot.Application.Tests/CargoPilot.Application.Tests.csproj
+++ b/apps/backend/tests/CargoPilot.Application.Tests/CargoPilot.Application.Tests.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/apps/backend/tests/CargoPilot.Application.Tests/CargoPilot.Application.Tests.csproj
+++ b/apps/backend/tests/CargoPilot.Application.Tests/CargoPilot.Application.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/apps/frontend/e2e/erp-canli-senaryolar.spec.ts
+++ b/apps/frontend/e2e/erp-canli-senaryolar.spec.ts
@@ -84,10 +84,13 @@ test.describe('ERP canlı senaryoları', () => {
     await page.getByLabel(`${FAKE_ERP_ROWS.transferred.name} satırını seç`).first().check();
     await page.getByRole('button', { name: 'Ürünlere Aktar' }).click();
 
-    const dialog = page.getByRole('dialog');
-    await expect(dialog).toBeVisible();
+    // Aktarım ekranı modal değil, kendi rotası: ürün ve araç ekleme sayfalarıyla
+    // aynı kabuğu kullanıyor.
+    await expect(page).toHaveURL(/\/erp\/aktar$/);
+    const editor = page.getByRole('table');
+    await expect(editor).toBeVisible();
     // Satırda iki açılır liste var (Tip ve Yük Grubu); tip ilk sıradadır.
-    await expect(dialog.getByRole('combobox').first()).toHaveText('Koli');
+    await expect(editor.getByRole('combobox').first()).toHaveText('Koli');
   });
 
   // (4) Sunucuda FourHours kayıtlıysa senkronizasyon sekmesi Günlük göstermez.

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@hookform/resolvers": "^5.7.1",
+        "@hookform/resolvers": "^5.8.0",
         "@radix-ui/react-alert-dialog": "^1.1.23",
         "@radix-ui/react-checkbox": "^1.3.11",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -59,7 +59,7 @@
         "three": "^0.162.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
         "zod": "^4.4.3",
-        "zustand": "^5.0.14"
+        "zustand": "^5.0.15"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -71,15 +71,15 @@
         "@types/react": "^18.3.28",
         "@types/react-dom": "^18.3.7",
         "@types/three": "^0.162.0",
-        "@typescript-eslint/eslint-plugin": "^8.66.0",
+        "@typescript-eslint/eslint-plugin": "^8.67.0",
         "@typescript-eslint/parser": "^8.58.2",
         "@vitejs/plugin-react": "^6.0.5",
         "autoprefixer": "^10.5.4",
         "eslint": "^10.8.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.1.0",
-        "eslint-plugin-react-refresh": "^0.5.3",
-        "globals": "^17.9.0",
+        "eslint-plugin-react-refresh": "^0.5.4",
+        "globals": "^17.11.0",
         "husky": "^9.1.7",
         "jsdom": "^27.4.0",
         "lint-staged": "^17.3.0",
@@ -806,9 +806,9 @@
       "license": "MIT"
     },
     "node_modules/@hookform/resolvers": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.7.1.tgz",
-      "integrity": "sha512-8wS/P4UDr5sQDe4nFaV51TVyfDPrWgNIXweqG0Bs9Z5LSuzKLb+RQNPvkN2oHM5SRrJyWrVH/F+LOUcFjUyvwQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.8.0.tgz",
+      "integrity": "sha512-2m6GvRLmYYK1Fwt093lGMf7db9l/+8pNuAtwoNkpBntJT4xcA5lNthYGWKViOc3z2SuaPD0HjE81pyXmqc1JyA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/utils": "^0.3.0"
@@ -836,7 +836,7 @@
         "superstruct": ">=0.12.0",
         "typanion": "^3.3.2",
         "valibot": ">=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc",
-        "vest": ">=3.0.0",
+        "vest": ">=6.0.0",
         "yup": "^1.0.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
@@ -3243,17 +3243,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
-      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/type-utils": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -3266,7 +3266,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.66.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -3296,55 +3296,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
-      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.67.0",
-        "@typescript-eslint/visitor-keys": "8.67.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
-      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.67.0",
-        "eslint-visitor-keys": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.67.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
@@ -3368,29 +3319,15 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
-      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0"
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
       },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/types": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
-      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3417,15 +3354,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
-      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -3438,87 +3375,6 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/project-service": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
-      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.66.0",
-        "@typescript-eslint/types": "^8.66.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
-      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
-      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
-      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.66.0",
-        "@typescript-eslint/tsconfig-utils": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
-        "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
@@ -3564,48 +3420,17 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.67.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
-      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.67.0",
-        "eslint-visitor-keys": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
-      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0"
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3619,111 +3444,16 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/project-service": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
-      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.66.0",
-        "@typescript-eslint/types": "^8.66.0",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
-      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
-      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
-      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.66.0",
-        "@typescript-eslint/tsconfig-utils": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
-        "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
-      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/types": "8.67.0",
         "eslint-visitor-keys": "^5.0.0"
       },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
-      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -5030,9 +4760,9 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
-      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.4.tgz",
+      "integrity": "sha512-7bqTKz7T0r+HKWFarNXByDE9/5+73wI2ru+M3zuqGbR7s/b/5/pQJXZoufWlrngqGqoZto73ZkGumCdLxk+4rw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -5559,9 +5289,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8875,9 +8605,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
-      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.15.tgz",
+      "integrity": "sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -64,7 +64,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.62.1",
-        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.3",
         "@types/node": "^25.9.5",
@@ -2961,9 +2961,9 @@
       }
     },
     "node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2975,9 +2975,18 @@
         "redent": "^3.0.0"
       },
       "engines": {
-        "node": ">=14",
+        "node": ">=22",
         "npm": ">=6",
         "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -39,15 +39,15 @@
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",
     "@types/three": "^0.162.0",
-    "@typescript-eslint/eslint-plugin": "^8.66.0",
+    "@typescript-eslint/eslint-plugin": "^8.67.0",
     "@typescript-eslint/parser": "^8.58.2",
     "@vitejs/plugin-react": "^6.0.5",
     "autoprefixer": "^10.5.4",
     "eslint": "^10.8.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.0",
-    "eslint-plugin-react-refresh": "^0.5.3",
-    "globals": "^17.9.0",
+    "eslint-plugin-react-refresh": "^0.5.4",
+    "globals": "^17.11.0",
     "husky": "^9.1.7",
     "jsdom": "^27.4.0",
     "lint-staged": "^17.3.0",
@@ -62,7 +62,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@hookform/resolvers": "^5.7.1",
+    "@hookform/resolvers": "^5.8.0",
     "@radix-ui/react-alert-dialog": "^1.1.23",
     "@radix-ui/react-checkbox": "^1.3.11",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -109,6 +109,6 @@
     "three": "^0.162.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^4.4.3",
-    "zustand": "^5.0.14"
+    "zustand": "^5.0.15"
   }
 }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.62.1",
-    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.3",
     "@types/node": "^25.9.5",

--- a/apps/frontend/src/components/shared/FormWithPreviewLayout.tsx
+++ b/apps/frontend/src/components/shared/FormWithPreviewLayout.tsx
@@ -19,7 +19,7 @@ export function FormWithPreviewLayout({
   return (
     <div className={cn('flex h-full flex-col', className)}>
       <div className="grid min-h-0 flex-1 grid-cols-5 gap-6 overflow-hidden">
-        <div className="relative col-span-3 flex min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-card">
+        <div className="relative col-span-3 flex min-h-0 flex-col overflow-hidden rounded-2xl border border-border bg-card">
           <div className="flex-1 overflow-y-auto p-5 pb-24 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
             {formContent}
           </div>

--- a/apps/frontend/src/components/shared/layouts/DashboardLayout.tsx
+++ b/apps/frontend/src/components/shared/layouts/DashboardLayout.tsx
@@ -365,6 +365,7 @@ const FIXED_HEIGHT_ROUTE_PATTERNS = [
   /^\/products\/[^/]+\/edit$/,
   /^\/vehicles\/new$/,
   /^\/vehicles\/[^/]+\/edit$/,
+  /^\/erp\/aktar$/,
 ];
 
 function checkIsFixedHeightRoute(pathname: string): boolean {

--- a/apps/frontend/src/features/data-management/imports/components/BulkImportDialog.test.tsx
+++ b/apps/frontend/src/features/data-management/imports/components/BulkImportDialog.test.tsx
@@ -475,6 +475,9 @@ describe('BulkImportDialog — ürün formu kuralları', () => {
     const user = userEvent.setup();
     renderCreateDialog([makeRow('a')]);
 
+    // Rotasyon kutucukları satırın ek alanlarında; kilit kuralı değişmedi, yeri değişti.
+    await user.click(screen.getByRole('button', { name: 'Urun a — ek alanlar' }));
+
     expect(screen.getByRole('checkbox', { name: 'Urun a — Z ekseni' })).toBeEnabled();
 
     await user.click(screen.getByRole('button', { name: 'Urun a — Yük Kısıtları: Normal' }));

--- a/apps/frontend/src/features/data-management/imports/components/BulkImportDialog.tsx
+++ b/apps/frontend/src/features/data-management/imports/components/BulkImportDialog.tsx
@@ -1,13 +1,21 @@
-import { useMemo, useRef, useState, type ChangeEvent, type DragEvent } from 'react';
+import {
+  Fragment,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+  type ReactNode,
+} from 'react';
 import * as XLSX from 'xlsx';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronDown, Download, ExternalLink, FileUp, Plus, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import { ImportSummaryPanel } from '@/features/data-management/imports/components/ImportSummaryPanel';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import {
   Select,
   SelectContent,
@@ -55,6 +63,11 @@ interface BulkImportDialogProps {
   draftItemIds?: Record<string, string>;
   /** 'update' mode changes dialog title and confirm button text for UpdatePending flow. */
   mode?: 'import' | 'update';
+  /**
+   * Rota yüzeyinde çizer: modal kabuğu yerine ürün/araç ekleme sayfalarındaki kart.
+   * Başlık ve açıklama sayfaya ait olduğu için burada yalnızca sayaç şeridi kalır.
+   */
+  asPage?: boolean;
 }
 
 // ─── Row model ────────────────────────────────────────────────────────────────
@@ -404,6 +417,97 @@ function confirmButtonLabel({
   return `${validRowCount} Ürün Ekle`;
 }
 
+// ─── Editor shell ─────────────────────────────────────────────────────────────
+
+interface EditorShellProps {
+  asPage: boolean;
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description: ReactNode;
+  /** Hata ve hazır sayaçları; ikisi de sıfırken null gelir. */
+  badges: ReactNode;
+  /** Yalnızca sayfa kabuğunda: kartı açan bölüm başlığı. */
+  sectionTitle: string;
+  /** Yalnızca sayfa kabuğunda: sağ sütun. Modalde yer olmadığı için çizilmez. */
+  summary: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Düzenleme ızgarasının dış çerçevesi. Aynı içerik iki yüzeyde çizilir: ürün
+ * ekranındaki Excel akışında modal, ERP aktarımında rota. Yalnızca kabuk değişir —
+ * ızgara, doğrulama ve gönderim kodu tek yerde kalır.
+ *
+ * Sayfa kabuğunda başlık ve açıklama sayfaya aittir (ürün/araç ekleme sayfalarında
+ * olduğu gibi kartın dışında durur), bu yüzden kart yalnızca sayaç şeridini taşır.
+ */
+function EditorShell({
+  asPage,
+  open,
+  onClose,
+  title,
+  description,
+  badges,
+  sectionTitle,
+  summary,
+  children,
+}: EditorShellProps) {
+  if (asPage) {
+    return (
+      /*
+        Ürün ve araç detay sayfalarındaki iskeletin aynısı: solda düzenleme kartı,
+        sağda bilgi paneli. Oran birebir 3/5 değil — ızgara 17 sütunlu olduğu için
+        panel sabit genişlikte kalır ve yalnızca xl'den itibaren çizilir; daha dar
+        ekranda tablo tam genişliği kullanır.
+      */
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 overflow-hidden xl:grid-cols-5">
+        <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-border bg-card xl:col-span-3">
+          {/*
+            Kart, ürün ve araç formlarındaki gibi bir bölüm başlığıyla açılır; sayaçlar
+            aynı satırın sağında durur. Önce yalnızca sağa yaslı bir rozet şeridi vardı
+            ve kartın girişi diğer ekranlara benzemiyordu.
+          */}
+          <div className="flex flex-none items-center justify-between gap-3 border-b px-5 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+              {sectionTitle}
+            </p>
+            <div className="flex items-center gap-2">{badges}</div>
+          </div>
+          {children}
+        </div>
+        <aside className="hidden min-h-0 min-w-0 xl:col-span-2 xl:flex xl:flex-col">
+          {summary}
+        </aside>
+      </div>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      {/*
+        Bu diyalog küçük bir onay kutusu değil, sayfa boyutunda bir düzenleme yüzeyi.
+        Ürün/araç ekleme sayfalarındaki kart diliyle aynı yarıçapı taşır; küçük
+        diyaloglar varsayılan `rounded-lg` ile kalır.
+      */}
+      <DialogContent className="flex h-[78vh] w-[95vw] max-w-[1280px] flex-col gap-0 overflow-hidden rounded-2xl p-0 sm:rounded-2xl">
+        <DialogHeader className="flex-none border-b px-6 py-4 pr-14">
+          <div className="flex items-center justify-between">
+            <div>
+              <DialogTitle className="text-xl font-bold tracking-tight text-foreground">
+                {title}
+              </DialogTitle>
+              <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>
+            </div>
+            <div className="mr-4 flex items-center gap-2">{badges}</div>
+          </div>
+        </DialogHeader>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // ─── Main dialog ──────────────────────────────────────────────────────────────
 
 export function BulkImportDialog({
@@ -412,11 +516,20 @@ export function BulkImportDialog({
   initialRows,
   draftItemIds,
   mode = 'import',
+  asPage = false,
 }: BulkImportDialogProps) {
   const isUpdate = mode === 'update';
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [rows, setRows] = useState<EditableRow[]>(() => initialRows ?? []);
   const [apiErrors, setApiErrors] = useState<string[]>([]);
+  /**
+   * Açılmış satırlar. Nadiren değişen alanlar (istif, katman, rotasyon, notlar)
+   * ana satırdan çıkarıldı; 17 sütun sağ özet paneliyle birlikte ekrana sığmıyor
+   * ve yatay kaydırma ürün adını görüş alanından çıkarıyordu. Alanlar silinmedi,
+   * bir tık ötede ve düzenlenebilir. Doğrulanan sekiz alanın tamamı ana satırda
+   * kalır, yani hiçbir hata buranın arkasına saklanmaz.
+   */
+  const [expandedRowIds, setExpandedRowIds] = useState<Set<string>>(() => new Set());
   /** Kısmi aktarım sonrası diyalogda kalan satırların özeti. */
   const [remainingNotice, setRemainingNotice] = useState<string | null>(null);
 
@@ -469,6 +582,13 @@ export function BulkImportDialog({
   );
   const errorRowCount = errorRowIds.size;
   const validRowCount = rows.length - errorRowCount;
+  /** Alan bazlı hata sayımı; özet panelindeki engel dökümünü besler. */
+  const errorFieldCounts = validations.reduce<Record<string, number>>((acc, validation) => {
+    for (const field of Object.keys(validation.errors)) {
+      acc[field] = (acc[field] ?? 0) + 1;
+    }
+    return acc;
+  }, {});
   const isDraftPending = updateDraftItem.isPending || bulkApproveDraft.isPending;
   const canImport = validRowCount > 0 && !bulkCreate.isPending && !isDraftPending;
   const confirmLabel = confirmButtonLabel({
@@ -594,6 +714,9 @@ export function BulkImportDialog({
 
   function handleClose() {
     onOpenChange(false);
+    // Rota kabuğunda bileşen zaten sökülüyor; satırları burada boşaltmak gezinmeden
+    // önce bir kare boş ızgara çizdirirdi.
+    if (asPage) return;
     setRows([]);
     setApiErrors([]);
     setRemainingNotice(null);
@@ -672,125 +795,157 @@ export function BulkImportDialog({
 
   // ─── Table state: editable grid ───────────────────────────────────────────
 
+  const editorTitle = isUpdate
+    ? 'ERP Güncellemeyi Onayla'
+    : draftItemIds
+      ? ERP_TERM.approve
+      : 'Toplu Ürün İçe Aktar';
+
+  const editorDescription = (
+    <>
+      Hücreleri tıklayarak doğrudan düzenleyin. Kırmızı alanları düzeltin, ardından{' '}
+      {draftItemIds ? 'ürünlere aktarın.' : 'içe aktarın.'}
+    </>
+  );
+
+  const editorBadges =
+    errorRowCount > 0 || validRowCount > 0 ? (
+      <>
+        {errorRowCount > 0 && (
+          <span className="rounded-full bg-destructive/10 px-3 py-1 text-xs font-medium text-destructive">
+            {errorRowCount} satırda hata var
+          </span>
+        )}
+        {/* Hata rozeti token'dan geldiği için koyu temada uyum sağlıyordu; başarı
+            rozetinin karşılığı olmadığından ErpConnectionStatusCard'daki aynı
+            yeşil tonları kullanır. */}
+        {validRowCount > 0 && (
+          <span className="rounded-full bg-green-100 px-3 py-1 text-xs font-medium text-green-800 dark:bg-green-900/60 dark:text-green-300">
+            {validRowCount} ürün aktarıma hazır
+          </span>
+        )}
+      </>
+    ) : null;
+
   return (
-    <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="flex h-[78vh] w-[95vw] max-w-[1280px] flex-col gap-0 overflow-hidden p-0">
-        {/* Header */}
-        <DialogHeader className="flex-none border-b px-6 py-4 pr-14">
-          <div className="flex items-center justify-between">
-            <div>
-              <DialogTitle>
-                {isUpdate
-                  ? 'ERP Güncellemeyi Onayla'
-                  : draftItemIds
-                    ? ERP_TERM.approve
-                    : 'Toplu Ürün İçe Aktar'}
-              </DialogTitle>
-              <p className="mt-0.5 text-xs text-muted-foreground">
-                Hücreleri tıklayarak doğrudan düzenleyin. Kırmızı alanları düzeltin, ardından{' '}
-                {draftItemIds ? 'ürünlere aktarın.' : 'içe aktarın.'}
-              </p>
-            </div>
-            <div className="mr-4 flex items-center gap-2">
-              {errorRowCount > 0 && (
-                <span className="rounded-full bg-destructive/10 px-3 py-1 text-xs font-medium text-destructive">
-                  {errorRowCount} satırda hata var
-                </span>
-              )}
-              {validRowCount > 0 && (
-                <span className="rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-700">
-                  {validRowCount} ürün aktarıma hazır
-                </span>
-              )}
-            </div>
-          </div>
-        </DialogHeader>
+    <EditorShell
+      asPage={asPage}
+      open={open}
+      onClose={handleClose}
+      title={editorTitle}
+      description={editorDescription}
+      badges={editorBadges}
+      sectionTitle={`${isUpdate ? 'Güncellenecek' : 'Aktarılacak'} Ürünler (${rows.length})`}
+      summary={
+        <ImportSummaryPanel
+          rows={rows}
+          errorRowCount={errorRowCount}
+          validRowCount={validRowCount}
+          errorFieldCounts={errorFieldCounts}
+        />
+      }
+    >
+      {/* Kısmi aktarım özeti */}
+      {remainingNotice && (
+        <div className="flex-none border-b border-amber-200 bg-amber-50 px-6 py-2" role="status">
+          <p className="text-xs font-medium text-amber-800">{remainingNotice}</p>
+        </div>
+      )}
 
-        {/* Kısmi aktarım özeti */}
-        {remainingNotice && (
-          <div className="flex-none border-b border-amber-200 bg-amber-50 px-6 py-2" role="status">
-            <p className="text-xs font-medium text-amber-800">{remainingNotice}</p>
-          </div>
-        )}
+      {/* API errors */}
+      {apiErrors.length > 0 && (
+        <div className="flex-none border-b border-destructive/20 bg-destructive/5 px-6 py-2">
+          <p className="mb-1 text-xs font-semibold text-destructive">
+            {draftItemIds
+              ? `${apiErrors.length} satır atlandı:`
+              : `Sunucu ${apiErrors.length} satırı reddetti:`}
+          </p>
+          <ul className="list-inside list-disc space-y-0.5">
+            {apiErrors.map((e, i) => (
+              <li key={i} className="text-xs text-destructive">
+                {e}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
-        {/* API errors */}
-        {apiErrors.length > 0 && (
-          <div className="flex-none border-b border-destructive/20 bg-destructive/5 px-6 py-2">
-            <p className="mb-1 text-xs font-semibold text-destructive">
-              {draftItemIds
-                ? `${apiErrors.length} satır atlandı:`
-                : `Sunucu ${apiErrors.length} satırı reddetti:`}
-            </p>
-            <ul className="list-inside list-disc space-y-0.5">
-              {apiErrors.map((e, i) => (
-                <li key={i} className="text-xs text-destructive">
-                  {e}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
+      {/*
+        Alt boşluk yüzen aksiyon çubuğunun altında satır bırakmaz. Yatay kaydırma
+        açık: sağ özet paneli ürün/araç sayfalarındaki 2/5 oranına çıkınca ızgaraya
+        ~990px kalıyor ve 17 sütun oraya sığmıyor. `ProductTable` ve `ERPItemsTable`
+        da geniş tabloları aynı şekilde `min-w` + yatay kaydırma ile çözüyor.
+      */}
+      <div className="flex-1 overflow-y-auto overflow-x-hidden pb-24">
+        <table className="w-full table-fixed border-separate border-spacing-0 text-xs">
+          <thead className="sticky top-0 z-10 bg-muted/60 backdrop-blur-sm">
+            {/*
+              Harf aralığı bilinçli olarak dar: `table-fixed` altında sütunlar yüzdeyle
+              bölüşüyor ve başlıklar `whitespace-nowrap`. `tracking-widest` denendi ve
+              "GENİŞLİK (X) *" gibi başlıkları hücresinden taşırıp komşusunun üstüne
+              bindirdi. Bölüm başlığında yer bol olduğu için orada geniş aralık kalabilir.
+            */}
+            <tr className="text-left align-top text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+              {/*
+                Yüzdeler + sabit sütunlar %100'ü aşmamalı. İkinci sütun satır açıcıdır;
+                nadiren değişen alanlar oraya taşındığı için ana satır artık yatay
+                kaydırma olmadan sığıyor.
 
-        {/* Scrollable table */}
-        <div className="flex-1 overflow-y-auto overflow-x-hidden">
-          <table className="w-full table-fixed border-separate border-spacing-0 text-xs">
-            <thead className="sticky top-0 z-10 bg-muted/60 backdrop-blur-sm">
-              <tr className="text-left text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                <th className="w-7 border-b px-1 py-1.5 text-center">#</th>
-                <th className="w-[11%] whitespace-nowrap border-b px-2 py-1.5">Ürün Adı *</th>
-                <th className="w-[8%] whitespace-nowrap border-b px-2 py-1.5">SKU *</th>
-                <th className="w-[7%] whitespace-nowrap border-b px-2 py-1.5">Tip *</th>
-                <th className="w-[7%] whitespace-nowrap border-b px-2 py-1.5">
-                  {DIMENSION_LABEL.width} *
-                </th>
-                <th className="w-[7%] whitespace-nowrap border-b px-2 py-1.5">
-                  {DIMENSION_LABEL.height} *
-                </th>
-                <th className="w-[7%] whitespace-nowrap border-b px-2 py-1.5">
-                  {DIMENSION_LABEL.length} *
-                </th>
-                <th className="w-[7%] whitespace-nowrap border-b px-2 py-1.5">Ağırlık *</th>
-                <th className="w-[9%] whitespace-nowrap border-b px-2 py-1.5">
-                  <div className="flex items-center justify-between gap-1">
-                    Yük Kısıtları
-                    <ColumnBulkFill
-                      title="Yük Kısıtları"
-                      options={FRAGILITY_FILL_OPTIONS}
-                      filledCount={filledFragilityCount}
-                      onApply={(values, overwrite) => fillFragility(values.map(Number), overwrite)}
-                    />
-                  </div>
-                </th>
-                <th className="w-[11%] whitespace-nowrap border-b px-2 py-1.5">
-                  <div className="flex items-center justify-between gap-1">
-                    Yük Grubu *
-                    <ColumnBulkFill
-                      title="Yük Grubu"
-                      options={LOAD_GROUP_FILL_OPTIONS}
-                      single
-                      filledCount={filledLoadGroupCount}
-                      onApply={fillLoadGroups}
-                    />
-                  </div>
-                </th>
-                <th className="w-[5%] whitespace-nowrap border-b px-1 py-1.5 text-center">İstif</th>
-                <th className="w-[7%] whitespace-nowrap border-b px-2 py-1.5">Katman Sayısı</th>
-                <th className="w-7 whitespace-nowrap border-b px-1 py-1.5 text-center">X</th>
-                <th className="w-7 whitespace-nowrap border-b px-1 py-1.5 text-center">Y</th>
-                <th className="w-7 whitespace-nowrap border-b px-1 py-1.5 text-center">Z</th>
-                <th className="whitespace-nowrap border-b px-2 py-1.5">Notlar</th>
-                <th className="w-8 border-b px-1 py-1.5" />
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row, idx) => {
-                const errs = validations.find((v) => v.id === row._id)?.errors ?? {};
-                const hasRowError = Object.keys(errs).length > 0;
-                // Aynı görünen hücre kontrolleri ekran okuyucuda satırla birlikte anılır.
-                const rowLabel = row.name.trim() || `${idx + 1}. satır`;
-                return (
+                Başlıklarda `whitespace-nowrap` yok: uzun etiket hücresine sığmayınca
+                komşusunun üstüne binmek yerine alt satıra geçer.
+              */}
+              <th className="w-7 border-b px-1 py-1.5 text-center">#</th>
+              <th className="w-8 border-b px-1 py-1.5">
+                <span className="sr-only">Ayrıntıyı aç</span>
+              </th>
+              <th className="w-[16%] border-b px-2 py-1.5">Ürün Adı *</th>
+              <th className="w-[10%] border-b px-2 py-1.5">SKU *</th>
+              <th className="w-[10%] border-b px-2 py-1.5">Tip *</th>
+              <th className="w-[8%] border-b px-2 py-1.5">{DIMENSION_LABEL.width} *</th>
+              <th className="w-[8%] border-b px-2 py-1.5">{DIMENSION_LABEL.height} *</th>
+              <th className="w-[8%] border-b px-2 py-1.5">{DIMENSION_LABEL.length} *</th>
+              <th className="w-[8%] border-b px-2 py-1.5">Ağırlık *</th>
+              {/*
+                Toplu doldurma düğmesi etiketin altında durur. `justify-between` ile
+                yan yanayken etiket iki satıra düştüğü anda düğme sağda asılı kalıyor
+                ve hangi sütuna ait olduğu okunmuyordu.
+              */}
+              <th className="w-[11%] border-b px-2 py-1.5 align-top">
+                <div className="flex flex-col items-start gap-1">
+                  <span>Yük Kısıtları</span>
+                  <ColumnBulkFill
+                    title="Yük Kısıtları"
+                    options={FRAGILITY_FILL_OPTIONS}
+                    filledCount={filledFragilityCount}
+                    onApply={(values, overwrite) => fillFragility(values.map(Number), overwrite)}
+                  />
+                </div>
+              </th>
+              <th className="w-[12%] border-b px-2 py-1.5 align-top">
+                <div className="flex flex-col items-start gap-1">
+                  <span>Yük Grubu *</span>
+                  <ColumnBulkFill
+                    title="Yük Grubu"
+                    options={LOAD_GROUP_FILL_OPTIONS}
+                    single
+                    filledCount={filledLoadGroupCount}
+                    onApply={fillLoadGroups}
+                  />
+                </div>
+              </th>
+              <th className="w-8 border-b px-1 py-1.5" />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => {
+              const errs = validations.find((v) => v.id === row._id)?.errors ?? {};
+              const hasRowError = Object.keys(errs).length > 0;
+              // Aynı görünen hücre kontrolleri ekran okuyucuda satırla birlikte anılır.
+              const rowLabel = row.name.trim() || `${idx + 1}. satır`;
+              const isExpanded = expandedRowIds.has(row._id);
+              return (
+                <Fragment key={row._id}>
                   <tr
-                    key={row._id}
                     className={cn(
                       'transition-colors',
                       hasRowError ? 'bg-destructive/[0.04]' : 'hover:bg-muted/30',
@@ -799,6 +954,33 @@ export function BulkImportDialog({
                     {/* Row number */}
                     <td className="border-b border-border/40 px-1 py-0.5 text-center text-[10px] text-muted-foreground">
                       {idx + 1}
+                    </td>
+
+                    {/* Ayrıntı açıcı */}
+                    <td className="border-b border-border/40 px-1 py-0.5">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                        aria-label={`${rowLabel} — ek alanlar`}
+                        aria-expanded={isExpanded}
+                        onClick={() =>
+                          setExpandedRowIds((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(row._id)) next.delete(row._id);
+                            else next.add(row._id);
+                            return next;
+                          })
+                        }
+                      >
+                        <ChevronDown
+                          className={cn(
+                            'h-3.5 w-3.5 transition-transform',
+                            isExpanded && 'rotate-180',
+                          )}
+                        />
+                      </Button>
                     </td>
 
                     {/* Ürün Adı */}
@@ -913,86 +1095,6 @@ export function BulkImportDialog({
                       />
                     </td>
 
-                    {/* İstiflenebilir */}
-                    <td className="border-b border-border/40 px-1 py-0.5 text-center">
-                      <Checkbox
-                        aria-label={`${rowLabel} — İstiflenebilir`}
-                        checked={row.isStackable}
-                        onCheckedChange={(checked) =>
-                          patchRow(row._id, { isStackable: Boolean(checked) })
-                        }
-                        className="h-4 w-4"
-                      />
-                    </td>
-
-                    {/* Katman Sayısı */}
-                    <td className="border-b border-border/40 px-2 py-0.5">
-                      <TextCell
-                        value={row.maxStackCount}
-                        onChange={(v) => patchRow(row._id, { maxStackCount: v })}
-                        type="number"
-                      />
-                    </td>
-
-                    {/* X/Y/Z rotasyon — tip ve kısıt kaynaklı kilitler ürün formundaki gibidir. */}
-                    <td className="border-b border-border/40 px-1 py-0.5 text-center">
-                      <Checkbox
-                        aria-label={`${rowLabel} — X ekseni`}
-                        checked={row.allowRotateX}
-                        disabled={row.tip === 'varil'}
-                        onCheckedChange={(checked) =>
-                          patchRow(row._id, { allowRotateX: Boolean(checked) })
-                        }
-                        className="h-4 w-4"
-                      />
-                    </td>
-                    <td className="border-b border-border/40 px-1 py-0.5 text-center">
-                      <Checkbox
-                        aria-label={`${rowLabel} — Y ekseni`}
-                        checked={row.allowRotateY}
-                        disabled={row.tip === 'palet'}
-                        onCheckedChange={(checked) =>
-                          patchRow(row._id, { allowRotateY: Boolean(checked) })
-                        }
-                        className="h-4 w-4"
-                      />
-                    </td>
-                    <td className="border-b border-border/40 px-1 py-0.5 text-center">
-                      <Checkbox
-                        aria-label={`${rowLabel} — Z ekseni`}
-                        checked={row.allowRotateZ}
-                        disabled={
-                          Number(row.fragility) >= 1 || row.tip === 'varil' || row.tip === 'palet'
-                        }
-                        onCheckedChange={(checked) =>
-                          patchRow(row._id, { allowRotateZ: Boolean(checked) })
-                        }
-                        className="h-4 w-4"
-                      />
-                    </td>
-
-                    {/* Notlar */}
-                    <td className="border-b border-border/40 px-2 py-0.5">
-                      <TooltipProvider delayDuration={300}>
-                        <Tooltip open={row.notes.trim() ? undefined : false}>
-                          <TooltipTrigger asChild>
-                            <div>
-                              <TextCell
-                                value={row.notes}
-                                onChange={(v) => patchRow(row._id, { notes: v })}
-                              />
-                            </div>
-                          </TooltipTrigger>
-                          <TooltipContent
-                            side="top"
-                            className="max-w-64 whitespace-pre-wrap break-words"
-                          >
-                            {row.notes}
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    </td>
-
                     {/* Sil */}
                     <td className="border-b border-border/40 px-1 py-0.5">
                       <Button
@@ -1008,93 +1110,191 @@ export function BulkImportDialog({
                       </Button>
                     </td>
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
 
-        {/* Footer */}
-        <div className="flex flex-none items-center justify-between border-t bg-background px-6 py-3">
-          <div className="flex items-center gap-2">
-            {/*
+                  {/*
+                  Ana satırdan çıkarılan alanlar. Hiçbiri silinmedi; burada etiketli
+                  olarak ve ürün formundaki bölüm diliyle duruyorlar. Notlar burada
+                  tam genişlik bulur — ızgarada tek hücreye sıkışıyordu.
+                */}
+                  {isExpanded && (
+                    <tr className="bg-muted/20">
+                      <td colSpan={12} className="border-b border-border/40 px-4 py-3">
+                        {/*
+                          Tek sıra: sayısal alan solda, kutucuk grupları yan yana,
+                          notlar en sağda kalan genişliği alır.
+                        */}
+                        <div className="flex flex-wrap items-start gap-x-6 gap-y-3">
+                          <div className="flex w-24 shrink-0 flex-col gap-1.5">
+                            <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                              Katman Sayısı
+                            </span>
+                            <TextCell
+                              value={row.maxStackCount}
+                              onChange={(v) => patchRow(row._id, { maxStackCount: v })}
+                              type="number"
+                            />
+                          </div>
+
+                          {/* X/Y/Z rotasyon — tip ve kısıt kaynaklı kilitler ürün formundaki gibidir. */}
+                          <div className="flex shrink-0 flex-col gap-1.5">
+                            <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                              Eksen Rotasyonu
+                            </span>
+                            <div className="flex h-7 items-center gap-3">
+                              <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                <Checkbox
+                                  aria-label={`${rowLabel} — X ekseni`}
+                                  checked={row.allowRotateX}
+                                  disabled={row.tip === 'varil'}
+                                  onCheckedChange={(checked) =>
+                                    patchRow(row._id, { allowRotateX: Boolean(checked) })
+                                  }
+                                  className="h-4 w-4"
+                                />
+                                X
+                              </label>
+                              <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                <Checkbox
+                                  aria-label={`${rowLabel} — Y ekseni`}
+                                  checked={row.allowRotateY}
+                                  disabled={row.tip === 'palet'}
+                                  onCheckedChange={(checked) =>
+                                    patchRow(row._id, { allowRotateY: Boolean(checked) })
+                                  }
+                                  className="h-4 w-4"
+                                />
+                                Y
+                              </label>
+                              <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                <Checkbox
+                                  aria-label={`${rowLabel} — Z ekseni`}
+                                  checked={row.allowRotateZ}
+                                  disabled={
+                                    Number(row.fragility) >= 1 ||
+                                    row.tip === 'varil' ||
+                                    row.tip === 'palet'
+                                  }
+                                  onCheckedChange={(checked) =>
+                                    patchRow(row._id, { allowRotateZ: Boolean(checked) })
+                                  }
+                                  className="h-4 w-4"
+                                />
+                                Z
+                              </label>
+                            </div>
+                          </div>
+
+                          {/* İstif kutucuğu rotasyon kutucuklarının yanında durur. */}
+                          <div className="flex shrink-0 flex-col gap-1.5">
+                            <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                              İstiflenebilir
+                            </span>
+                            <div className="flex h-7 items-center">
+                              <Checkbox
+                                aria-label={`${rowLabel} — İstiflenebilir`}
+                                checked={row.isStackable}
+                                onCheckedChange={(checked) =>
+                                  patchRow(row._id, { isStackable: Boolean(checked) })
+                                }
+                                className="h-4 w-4"
+                              />
+                            </div>
+                          </div>
+
+                          <div className="flex min-w-[200px] flex-1 flex-col gap-1.5">
+                            <span className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+                              Özel Taşıma Notları
+                            </span>
+                            <TextCell
+                              value={row.notes}
+                              onChange={(v) => patchRow(row._id, { notes: v })}
+                            />
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/*
+          Yüzen aksiyon çubuğu: ürün ve araç formlarındaki desenin aynısı. Kullanıcı bu
+          ekrana zaten aynı biçimdeki bir çubuktan geliyor; sabit alt şerit geçişi
+          bozuyordu. Kaydırma alanındaki `pb-24` çubuğun altında satır bırakmaz.
+        */}
+      <div className="pointer-events-none absolute bottom-4 left-1/2 z-20 -translate-x-1/2">
+        <div className="pointer-events-auto flex items-center gap-2 rounded-2xl border border-border bg-background px-6 py-3 shadow-lg">
+          {/*
               ERP onay akisinda elle satir eklenemez: satirin karsiligi olan taslak
               olmadigi icin onayda sessizce dusuyordu. Yeni urun tekil urun formundan
               ya da Excel aktarimindan eklenir.
             */}
-            {!draftItemIds && (
+          {!draftItemIds && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gap-1.5 text-xs"
+              type="button"
+              onClick={() => setRows((p) => [...p, emptyRow()])}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              Satır Ekle
+            </Button>
+          )}
+          {!draftItemIds && (
+            <>
               <Button
                 variant="ghost"
                 size="sm"
                 className="gap-1.5 text-xs"
                 type="button"
-                onClick={() => setRows((p) => [...p, emptyRow()])}
+                onClick={() => fileInputRef.current?.click()}
               >
-                <Plus className="h-3.5 w-3.5" />
-                Satır Ekle
+                <FileUp className="h-3.5 w-3.5" />
+                Dosya Değiştir
               </Button>
-            )}
-            {!draftItemIds && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="gap-1.5 text-xs"
-                  type="button"
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  <FileUp className="h-3.5 w-3.5" />
-                  Dosya Değiştir
+              <Button
+                variant="ghost"
+                size="sm"
+                className="gap-1.5 text-xs"
+                type="button"
+                onClick={downloadItemImportTemplate}
+              >
+                <Download className="h-3.5 w-3.5" />
+                Şablonu İndir
+              </Button>
+              {ITEM_SHEETS_TEMPLATE_URL && (
+                <Button variant="ghost" size="sm" className="gap-1.5 text-xs" type="button" asChild>
+                  <a href={ITEM_SHEETS_TEMPLATE_URL} target="_blank" rel="noreferrer">
+                    <ExternalLink className="h-3.5 w-3.5" />
+                    Google Sheets
+                  </a>
                 </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="gap-1.5 text-xs"
-                  type="button"
-                  onClick={downloadItemImportTemplate}
-                >
-                  <Download className="h-3.5 w-3.5" />
-                  Şablonu İndir
-                </Button>
-                {ITEM_SHEETS_TEMPLATE_URL && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="gap-1.5 text-xs"
-                    type="button"
-                    asChild
-                  >
-                    <a href={ITEM_SHEETS_TEMPLATE_URL} target="_blank" rel="noreferrer">
-                      <ExternalLink className="h-3.5 w-3.5" />
-                      Google Sheets
-                    </a>
-                  </Button>
-                )}
-              </>
-            )}
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept=".xlsx,.xls,.csv"
-              className="hidden"
-              onChange={handleFileChange}
-            />
-          </div>
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={handleClose} type="button">
-              İptal
-            </Button>
-            <Button
-              size="sm"
-              onClick={() => void handleImport()}
-              disabled={!canImport}
-              type="button"
-            >
-              {confirmLabel}
-            </Button>
-          </div>
+              )}
+            </>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".xlsx,.xls,.csv"
+            className="hidden"
+            onChange={handleFileChange}
+          />
+          {/* Yardımcı aksiyonlarla kesinleştirme aksiyonlarını ayırır; ERP akışında
+                soldaki grup hiç çizilmediği için ayraç da çizilmez. */}
+          {!draftItemIds && <span className="mx-1 h-5 w-px bg-border" aria-hidden="true" />}
+          <Button variant="outline" size="sm" onClick={handleClose} type="button">
+            İptal
+          </Button>
+          <Button size="sm" onClick={() => void handleImport()} disabled={!canImport} type="button">
+            {confirmLabel}
+          </Button>
         </div>
-      </DialogContent>
-    </Dialog>
+      </div>
+    </EditorShell>
   );
 }

--- a/apps/frontend/src/features/data-management/imports/components/ERPItemsTable.test.tsx
+++ b/apps/frontend/src/features/data-management/imports/components/ERPItemsTable.test.tsx
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { useErpTransferStore } from '@/lib/store/useErpTransferStore';
 import type { ReactNode } from 'react';
 import type { DraftItem, DraftItemsParams } from '@/lib/api/useDraftItems';
-import type { EditableRow } from './BulkImportDialog';
 
 const mocks = vi.hoisted(() => ({
   connection: vi.fn(),
@@ -111,21 +111,22 @@ vi.mock('@/lib/api/useDraftItems', async (importOriginal) => {
   };
 });
 
-interface BulkImportDialogStubProps {
-  open: boolean;
-  initialRows: EditableRow[];
-  draftItemIds: Record<string, string>;
-}
+/**
+ * /erp/aktar rotasının yerine geçen sonda. Aktarım ekranı artık modal değil rota
+ * olduğu için, taşınan satırlar prop'tan değil store'dan okunur; testlerin sorduğu
+ * soru aynı kalıyor: hangi kayıtlar aktarıma gitti?
+ */
+function TransferProbe() {
+  const rows = useErpTransferStore((s) => s.rows);
+  const draftItemIds = useErpTransferStore((s) => s.draftItemIds);
 
-vi.mock('./BulkImportDialog', () => ({
-  BulkImportDialog: ({ open, initialRows, draftItemIds }: BulkImportDialogStubProps) =>
-    open ? (
-      <div data-testid="bulk-import-dialog">
-        <span data-testid="dialog-row-names">{initialRows.map((r) => r.name).join('|')}</span>
-        <span data-testid="dialog-draft-ids">{Object.values(draftItemIds).join('|')}</span>
-      </div>
-    ) : null,
-}));
+  return (
+    <div data-testid="bulk-import-dialog">
+      <span data-testid="dialog-row-names">{rows.map((r) => r.name).join('|')}</span>
+      <span data-testid="dialog-draft-ids">{Object.values(draftItemIds).join('|')}</span>
+    </div>
+  );
+}
 
 const { ERPItemsTable } = await import('./ERPItemsTable');
 
@@ -133,7 +134,12 @@ function renderTable(node: ReactNode = <ERPItemsTable />) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter>{node}</MemoryRouter>
+      <MemoryRouter initialEntries={['/erp']}>
+        <Routes>
+          <Route path="/erp" element={node} />
+          <Route path="/erp/aktar" element={<TransferProbe />} />
+        </Routes>
+      </MemoryRouter>
     </QueryClientProvider>,
   );
 }
@@ -238,6 +244,8 @@ const draftItems: DraftItem[] = [
 describe('ERPItemsTable', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Store oturum deposuna yazıyor; testler arası sızmasın.
+    useErpTransferStore.getState().clear();
     mocks.draftItemsState.isLoading = false;
     mocks.draftItemsState.isEmpty = false;
     mocks.draftItemsState.error = null;
@@ -264,6 +272,15 @@ describe('ERPItemsTable', () => {
     expect(screen.getByText('Palet Kasa 60x40')).toBeInTheDocument();
     expect(screen.getByText('KOL-3020')).toBeInTheDocument();
     expect(screen.queryByText('Aktarilmis Urun')).not.toBeInTheDocument();
+  });
+
+  it('araç çubuğu ERP ayarları köprüsünü taşır', () => {
+    renderTable();
+
+    expect(screen.getByRole('link', { name: /ERP Ayarları/ })).toHaveAttribute(
+      'href',
+      '/settings?tab=erp',
+    );
   });
 
   it('tip sütunu ERP productType alanını değil gerçek kategoriyi gösterir', () => {
@@ -498,6 +515,28 @@ describe('ERPItemsTable', () => {
 
     expect(mocks.bulkReject).toHaveBeenCalledTimes(1);
     expect(mocks.bulkReject.mock.calls[0][0]).toEqual(['11111111-1111-4111-8111-111111111111']);
+  });
+
+  /**
+   * Güncelleme reddi ayrı bir backend geçişi: taslak `Rejected` değil `UpdateDismissed`
+   * olur ve 'Reddedilenler' sorgusu iki durumu birden döndürür. Frontend'in bu yolda da
+   * aynı toplu ret ucunu çağırdığı doğrulanmazsa, geçiş sessizce kopabilir.
+   */
+  it('Güncellemeler sekmesinden reddetme de toplu ret ucunu çağırır', async () => {
+    const user = userEvent.setup();
+    renderTable();
+
+    await user.click(screen.getByRole('button', { name: /Güncellemeler/ }));
+    await user.click(
+      await screen.findByRole('checkbox', { name: 'Guncellenecek Urun A güncelleme seç' }),
+    );
+    await user.click(screen.getByRole('button', { name: /^Reddet/ }));
+
+    const dialog = await screen.findByRole('alertdialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Reddet' }));
+
+    expect(mocks.bulkReject).toHaveBeenCalledTimes(1);
+    expect(mocks.bulkReject.mock.calls[0][0]).toEqual(['77777777-7777-4777-8777-777777777777']);
   });
 
   it('Reddedilenler sekmesi reddedilen kayıtları ve geri alma yolunu gösterir', async () => {

--- a/apps/frontend/src/features/data-management/imports/components/ERPItemsTable.tsx
+++ b/apps/frontend/src/features/data-management/imports/components/ERPItemsTable.tsx
@@ -1,5 +1,5 @@
 ﻿import { useCallback, useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 import { FilterTabs } from '@/components/shared/FilterTabs';
 import {
@@ -13,6 +13,7 @@ import {
   Loader2,
   RefreshCw,
   RotateCcw,
+  Settings2,
   SlidersHorizontal,
   Upload,
   XCircle,
@@ -68,7 +69,7 @@ import { useDebounce } from '@/lib/hooks/useDebounce';
 import { ITEM_CATEGORY } from '@/lib/api/itemMappers';
 import { ProductTypeCell } from '@/components/shared/ProductTypeCell';
 import type { ProductType } from '@/features/data-management/products/schemas/productSchema';
-import { BulkImportDialog, type EditableRow } from './BulkImportDialog';
+import { useErpTransferStore } from '@/lib/store/useErpTransferStore';
 import { ErpSyncRequirementsDialog } from './ErpSyncRequirementsDialog';
 import { ErpSyncDialog } from '@/features/platform/erp/components/ErpSyncDialog';
 import { collectMissingSyncRequirements } from '@/features/data-management/imports/utils/erpSyncRequirements';
@@ -150,16 +151,34 @@ const BELOW_TABLE_H = 80;
 
 // ─── Skeleton ─────────────────────────────────────────────────────────────────
 
-const SKELETON_COLS = 10;
+/**
+ * İskelet kolonları gerçek tablonun genişlikleriyle birebir eşleşir. Sabit sayıda
+ * genişliksiz kolon çizilirken `table-fixed` kolonları eşit dağıtıyor, veri gelince
+ * yerleşim zıplıyordu. Son kolon yalnızca Reddedilenler sekmesinde çizilir.
+ */
+const SKELETON_COLUMNS = [
+  { head: 'w-10', bar: 'w-4' },
+  { head: 'w-52', bar: 'w-36' },
+  { head: 'w-28', bar: 'w-16' },
+  { head: 'w-24', bar: 'w-14' },
+  { head: 'w-32', bar: 'w-20' },
+  { head: 'w-24', bar: 'w-12' },
+  { head: 'w-24', bar: 'w-12' },
+  { head: 'w-24', bar: 'w-12' },
+  { head: 'w-24', bar: 'w-12' },
+  { head: 'w-40', bar: 'w-24' },
+] as const;
 
-function ERPItemsTableSkeleton() {
+function ERPItemsTableSkeleton({ columnCount }: { columnCount: number }) {
+  const columns = SKELETON_COLUMNS.slice(0, columnCount);
+
   return (
     <Table className="min-w-[1100px] table-fixed">
       <TableHeader>
         <TableRow className="h-9 bg-muted/40 hover:bg-muted/40">
-          {Array.from({ length: SKELETON_COLS }).map((_, i) => (
-            <TableHead key={i}>
-              <Skeleton className="h-3 w-16" />
+          {columns.map((column, i) => (
+            <TableHead key={i} className={cn('py-0 px-3', column.head)}>
+              <Skeleton className={cn('h-3', column.bar)} />
             </TableHead>
           ))}
         </TableRow>
@@ -167,9 +186,9 @@ function ERPItemsTableSkeleton() {
       <TableBody>
         {Array.from({ length: 6 }).map((_, i) => (
           <TableRow key={i} className="h-12 hover:bg-transparent">
-            {Array.from({ length: SKELETON_COLS }).map((_, j) => (
+            {columns.map((column, j) => (
               <TableCell key={j} className="py-0 px-3">
-                <Skeleton className="h-4 w-full" />
+                <Skeleton className={cn('h-3', column.bar)} />
               </TableCell>
             ))}
           </TableRow>
@@ -182,6 +201,8 @@ function ERPItemsTableSkeleton() {
 // ─── ERPItemsTable ─────────────────────────────────────────────────────────────
 
 export function ERPItemsTable() {
+  const navigate = useNavigate();
+  const startTransfer = useErpTransferStore((s) => s.start);
   const { data: connection } = useERPConnection();
   const { data: erpSettings } = useERPSettings();
   const integrationId = connection?.id;
@@ -198,14 +219,10 @@ export function ERPItemsTable() {
   );
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [importOpen, setImportOpen] = useState(false);
-  const [importRows, setImportRows] = useState<EditableRow[]>([]);
-  const [importDraftIds, setImportDraftIds] = useState<Record<string, string>>({});
   const [showFilterPanel, setShowFilterPanel] = useState(false);
   const [typeFilters, setTypeFilters] = useState<Set<TypeFilterKey>>(new Set());
   const [statusFilter, setStatusFilter] = useState<number>(DRAFT_PENDING);
   const [selectAllMode, setSelectAllMode] = useState(false);
-  const [importMode, setImportMode] = useState<'import' | 'update'>('import');
   const [requirementsOpen, setRequirementsOpen] = useState(false);
   const [syncDialogOpen, setSyncDialogOpen] = useState(false);
   const [rejectConfirmOpen, setRejectConfirmOpen] = useState(false);
@@ -383,6 +400,10 @@ export function ERPItemsTable() {
     if (integrationId) triggerSync({ integrationId });
   }
 
+  /**
+   * Aktarım artık kendi rotasında açılıyor; seçim bu bileşenle birlikte söküldüğü için
+   * satırlar store'a yazılıp taşınır.
+   */
   function handleOpenImport() {
     // Seçim açık sayfayla sınırlı değildir; satırlar tüm bilinen kayıtlardan çözülür,
     // aksi halde yalnızca o an ekranda duran kadarı aktarım ekranına giderdi.
@@ -394,10 +415,8 @@ export function ERPItemsTable() {
     rows.forEach((row, i) => {
       draftIds[row._id] = selected[i].id;
     });
-    setImportRows(rows);
-    setImportDraftIds(draftIds);
-    setImportMode(isUpdateTab ? 'update' : 'import');
-    setImportOpen(true);
+    startTransfer({ rows, draftItemIds: draftIds, mode: isUpdateTab ? 'update' : 'import' });
+    navigate('/erp/aktar');
   }
 
   // Toplu ret teyitsiz calismaz; kullanici kac kaydin ne olacagini gorur.
@@ -466,9 +485,9 @@ export function ERPItemsTable() {
           </Button>
 
           {showFilterPanel && (
-            <div className="absolute left-0 top-full z-20 mt-1 min-w-[180px] rounded-xl border border-border bg-background shadow-lg">
+            <div className="absolute left-0 top-full z-20 mt-1 min-w-[200px] rounded-xl border border-border bg-background shadow-lg">
               <div className="p-3">
-                <p className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
                   Tip
                 </p>
                 <div className="space-y-2">
@@ -521,8 +540,16 @@ export function ERPItemsTable() {
           )}
         </div>
 
+        {/* ERP Ayarları */}
+        <Button asChild variant="outline" size="sm" className="shrink-0 gap-1.5 text-xs">
+          <Link to={ERP_SETTINGS_ROUTE.connection}>
+            <Settings2 className="h-3.5 w-3.5" />
+            {ERP_TERM.settings}
+          </Link>
+        </Button>
+
+        {/* ERP ile Senkronize Et — ürün/araç ekranlarındaki gibi birincil aksiyon en sonda */}
         <Button
-          variant="outline"
           size="sm"
           className="shrink-0 gap-1.5 text-xs"
           onClick={handleSync}
@@ -547,7 +574,7 @@ export function ERPItemsTable() {
       {/* Table */}
       <div
         ref={tableCardRef}
-        className="overflow-x-auto overflow-hidden rounded-2xl border border-border bg-background"
+        className="overflow-x-auto scrollbar-hide rounded-2xl border border-border bg-background"
       >
         {isDraftError ? (
           <QueryErrorState
@@ -558,7 +585,7 @@ export function ERPItemsTable() {
             className="m-4 w-auto"
           />
         ) : showSkeleton ? (
-          <ERPItemsTableSkeleton />
+          <ERPItemsTableSkeleton columnCount={columnCount} />
         ) : (
           <Table className="min-w-[1100px] table-fixed">
             <TableHeader>
@@ -572,32 +599,32 @@ export function ERPItemsTable() {
                     />
                   )}
                 </TableHead>
-                <TableHead className="w-52 whitespace-nowrap py-0 px-3 text-[11px] font-semibold uppercase tracking-wide">
+                <TableHead className="w-52 whitespace-nowrap py-0 px-3 text-[10px] font-semibold uppercase tracking-widest">
                   Ürün
                 </TableHead>
-                <TableHead className="w-28 whitespace-nowrap py-0 px-3 text-[11px] font-semibold uppercase tracking-wide">
+                <TableHead className="w-28 whitespace-nowrap py-0 px-3 text-[10px] font-semibold uppercase tracking-widest">
                   Tip
                 </TableHead>
-                <TableHead className="w-24 whitespace-nowrap py-0 px-3 text-[11px] font-semibold uppercase tracking-wide">
+                <TableHead className="w-24 whitespace-nowrap py-0 px-3 text-[10px] font-semibold uppercase tracking-widest">
                   SKU
                 </TableHead>
-                <TableHead className="w-32 whitespace-nowrap py-0 px-3 text-[11px] font-semibold uppercase tracking-wide">
+                <TableHead className="w-32 whitespace-nowrap py-0 px-3 text-[10px] font-semibold uppercase tracking-widest">
                   Barkod
                 </TableHead>
-                <TableHead className="w-24 whitespace-nowrap py-0 px-3 text-[11px] font-semibold uppercase tracking-wide">
+                <TableHead className="w-24 whitespace-nowrap py-0 px-3 text-[10px] font-semibold uppercase tracking-widest">
                   {DIMENSION_LABEL.width}
                 </TableHead>
-                <TableHead className="w-24 whitespace-nowrap py-0 px-3 text-[11px] font-semibold uppercase tracking-wide">
+                <TableHead className="w-24 whitespace-nowrap py-0 px-3 text-[10px] font-semibold uppercase tracking-widest">
                   {DIMENSION_LABEL.height}
                 </TableHead>
-                <TableHead className="w-24 whitespace-nowrap py-0 px-3 text-[11px] font-semibold uppercase tracking-wide">
+                <TableHead className="w-24 whitespace-nowrap py-0 px-3 text-[10px] font-semibold uppercase tracking-widest">
                   {DIMENSION_LABEL.length}
                 </TableHead>
-                <TableHead className="w-24 whitespace-nowrap py-0 px-3 text-[11px] font-semibold uppercase tracking-wide">
+                <TableHead className="w-24 whitespace-nowrap py-0 px-3 text-[10px] font-semibold uppercase tracking-widest">
                   Ağırlık
                 </TableHead>
                 {isRejectedTab && (
-                  <TableHead className="w-40 whitespace-nowrap py-0 px-3 text-[11px] font-semibold uppercase tracking-wide">
+                  <TableHead className="w-40 whitespace-nowrap py-0 px-3 text-[10px] font-semibold uppercase tracking-widest">
                     İşlem
                   </TableHead>
                 )}
@@ -896,21 +923,10 @@ export function ERPItemsTable() {
         />
       )}
 
-      {/* Transfer modal */}
-      <BulkImportDialog
-        key={importOpen ? importRows.map((r) => r._id).join(',') : 'closed'}
-        open={importOpen}
-        onOpenChange={(open) => {
-          setImportOpen(open);
-          if (!open) {
-            setSelectAllMode(false);
-            setSelectedIds(new Set());
-          }
-        }}
-        initialRows={importRows}
-        draftItemIds={importDraftIds}
-        mode={importMode}
-      />
+      {/*
+        Aktarım ekranı artık burada değil, /erp/aktar rotasında. Gezinme bu bileşeni
+        söktüğü için seçimi ayrıca temizlemek gerekmiyor.
+      */}
     </div>
   );
 }

--- a/apps/frontend/src/features/data-management/imports/components/ImportSummaryPanel.tsx
+++ b/apps/frontend/src/features/data-management/imports/components/ImportSummaryPanel.tsx
@@ -1,0 +1,295 @@
+import { CheckCircle2, Info } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { DIMENSION_SHORT_LABEL } from '@/lib/config/erpTerms';
+import type { EditableRow } from '@/features/data-management/imports/utils/itemImportRow';
+
+interface SummaryRow {
+  label: string;
+  value: string;
+  tone?: 'default' | 'error' | 'ok';
+}
+
+/** Boş ya da sayısal olmayan hücre toplama girmez; kullanıcı henüz doldurmamış olabilir. */
+function toNumber(value: string): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+/** Santimetre kenarlardan m³; ürün özet panelindeki hesabın aynısı. */
+function totalVolumeM3(rows: readonly EditableRow[]): number {
+  return rows.reduce(
+    (sum, row) =>
+      sum + (toNumber(row.width) * toNumber(row.height) * toNumber(row.length)) / 1_000_000,
+    0,
+  );
+}
+
+function totalWeightKg(rows: readonly EditableRow[]): number {
+  return rows.reduce((sum, row) => sum + toNumber(row.weight), 0);
+}
+
+/**
+ * Doğrulama alan adlarının okunur karşılığı. `validateRow` bu sekiz alanı üretir;
+ * sekizi de ızgaranın ana satırında düzenlenir, yani hiçbir engel açılır satırın
+ * arkasında saklı kalmaz.
+ */
+// Ölçü adları sözlükten türetilir; elle yazılınca koordinat standardı değiştiğinde
+// (Derinlik → Uzunluk) burası sessizce bayatlıyordu.
+const BLOCKER_LABEL: Record<string, string> = {
+  name: 'Ürün adı eksik',
+  sku: 'SKU sorunu',
+  tip: 'Tip seçilmemiş',
+  width: `${DIMENSION_SHORT_LABEL.width} eksik`,
+  height: `${DIMENSION_SHORT_LABEL.height} eksik`,
+  length: `${DIMENSION_SHORT_LABEL.length} eksik`,
+  weight: `${DIMENSION_SHORT_LABEL.weight} eksik`,
+  stackGroup: 'Yük grubu seçilmemiş',
+};
+
+/** Histogram kova sayısı; 90 satırlık tipik partide şekli okunur kılan aralık. */
+const VOLUME_BIN_COUNT = 8;
+
+interface ImportSummaryPanelProps {
+  rows: readonly EditableRow[];
+  errorRowCount: number;
+  validRowCount: number;
+  /** Alan adı → o alanda hatası olan satır sayısı. */
+  errorFieldCounts: Readonly<Record<string, number>>;
+}
+
+/**
+ * Aktarım ekranının sağ sütunu. Ürün ve araç detay sayfalarında bu sütunda 3D
+ * önizleme durur; toplu aktarımda önizlenecek tek bir nesne olmadığı için aynı
+ * yerde bu ekranın tek gerçek sorusu cevaplanır: aktarımı ne engelliyor?
+ *
+ * İstatistik listesinin biçimi bilinçli olarak ürün önizleme panelindekiyle aynıdır.
+ */
+export function ImportSummaryPanel({
+  rows,
+  errorRowCount,
+  validRowCount,
+  errorFieldCounts,
+}: ImportSummaryPanelProps) {
+  const missingStackGroupCount = rows.filter((row) => !row.stackGroup).length;
+
+  /**
+   * Yük grubu dağılımı — yalnızca gerçekten birden fazla grup varsa çizilir.
+   * Tek gruplu bir dağılım "grafik" değildir; tek dilimli pasta ya da tek çubuklu
+   * grafik bilinen bir anti-desen. Partinin tamamı aynı gruptaysa bölüm hiç
+   * görünmez ve panel doğal boyunda kalır.
+   */
+  const groupCounts = new Map<string, number>();
+  for (const row of rows) {
+    const key = row.stackGroup || 'Atanmamış';
+    groupCounts.set(key, (groupCounts.get(key) ?? 0) + 1);
+  }
+  const groupRows =
+    groupCounts.size > 1
+      ? Array.from(groupCounts, ([label, count]) => ({ label, count })).sort(
+          (a, b) => b.count - a.count || a.label.localeCompare(b.label, 'tr'),
+        )
+      : [];
+  const maxGroupCount = groupRows.reduce((max, group) => Math.max(max, group.count), 0);
+
+  /**
+   * Ürün başına hacim dağılımı. Tip ve yük grubu bir partide çoğunlukla tekdüze
+   * olduğu için kategorik grafik tek dilime düşüyordu; hacim sürekli bir ölçü ve
+   * gerçekten dağılıyor, dolayısıyla histogram burada dejenere olmuyor.
+   *
+   * Tek ölçü → tek renk, gösterge kutusu gerekmez; başlık ölçüyü zaten adlandırır.
+   */
+  const itemVolumes = rows
+    .map((row) => (toNumber(row.width) * toNumber(row.height) * toNumber(row.length)) / 1_000_000)
+    .filter((volume) => volume > 0)
+    .sort((a, b) => a - b);
+
+  const minVolume = itemVolumes[0] ?? 0;
+  const maxVolume = itemVolumes[itemVolumes.length - 1] ?? 0;
+  const binWidth = (maxVolume - minVolume) / VOLUME_BIN_COUNT || 1;
+
+  const volumeBins = Array.from({ length: VOLUME_BIN_COUNT }, (_, index) => {
+    const from = minVolume + index * binWidth;
+    const to = index === VOLUME_BIN_COUNT - 1 ? maxVolume : from + binWidth;
+    const count = itemVolumes.filter((volume) =>
+      index === VOLUME_BIN_COUNT - 1 ? volume >= from : volume >= from && volume < to,
+    ).length;
+    return { from, to, count };
+  });
+  const maxBinCount = volumeBins.reduce((max, bin) => Math.max(max, bin.count), 0);
+
+  const blockers = Object.entries(errorFieldCounts)
+    .filter(([, count]) => count > 0)
+    .map(([field, count]) => ({ field, count, label: BLOCKER_LABEL[field] ?? field }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label, 'tr'));
+
+  const summaryRows: SummaryRow[] = [
+    { label: 'Toplam satır', value: String(rows.length) },
+    {
+      label: 'Aktarıma hazır',
+      value: String(validRowCount),
+      tone: validRowCount > 0 ? 'ok' : 'default',
+    },
+    {
+      label: 'Hatalı',
+      value: String(errorRowCount),
+      tone: errorRowCount > 0 ? 'error' : 'default',
+    },
+    { label: 'Toplam hacim', value: `${totalVolumeM3(rows).toFixed(2)} m³` },
+    { label: 'Toplam ağırlık', value: `${totalWeightKg(rows).toFixed(0)} kg` },
+  ];
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-border bg-card p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">
+          Aktarım Özeti
+        </p>
+        <span className="rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground">
+          {rows.length} satır
+        </span>
+      </div>
+
+      {/*
+        Ürün ve araç panellerinde bu kutuda 3D önizleme durur. Toplu aktarımda
+        önizlenecek tek bir nesne yok; aynı yerde aktarımı engelleyen alanlar
+        sayılır. Veri `validateRow` sonucundan gelir, yeni bir hesap yapılmaz.
+      */}
+      {/*
+        Hacim dağılımı. Tek ölçü olduğu için tek renk ve gösterge kutusu yok; sayılar
+        her çubuğun üstüne değil, yalnızca en yüksek kovaya ve ipucuna yazılır.
+        Çubuklar tabana oturur, aralarında 2px yüzey boşluğu ve üstleri 4px yuvarlaktır.
+      */}
+      <div className="mb-3 mt-1 flex min-h-[160px] flex-1 flex-col rounded-lg bg-muted/40 p-3">
+        <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+          Ürün başına hacim
+        </p>
+
+        {itemVolumes.length > 0 ? (
+          <>
+            <div
+              className="flex min-h-[80px] flex-1 items-end gap-0.5"
+              role="img"
+              aria-label={`Hacim dağılımı: ${itemVolumes.length} ürün, ${minVolume.toFixed(2)} ile ${maxVolume.toFixed(2)} m³ arasında`}
+            >
+              {volumeBins.map((bin, index) => (
+                <div
+                  key={index}
+                  title={`${bin.from.toFixed(2)}–${bin.to.toFixed(2)} m³ · ${bin.count} ürün`}
+                  className="flex h-full flex-1 flex-col justify-end"
+                >
+                  {bin.count === maxBinCount && bin.count > 0 && (
+                    <span className="mb-1 text-center text-[10px] tabular-nums text-muted-foreground">
+                      {bin.count}
+                    </span>
+                  )}
+                  <div
+                    className="w-full rounded-t bg-primary/70"
+                    style={{
+                      height: maxBinCount > 0 ? `${(bin.count / maxBinCount) * 100}%` : '0%',
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+            <div className="mt-1.5 flex items-center justify-between border-t border-border/50 pt-1.5 text-[10px] tabular-nums text-muted-foreground">
+              <span>{minVolume.toFixed(2)} m³</span>
+              <span>{maxVolume.toFixed(2)} m³</span>
+            </div>
+          </>
+        ) : (
+          <div className="flex flex-1 items-center justify-center">
+            <p className="text-xs text-muted-foreground">Ölçüsü girilmiş ürün yok.</p>
+          </div>
+        )}
+      </div>
+
+      {groupRows.length > 0 && (
+        <div className="mb-3 mt-1 rounded-lg bg-muted/40 p-3">
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+            Yük grubu dağılımı
+          </p>
+          <ul className="flex flex-col gap-1.5">
+            {groupRows.map((group) => (
+              <li key={group.label} className="flex items-center gap-2">
+                <span className="w-24 shrink-0 truncate text-xs text-muted-foreground">
+                  {group.label}
+                </span>
+                {/* Tek ölçünün kategoriler arası karşılaştırması: tek nötr ton yeter,
+                    kategorik palet gerekmez. Sayı çubuğun yanında yazılı. */}
+                <span className="flex h-2 min-w-0 flex-1 items-center">
+                  <span
+                    className="h-full rounded-full bg-foreground/25"
+                    style={{ width: `${(group.count / maxGroupCount) * 100}%` }}
+                  />
+                </span>
+                <span className="w-6 shrink-0 text-right text-xs font-medium tabular-nums text-foreground">
+                  {group.count}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {blockers.length > 0 ? (
+        <div className="mb-3 rounded-lg border border-border/50 p-2.5">
+          <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+            Aktarımı engelleyenler
+          </p>
+          <ul className="flex flex-col gap-1">
+            {blockers.map((blocker) => (
+              <li key={blocker.field} className="flex items-center justify-between gap-2">
+                <span className="text-xs text-foreground">{blocker.label}</span>
+                <span className="text-xs font-medium tabular-nums text-destructive">
+                  {blocker.count}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <p className="mb-3 flex items-center gap-1.5 text-xs text-green-700 dark:text-green-400">
+          <CheckCircle2 className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          Engel yok — {validRowCount} satır aktarıma hazır.
+        </p>
+      )}
+
+      <div className="flex flex-col">
+        {summaryRows.map((row) => (
+          <div
+            key={row.label}
+            className="flex items-center justify-between border-b border-border/50 py-1 last:border-0"
+          >
+            <span className="text-xs text-muted-foreground">{row.label}</span>
+            <span
+              className={cn(
+                'text-xs font-medium tabular-nums',
+                row.tone === 'error' && 'text-destructive',
+                row.tone === 'ok' && 'text-green-700 dark:text-green-400',
+                (!row.tone || row.tone === 'default') && 'text-foreground',
+              )}
+            >
+              {row.value}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/*
+        ERP yük grubu göndermiyor ama alan zorunlu; ekran bu yüzden her açılışta
+        hatalı başlıyor. Varsayılan atamak doğrulama davranışını değiştirirdi, bu
+        yüzden yalnızca toplu doldurmanın nerede olduğu söyleniyor.
+      */}
+      {missingStackGroupCount > 0 && (
+        <div className="mt-3 flex gap-2 rounded-lg border border-border/50 bg-muted/40 p-2">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            ERP yük grubu göndermiyor. Tablodaki <span className="font-medium">Yük Grubu</span>{' '}
+            başlığındaki <span className="font-medium">Tümü</span> menüsünden hepsine birden
+            atayabilirsiniz.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/features/data-management/products/components/ProductForm.tsx
+++ b/apps/frontend/src/features/data-management/products/components/ProductForm.tsx
@@ -1272,7 +1272,7 @@ function PreviewPanel(props: PreviewPanelProps) {
   ];
 
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-xl border border-border bg-card p-3">
+    <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-border bg-card p-3">
       {/* Başlık */}
       <div className="mb-2 flex items-center justify-between">
         <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">

--- a/apps/frontend/src/features/data-management/vehicles/components/VehiclePreviewPanel.tsx
+++ b/apps/frontend/src/features/data-management/vehicles/components/VehiclePreviewPanel.tsx
@@ -109,7 +109,7 @@ export function VehiclePreviewPanel({ form, vehicle, isCreateMode = false }: Pro
   ];
 
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-xl border border-border bg-card p-3">
+    <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-border bg-card p-3">
       {/* Başlık + operasyonel durum */}
       <div className="mb-2 flex items-center justify-between">
         <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground">

--- a/apps/frontend/src/lib/store/useErpTransferStore.ts
+++ b/apps/frontend/src/lib/store/useErpTransferStore.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+import type { EditableRow } from '@/features/data-management/imports/components/BulkImportDialog';
+
+export type ErpTransferMode = 'import' | 'update';
+
+interface ErpTransferPayload {
+  /** Aktarım ekranında düzenlenecek satırlar. */
+  rows: EditableRow[];
+  /** row._id → taslak kaydın backend kimliği; onay bu eşlemeyle yapılır. */
+  draftItemIds: Record<string, string>;
+  mode: ErpTransferMode;
+}
+
+interface ErpTransferStore extends ErpTransferPayload {
+  start: (payload: ErpTransferPayload) => void;
+  clear: () => void;
+}
+
+const EMPTY: ErpTransferPayload = { rows: [], draftItemIds: {}, mode: 'import' };
+
+/**
+ * ERP taslaklarının aktarım ekranına taşınmasını sağlar.
+ *
+ * Aktarım modalken bu veri prop olarak geçiyordu; rota kabuğunda gezinme listeyi
+ * söktüğü için seçim bellekte kalamıyor. Store yalnızca kullanıcının seçimini ve
+ * düzenlediği form modelini tutar — taslak kayıtlarının kendisi TanStack Query
+ * cache'inde kalır, buraya kopyalanmaz.
+ *
+ * Kalıcı depoya **yazılmaz**. Kısmi aktarımda başarılı satırlar sunucuda onaylanır ve
+ * ekrandaki liste kalanlara düşer; store bunu takip etmediği için kalıcı bir kopya,
+ * yenilemeden sonra zaten aktarılmış satırların tekrar gönderilmesine yol açardı.
+ * Yenilemede seçim kaybolur ve sayfa listeye döner — aktarım modalken de böyleydi.
+ */
+export const useErpTransferStore = create<ErpTransferStore>((set) => ({
+  ...EMPTY,
+  start: (payload) => set(payload),
+  clear: () => set(EMPTY),
+}));

--- a/apps/frontend/src/pages/erp/ERPItemsPage.test.tsx
+++ b/apps/frontend/src/pages/erp/ERPItemsPage.test.tsx
@@ -38,23 +38,11 @@ describe('ERPItemsPage', () => {
     expect(screen.queryByRole('link', { name: /Genel Bakış/ })).not.toBeInTheDocument();
   });
 
-  it('şirket yöneticisine ERP ayarları köprüsü gösterir', () => {
-    signInAs(USER_ROLES.CompanyAdmin);
-    renderPage();
-
-    expect(screen.getByRole('link', { name: /ERP Ayarları/ })).toHaveAttribute(
-      'href',
-      '/settings?tab=erp',
-    );
-  });
-
-  it('yetkisiz kullanıcıya ayarlar köprüsü göstermez', () => {
-    signInAs(USER_ROLES.CompanyWorker);
-    renderPage();
-
-    expect(screen.queryByRole('link', { name: /ERP Ayarları/ })).not.toBeInTheDocument();
-  });
-
+  /**
+   * ERP ayarları köprüsü, ürün/araç ekranlarındaki gibi tablo araç çubuğuna taşındı;
+   * köprünün kendisi ERPItemsTable testinde doğrulanır. Yetkisiz kullanıcıda tablo hiç
+   * çizilmediği için köprü de çizilmez — aşağıdaki test bunun tek güvencesi.
+   */
   it('yetkisiz kullanıcıya tablo yerine kilit mesajı gösterir', () => {
     signInAs(USER_ROLES.CompanyWorker);
     renderPage();

--- a/apps/frontend/src/pages/erp/ERPItemsPage.tsx
+++ b/apps/frontend/src/pages/erp/ERPItemsPage.tsx
@@ -1,9 +1,8 @@
 import { Link } from 'react-router-dom';
-import { Settings2, ShieldAlert } from 'lucide-react';
+import { ShieldAlert } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { ERPItemsTable } from '@/features/data-management/imports/components/ERPItemsTable';
-import { ERP_SETTINGS_ROUTE, ERP_TERM } from '@/lib/config/erpTerms';
 import { isCompanyAdminRole, useAuthStore } from '@/lib/store/useAuthStore';
 
 function ERPAccessLocked() {
@@ -40,16 +39,6 @@ export function ERPItemsPage() {
             ERP ile senkronize ettiğiniz ürünleri inceleyin ve Cargo Pilot ürünlerine aktarın.
           </p>
         </div>
-        {canManageErp && (
-          <div className="flex flex-wrap gap-2">
-            <Button asChild variant="outline" size="sm">
-              <Link to={ERP_SETTINGS_ROUTE.connection}>
-                <Settings2 className="mr-1.5 h-3.5 w-3.5" />
-                {ERP_TERM.settings}
-              </Link>
-            </Button>
-          </div>
-        )}
       </div>
       {canManageErp ? <ERPItemsTable /> : <ERPAccessLocked />}
     </div>

--- a/apps/frontend/src/pages/erp/ErpTransferPage.tsx
+++ b/apps/frontend/src/pages/erp/ErpTransferPage.tsx
@@ -1,0 +1,59 @@
+import { Navigate, useNavigate } from 'react-router-dom';
+import { BulkImportDialog } from '@/features/data-management/imports/components/BulkImportDialog';
+import { ERP_TERM } from '@/lib/config/erpTerms';
+import { useErpTransferStore } from '@/lib/store/useErpTransferStore';
+
+/**
+ * ERP taslaklarının ürüne dönüştüğü düzenleme ekranı. Ürün ve araç ekleme
+ * sayfalarıyla aynı kabuk: başlık bloğu, kalan alanı dolduran kart, kartın üzerinde
+ * yüzen aksiyon çubuğu.
+ *
+ * Aktarılacak satırlar listeden `useErpTransferStore` ile taşınır; adresin doğrudan
+ * açılması hâlinde aktarılacak bir şey yoktur ve kullanıcı listeye döner.
+ */
+export function ErpTransferPage() {
+  const navigate = useNavigate();
+  const rows = useErpTransferStore((s) => s.rows);
+  const draftItemIds = useErpTransferStore((s) => s.draftItemIds);
+  const mode = useErpTransferStore((s) => s.mode);
+  const clearTransfer = useErpTransferStore((s) => s.clear);
+
+  if (rows.length === 0) return <Navigate to="/erp" replace />;
+
+  const isUpdate = mode === 'update';
+
+  /** Hem iptalde hem başarılı aktarımda çalışır; ikisi de listeye döner. */
+  function handleLeave() {
+    clearTransfer();
+    navigate('/erp');
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-6">
+      <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-xl font-bold tracking-tight text-foreground">
+            {isUpdate ? 'ERP Güncellemeyi Onayla' : ERP_TERM.approve}
+          </h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            Hücreleri tıklayarak doğrudan düzenleyin. Kırmızı alanları düzeltin, ardından ürünlere
+            aktarın.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        <BulkImportDialog
+          asPage
+          open
+          onOpenChange={(next) => {
+            if (!next) handleLeave();
+          }}
+          initialRows={rows}
+          draftItemIds={draftItemIds}
+          mode={mode}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/lazyPages.ts
+++ b/apps/frontend/src/pages/lazyPages.ts
@@ -96,6 +96,10 @@ export const ShareLinksPage = lazy(() =>
 export const NotificationsPage = lazy(() =>
   import('@/pages/notifications/NotificationsPage').then((m) => ({ default: m.NotificationsPage })),
 );
+export const ErpTransferPage = lazy(() =>
+  import('@/pages/erp/ErpTransferPage').then((m) => ({ default: m.ErpTransferPage })),
+);
+
 export const ERPItemsPage = lazy(() =>
   import('@/pages/erp/ERPItemsPage').then((m) => ({ default: m.ERPItemsPage })),
 );

--- a/apps/frontend/src/pages/products/ProductCreatePage.tsx
+++ b/apps/frontend/src/pages/products/ProductCreatePage.tsx
@@ -7,12 +7,14 @@ export function ProductCreatePage() {
   const createItem = useCreateItem();
 
   return (
-    <div className="flex h-full flex-col gap-4">
-      <div className="shrink-0">
-        <h1 className="text-xl font-bold tracking-tight text-foreground">Yeni Ürün Ekle</h1>
-        <p className="mt-0.5 text-sm text-muted-foreground">
-          Ürünün kimliğini, fiziksel özelliklerini ve kısıtlarını tanımlayın.
-        </p>
+    <div className="flex h-full flex-col gap-6">
+      <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-xl font-bold tracking-tight text-foreground">Yeni Ürün Ekle</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            Ürünün kimliğini, fiziksel özelliklerini ve kısıtlarını tanımlayın.
+          </p>
+        </div>
       </div>
 
       <div className="flex flex-col flex-1 min-h-0">

--- a/apps/frontend/src/pages/products/ProductEditPage.tsx
+++ b/apps/frontend/src/pages/products/ProductEditPage.tsx
@@ -37,8 +37,8 @@ export function ProductEditPage() {
   }
 
   return (
-    <div className="flex h-full flex-col gap-4">
-      <div className="flex shrink-0 items-start justify-between gap-4">
+    <div className="flex h-full flex-col gap-6">
+      <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <div className="flex items-center gap-2">
             <h1 className="text-xl font-bold tracking-tight text-foreground">Ürün Detayı</h1>

--- a/apps/frontend/src/pages/vehicles/VehicleCreatePage.tsx
+++ b/apps/frontend/src/pages/vehicles/VehicleCreatePage.tsx
@@ -9,12 +9,14 @@ export function VehicleCreatePage() {
   const createVehicle = useCreateVehicle();
 
   return (
-    <div className="flex h-full flex-col gap-4">
-      <div className="shrink-0">
-        <h1 className="text-xl font-bold tracking-tight text-foreground">Yeni Araç Ekle</h1>
-        <p className="mt-0.5 text-sm text-muted-foreground">
-          Araç tipini, kimlik bilgilerini ve özelliklerini tanımlayın.
-        </p>
+    <div className="flex h-full flex-col gap-6">
+      <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-xl font-bold tracking-tight text-foreground">Yeni Araç Ekle</h1>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            Araç tipini, kimlik bilgilerini ve özelliklerini tanımlayın.
+          </p>
+        </div>
       </div>
 
       <div className="flex flex-col flex-1 min-h-0">

--- a/apps/frontend/src/pages/vehicles/VehicleEditPage.tsx
+++ b/apps/frontend/src/pages/vehicles/VehicleEditPage.tsx
@@ -53,8 +53,8 @@ export function VehicleEditPage() {
   }
 
   return (
-    <div className="flex h-full flex-col gap-4">
-      <div className="flex shrink-0 items-start justify-between gap-4">
+    <div className="flex h-full flex-col gap-6">
+      <div className="flex shrink-0 flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <h1 className="text-xl font-bold tracking-tight text-foreground">Araç Detayı</h1>
           <p className="mt-0.5 text-sm text-muted-foreground">

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import {
   ContactPage,
   DashboardPage,
   ERPItemsPage,
+  ErpTransferPage,
   ErrorPage,
   ForceChangePasswordPage,
   ForgotPasswordPage,
@@ -280,6 +281,16 @@ export const router = createBrowserRouter([
                 element: (
                   <PageSuspense>
                     <ERPItemsPage />
+                  </PageSuspense>
+                ),
+              },
+              {
+                // Seçilen taslakların düzenlendiği aktarım ekranı; ürün/araç ekleme
+                // sayfalarıyla aynı sabit yükseklikli kabuğu kullanır.
+                path: '/erp/aktar',
+                element: (
+                  <PageSuspense>
+                    <ErpTransferPage />
                   </PageSuspense>
                 ),
               },

--- a/docs/adr/ADR-0000-sablon.md
+++ b/docs/adr/ADR-0000-sablon.md
@@ -1,0 +1,56 @@
+# ADR-NNNN — <Konu>
+
+- **Durum:** Önerildi | Kabul edildi | Reddedildi | Yerini aldı: ADR-XXXX
+- **Tarih:** YYYY-MM-DD *(kararın alındığı tarih; ADR sonradan yazıldıysa yazım tarihi değil)*
+- **Kapsam:** <iş kalemi / PR numaraları> · **Etkilediği kod:** `<yol>`
+
+## Bağlam
+
+Karar öncesi durum: ne vardı, hangi sorun görüldü, sorunun kanıtı nedir.
+Her iddia `dosya:satır`, ölçüm ya da PR numarasıyla desteklenir. Ölçülmemiş sayı
+**tahmin** olarak etiketlenir. ADR geriye dönük yazıldıysa burada belirtilir.
+
+## Karar
+
+### 1. <Alt kararın tek cümlelik ifadesi>
+
+Kararın kendisi; mümkünse koddaki karşılığı (`dosya:satır`).
+
+Gerekçe:
+
+- <neden bu yol seçildi — kanıtla>
+- <ölçüm varsa sayı ile>
+
+Sonuçları:
+
+- <bu kararın kabul edilen bedeli, kısıtı veya yan etkisi>
+- <kararın ileride ne beklediği>
+
+### 2. <İkinci alt karar>
+
+Gerekçe:
+
+- …
+
+Sonuçları:
+
+- …
+
+## <Konuya özel bölüm>
+
+Ölçüm tablosu, sözleşme, şema, ön koşul listesi gibi konuya özgü içerik.
+Bölüm sayısı ve adı serbesttir.
+
+## Alternatifler
+
+| Alternatif | Neden seçilmedi |
+|---|---|
+| <alternatif 1> | <gerekçe; ölçülerek elendiyse ölçüm sayısı> |
+| <alternatif 2> | <gerekçe> |
+
+*En az iki elenen alternatif zorunludur.*
+
+## Açık konular
+
+- <bu karara bilinçli olarak girmeyen iş, kime/ne zamana bırakıldığıyla>
+- <ölçülemeyen risk>

--- a/docs/adr/ADR-0001-erp-baglanti-mimarisi.md
+++ b/docs/adr/ADR-0001-erp-baglanti-mimarisi.md
@@ -1,4 +1,4 @@
-# ADR — ERP Bağlantı Mimarisi
+# ADR-0001 — ERP Bağlantı Mimarisi
 
 - **Durum:** Kabul edildi
 - **Tarih:** 2026-08-11

--- a/docs/adr/ADR-0002-optimizasyon-motoru-modulerlestirme.md
+++ b/docs/adr/ADR-0002-optimizasyon-motoru-modulerlestirme.md
@@ -1,0 +1,151 @@
+# ADR-0002 — Optimizasyon Motorunun Application Katmanına Taşınması ve Modüllere Bölünmesi
+
+- **Durum:** Kabul edildi
+- **Tarih:** 2026-08-11 *(karar tarihi; ADR 2026-08-17'de geriye dönük yazıldı)*
+- **Kapsam:** ALG-01…ALG-07 · PR #935 (`caab495d`) · **İlgili:** ADR-0005 (modül bayrakları)
+- **Etkilediği kod:** `apps/backend/CargoPilot.Application/Common/Optimization/`
+
+> **Geriye dönük kayıt.** Karar 2026-08-11'de alınıp uygulandı; bu ADR sonradan, kodun ve
+> commit'in üzerinden doğrulanarak yazıldı. Aşağıdaki tüm sayılar `dev` @ `628c55d4` üzerinde
+> yeniden ölçülmüştür.
+
+## Bağlam
+
+Yerleştirme motoru tek bir dosyaydı: `apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs`,
+**600 satır** (ölçüm: `git show caab495d^:apps/backend/CargoPilot.Infrastructure/Services/OptimizationEngine.cs | wc -l` → `600`).
+
+İki sorun vardı:
+
+1. **Yanlış katman.** Motor saf hesaplama yapıyor: girdi `OptimizationInput`, çıktı
+   `OptimizationResult`; veritabanı, dosya sistemi, HTTP ya da başka bir dış kaynak kullanmıyor.
+   Infrastructure katmanında durması Clean Architecture sözleşmesine aykırıydı
+   (`apps/backend/docs/architecture.md`) ve motoru test etmek için Infrastructure'ın tüm
+   bağımlılıklarını ayağa kaldırmayı gerektiriyordu.
+2. **Tek dosyada altı ayrı sorumluluk.** Sıralama, yönelim üretimi, sert kısıt doğrulaması,
+   hacim skorlaması, denge skorlaması ve LIFO bölge hesabı aynı dosyada iç içeydi. Bir kısıtı
+   değiştirmek diğer beşini okumayı gerektiriyordu.
+
+Karşı risk açıktı: motorun sıcak döngüsü kutu × aday nokta × yönelim üzerinde çalışır ve
+500 kutuluk senaryoda saniyeler mertebesindedir. Bölme, doğruluğu veya hızı bozmamalıydı.
+
+## Karar
+
+### 1. Motor Infrastructure'dan Application'a taşındı
+
+`CargoPilot.Infrastructure/Services/OptimizationEngine.cs` silindi (`git show --stat caab495d`:
+`600 ---`), yerine `CargoPilot.Application/Common/Optimization/` klasörü açıldı.
+DI kaydı da Application'a taşındı: `CargoPilot.Application/DependencyInjection.cs:24`
+`services.AddScoped<IOptimizationEngine, OptimizationEngine>();`
+
+Gerekçe:
+
+- Motor saf fonksiyondur; Application katmanının tanımına birebir uyar.
+- `IOptimizationEngine` (`Common/Interfaces/IOptimizationEngine.cs`) zaten Application'daydı;
+  arayüz ve gerçekleştirim ayrı katmanlardaydı ama arada hiçbir altyapı bağımlılığı yoktu.
+- Taşıma sayesinde motor, Infrastructure'a hiç referans vermeyen ayrı bir test projesinden
+  (`CargoPilot.Engine.Tests`) doğrudan örneklenebiliyor.
+
+Sonuçları:
+
+- Sınıflar `internal` kaldı; test görünürlüğü `InternalsVisibleTo` ile verildi
+  (`CargoPilot.Application/AssemblyInfo.cs:5,8`). Motor iç yapısı API yüzeyi değildir.
+- Infrastructure artık motoru tanımıyor; motor değişikliği Infrastructure'ı yeniden derletmiyor.
+
+### 2. Bölme biçimi arayüz/plugin değil, statik fonksiyonlardır
+
+Motor 7 dosyaya bölündü. Bölünen parçaların hiçbiri arayüz, sınıf örneği ya da DI kaydı değildir;
+hepsi `internal static class` içinde saf statik fonksiyonlardır ve motor bunları **doğrudan
+adıyla** çağırır.
+
+Bugünkü ölçüm (`wc -l`, `dev` @ `628c55d4`):
+
+| Dosya | Sorumluluk | Satır (#935) | Satır (bugün) |
+|---|---|---:|---:|
+| `OptimizationEngine.cs` | greedy döngü, aday tarama, maliyet toplama | 240 | 300 |
+| `PlacementValidator.cs` | sert kısıtlar, yönelim üretimi | 261 | 314 |
+| `BalanceScoring.cs` | denge terimi + ikinci geçiş takas | 207 | 220 |
+| `LifoPlacement.cs` | grup bölgeleri, LIFO dikey kuralı | 91 | 131 |
+| `ItemOrdering.cs` | yerleştirme sırası | 71 | 71 |
+| `VolumeScoring.cs` | hacim/derinlik/genişlik terimleri | 28 | 55 |
+| `PlacedBox.cs` | yerleşim kaydı | 17 | 17 |
+| **Toplam** | | **915** | **1 108** |
+
+Gerekçe:
+
+- **Sıcak döngüye tek bir dolaylı çağrı bile eklenmedi.** `OptimizationEngine.cs:128-134`'teki
+  altı sert kısıt kontrolü doğrudan statik çağrıdır (`PlacementValidator.HasOverlap(...)`,
+  `PlacementValidator.HasSupport(...)`, …). Arayüz kullanılsaydı bu satırların her biri
+  kutu × aday nokta × yönelim başına bir sanal çağrı olurdu ve JIT satır içine alamazdı.
+- Saf statik fonksiyon durumsuzdur; motorun determinizmi (`DeterminizmTests.cs`) çağrı sırasına
+  bağlıdır, nesne ömrüne değil. Örnek tabanlı bir modül modeli buraya gizli durum sızdırabilirdi.
+- Modülün açık/kapalı olması `bool` bayrakla çözülür (ADR-0005), plugin kaydıyla değil:
+  `OptimizationEngine.cs:17-19` bayrakları döngüden **önce bir kez** çözüp yerel `bool`lere okur.
+
+Sonuçları:
+
+- **Bu kararın en çok saldırıya uğrayacak yeri burasıdır.** "Düzgün mimari" adına
+  `IPlacementValidator`, `IScoringModule`, `IEnumerable<IConstraint>` gibi bir soyutlama
+  önermek, bu ADR'nin bilinçli olarak reddettiği şeydir. Böyle bir öneri, ölçülmüş bir
+  performans gerekçesiyle ve yeni bir ADR ile gelmelidir; bu ADR'ye dayanarak yapılamaz.
+- Dosyalar birbirine `using` ile değil, aynı ad alanında doğrudan bağlıdır. Bu, dairesel
+  bağımlılık riskini kaldırır ama modülleri ayrı derlenebilir birimler yapmaz — kasıtlı.
+- Toplam satır sayısı 600'den 915'e çıktı (+%53). Artışın büyük kısmı XML dokümantasyonu ve
+  kalibrasyon yorumlarıdır (ör. `OptimizationEngine.cs:241-268` maliyet fonksiyonu açıklaması).
+  Satır sayısı bu kararda başarı ölçütü değildir.
+
+### 3. Bölmeden önce 16 golden-master snapshot testi yazıldı
+
+Bölme, davranışı önce kilitleyip sonra taşıma sırasıyla yapıldı. `CargoPilot.Engine.Tests`
+projesi ve **16 snapshot** aynı değişiklikle repoya girdi
+(ölçüm: `git show caab495d --stat -- 'apps/backend/CargoPilot.Engine.Tests/Snapshots/'` → 16 `.json`;
+dağılım 6 VolumeFirst · 5 Lifo · 5 WeightBalance).
+
+Gerekçe:
+
+- Motor greedy'dir; en-iyi-aday seçimi `decimal` skorların karşılaştırmasına dayanır. Terimlerin
+  toplama sırası değişirse yuvarlama farkı seçimi kaydırabilir. Bu, derleme hatası vermez —
+  yalnızca plan sessizce değişir. Snapshot dışında bunu yakalayacak bir mekanizma yoktu.
+- Snapshot'lar bayt düzeyinde karşılaştırıldığı için "aynı doluluk, farklı yerleşim" bile kırmızı verir.
+
+Sonuçları:
+
+- Toplama sırası artık sözleşmedir ve kodda yazılıdır: `OptimizationEngine.cs:246-255`
+  "TOPLAMA SIRASI KRİTİKTİR — yerçekimi → uzunluk → denge → genişlik → bölge".
+- Snapshot korpusu bu karardan sonraki her motor işinde kabul kapısı oldu; ADR-0003 ve ADR-0004
+  aynı korpusa karşı ölçüldü ve ikisi de 0 kayma raporladı.
+
+## Bölmenin doğrulanması
+
+Bölme yedi adımda yapıldı ve **hiçbir adımda snapshot kaymadı**. Adımlar PR #935'te tek commit
+olarak birleştirildiği için adım adım kanıt commit geçmişinde ayrı ayrı durmuyor; bugün
+doğrulanabilir olan sonuç şudur:
+
+- Bölmeyle birlikte giren 16 snapshot dosyasının hiçbiri sonradan yeniden üretilmedi.
+  Bölmeden bu yana `Snapshots/` altına eklenen tek dosya
+  `Lifo_UcGrup_AynalanmisYukleme_BolgeSirasiKorunur.json`'dır ve o da yeni bir senaryodur,
+  mevcut bir snapshot'ın yenilenmesi değildir
+  (`git log --diff-filter=A --name-only caab495d..HEAD -- .../Snapshots/`).
+- Motorun tek genel yüzeyi `IOptimizationEngine.Run` olarak kaldı; imzası bölmeden bu yana
+  değişmedi.
+
+## Alternatifler
+
+| Alternatif | Neden seçilmedi |
+|---|---|
+| **Tek dosyada bırakmak** (600 satır) | Katman ihlali kendiliğinden çözülmezdi ve motoru Infrastructure bağımlılıkları olmadan test etmek mümkün olmazdı. Ayrıca ADR-0003/ADR-0004'ün dokunduğu iki farklı kısıt aynı dosyada olurdu; iki iş kalemi aynı hunk'ta çakışırdı. |
+| **Arayüz + DI ile plugin mimarisi** (`IConstraint`, `IScoringModule` listeleri) | Sıcak döngüde kutu × aday nokta × yönelim başına sanal çağrı ekler; `OptimizationEngine.cs:128-134`'teki altı kontrol JIT tarafından satır içine alınamaz hale gelirdi. Modül açma/kapama zaten `bool` bayrakla çözülebiliyordu (ADR-0005) — soyutlamanın karşılığı yoktu. **Bu ADR'nin bilinçli reddi.** |
+| **Ayrı `CargoPilot.Engine` derlemesi** | Katman sorununu çözerdi ama `internal` görünürlüğü kaybettirir, motorun iç tiplerini (`PlacedBox`, `PlacementValidator`) yayın yüzeyi yapardı. `InternalsVisibleTo` ile test erişimi aynı sonucu bedelsiz verdi. |
+| **Önce bölüp sonra test yazmak** | Snapshot olmadan bölmenin davranışı koruyup korumadığı ölçülemezdi; greedy `decimal` skorlamada davranış kayması derleme hatası vermez, sessizce plan değiştirir. |
+
+## Açık konular
+
+- Klasör bölmeden sonra iki dosya daha aldı: `DoorSetFactory.cs` (37) ve `LoadingCorner.cs` (50),
+  ikisi de PR #1013 koordinat standardı çalışmasından. Bunlar `public static` — motorun içi
+  değil, kapı/başlangıç köşesi türetme yardımcılarıdır. Klasörün bugünkü toplamı
+  **9 dosya / 1 195 satır**; bu ADR'nin kapsadığı 7 dosya **1 108 satırdır**.
+- Bölme performans **ölçümü** ile doğrulanmadı; gerekçe analitiktir (sanal çağrı yok, satır içi
+  alma korundu). Bugün `PerformansTabanCizgisiTests.cs` bir taban çizgisi tutuyor, ama bölme
+  öncesi/sonrası karşılaştırması yapılmamıştır — **ölçülmedi**.
+- `ContaminationFilter.cs` bölmeye dahil edilmedi; `Common/` altında kaldı. Motorun içinden
+  değil, komut işleyicilerinden çağrılıyor
+  (`CreatePlanCommandHandler.cs:162`, `ReOptimizePlanCommandHandler.cs:93`). Yeri tartışmaya açık.

--- a/docs/adr/ADR-0003-lifo-bolge-sert-kisiti.md
+++ b/docs/adr/ADR-0003-lifo-bolge-sert-kisiti.md
@@ -1,0 +1,156 @@
+# ADR-0003 — LIFO Bölge Kısıtı: İki Kademeli Sert Kısıt
+
+- **Durum:** Kabul edildi
+- **Tarih:** 2026-08-15 *(karar tarihi; ADR 2026-08-17'de geriye dönük yazıldı)*
+- **Kapsam:** OPT-02 · PR #990 (`b12a2e0f`), PR #1002 (`7b699f35`)
+- **Etkilediği kod:** `CargoPilot.Application/Common/Optimization/LifoPlacement.cs`,
+  `.../OptimizationEngine.cs`
+
+> **Geriye dönük kayıt.** Karar 2026-08-15'te alınıp uygulandı; bu ADR sonradan yazıldı.
+> Ölçümler gerçek `dotnet test` koşularından alınmıştır (.NET 8.0.419).
+
+## Bağlam
+
+LIFO kriterinde her boşaltma grubuna araç uzunluğu üzerinde bir Z bölgesi ayrılır
+(`LifoPlacement.ComputeGroupZones`). Amaç, ilk inecek grubun kapıya en yakın, son inecek grubun
+en uzakta durmasıdır — operatör kamyonu doğru sırayla boşaltabilsin diye.
+
+Bölge disiplini **yumuşak ceza** ile uygulanıyordu: bölgeden taşan her santimetre skora
+`2 000` ekliyordu. Aynı skor toplamında yerçekimi terimi ise `1 000 000` katsayılıydı
+(`OptimizationEngine.cs:11` `GravityCoefficient = 1_000_000m`, `LifoPlacement.cs:29`
+`ZoneOverflowPenaltyPerCm = 2_000m`). Yani bölge cezası yerçekiminden **500× zayıftı**.
+
+Sonuç analitik olarak nettir: her iki terim de cm'de lineerdir, dolayısıyla motor
+`taşma_cm × 2 000 < yükselme_cm × 1 000 000` olduğu sürece **ihlali seçer**. 1 cm yükselmekten
+kaçınmak 500 cm taşmayı affeder. Pratikte bu, çok katmanlı LIFO planlarında bölgenin daima
+ihlal edilmesi demekti.
+
+Üç ek tespit kararı belirledi:
+
+1. **LIFO'nun dikey yarısı zaten sert kısıttı.** `OptimizationEngine.cs`'te
+   `ViolatesStackability` aday elemeyle (`continue`) çalışıyor; yatay yarısının yumuşak kalması
+   mimari tutarsızlıktı.
+2. **Kodun kendi testi sert kısıt iddia ediyordu.** `GroupZoneTests.cs:46`
+   (bugün, PR #1002'nin test yenilemesinden sonra `:55`) kesin içerme assert'i yapıyor:
+   `Assert.True(placement.Z >= zoneStart && placement.Z + placement.Length <= zoneEnd, …)`.
+   Sözleşme sert, uygulama yumuşaktı.
+3. **Test korpusu bu çatışmayı hiç tetiklemiyordu.** 5 LIFO golden-master snapshot'ının
+   tamamında tek Y değeri vardı ve o da `0`'dı; çok katmanlı LIFO senaryosu adedi **0**.
+   `GroupZoneTests.cs`'te de araç yüksekliği kutu yüksekliğine eşitti, yani `:46`'daki sert
+   assert **tesadüfen** geçiyordu.
+
+## Karar
+
+### 1. Bölge, iki kademeli aday seçimiyle sert kısıt yapıldı
+
+Aday tarama iki en-iyi tutar: genel en iyi (`best`) ve bölge içi en iyi (`bestInZone`).
+Tarama bittiğinde bölge içi geçerli bir aday varsa **yalnızca o kazanır**.
+
+- `OptimizationEngine.cs:99-100` — `PlacedBox? bestInZone = null; var bestInZoneScore = decimal.MaxValue;`
+- `OptimizationEngine.cs:158-162` — mevcut `if (score < bestScore)` bloğu **aynen korunarak**
+  ikinci kademe eklendi: `if (LifoPlacement.IsInsideZone(...) && score < bestInZoneScore) …`
+- `OptimizationEngine.cs:167` — kısıtın sertleştiği tek satır: `best = bestInZone ?? best;`
+- `LifoPlacement.cs:127` — yeni saf yüklem `IsInsideZone(zoneStart, zoneEnd, ez, length)`
+
+Gerekçe:
+
+- Bölge içi aday yoksa (bölge kutudan dar kalabilir) bugünkü cezalı skorlamaya düşülür, yani
+  **kutu yalnızca bölgesi yüzünden düşmez.** Kapasite kaybı riski böyle kapatıldı.
+- Katı `<` karşılaştırması ikinci kademede de korundu; eşit skorlu adaylarda ilk gelen kazanır,
+  determinizm bozulmaz (`DeterminizmTests` yeşil kaldı).
+- Ek maliyet aday başına O(1) karşılaştırmadır.
+
+Sonuçları:
+
+- Ölçülen düzelme: bölge ihlali **P1 4/8 → 0/8**, **P2 2/5 → 0/5**.
+- Yerleşen kutu ve doluluk **birebir aynı kaldı**: P1 8 kutu / FillRate 1,0 · P2 5 kutu /
+  FillRate 0,2125. Sert kısıt hiçbir kutu kaybettirmedi; bu parite test içinde assert olarak
+  kilitlendi (`LifoBolgeKisitiTests.cs`).
+- **Snapshot kayması 0.** `git status --short apps/backend/CargoPilot.Engine.Tests/Snapshots/`
+  → boş çıktı; 5 LIFO golden-master yeniden üretilmeden geçti.
+- Performans regresyonu yok: LIFO 500 kutu 9 777 ms → 8 107 ms, VolumeFirst 10 058 → 9 855 ms,
+  WeightBalance 20 968 → 20 771 ms (farklar ölçüm gürültüsü mertebesinde, üst sınır 120 000 ms).
+- Yedek kademeye düşen yerleşim **hiçbir yere raporlanmıyor**; kullanıcı planın bölge dışına
+  taştığını göremiyor. Bilinçli kapsam sınırı, aşağıda açık konu.
+
+### 2. Bölge katsayısı 2 000'de kaldı
+
+`LifoPlacement.cs:29` `ZoneOverflowPenaltyPerCm = 2_000m` — değer **değişmedi**, yalnızca
+literal isimlendirildi.
+
+Gerekçe:
+
+- Katsayı artık diğer terimlerin akranı değil; yalnızca **yedek kademede** adayları kendi
+  aralarında sıralar. Bölge içi aday varsa o skorun bölge terimi zaten `0`'dır.
+- Katsayıyı büyütmek ölçülerek elendi (aşağıya bakınız). Yerçekimi katsayısıyla yarışan bir
+  sayı seçmek, kararın gerçek dayanağını (sözleşme sertliği) kalibrasyona bırakmak olurdu.
+
+Sonuçları:
+
+- `OptimizationEngine.cs:256-264`'teki maliyet fonksiyonu yorumu bunu yazılı hale getirdi:
+  "BÖLGE TERİMİ ARTIK DİĞERLERİNİN AKRANI DEĞİLDİR… Katsayının yerçekimi katsayısından küçük
+  olması bu nedenle bölge disiplinini zayıflatmaz."
+- `ScoringWeights.Zone > Gravity` biçiminde bir sıra testi **yazılmadı** ve yazılmamalıdır;
+  yanlış invaryantı kilitler (aşağıya bakınız).
+
+## Ölçüm — üç varyantın karşılaştırması
+
+İki senaryo, gerçek `dotnet test` ile üç kod durumunda koşuldu.
+
+- **P1** — araç 100×200×200, 2 grup × 4 kutu (100×50×100), `Fixed`, `Rear`, `clusterGroups: true`.
+  Taşma büyüklüğü 100 cm, kat yüksekliği 50 cm.
+- **P2** (ayırt edici) — araç 100×200×200, grup1 4×(50×50×60), grup2 1×(50×50×100).
+  Grup1'in ikinci sıra kutusu bölgesini yalnız **20 cm** aşar; bölge içi alternatif bir kat
+  yukarıdadır (50 cm).
+
+| Varyant | P1 ihlal | P1 yerleşen / fill | P2 ihlal | P2 yerleşen / fill |
+|---|---|---|---|---|
+| Mevcut (katsayı 2 000) | 4/8 | 8 / 1,0 | 2/5 | 5 / 0,2125 |
+| Katsayı 2 000 000 | 0/8 | 8 / 1,0 | **1/5** | 5 / 0,2125 |
+| **İki kademeli sert kısıt** | **0/8** | 8 / 1,0 | **0/5** | 5 / 0,2125 |
+
+P2'deki kalan ihlal tam olarak analitik eşikte: taşma 20 cm < kat yüksekliği 50 cm ÷ 2 = 25 cm.
+Yani sonlu hiçbir katsayı garanti üretmiyor; yalnızca eşiği kaydırıyor.
+
+## Alternatifler
+
+| Alternatif | Neden seçilmedi |
+|---|---|
+| **Katsayıyı 2 000 → 2 000 000 yapmak** (bölgeyi yerçekiminin üstüne çıkarmak) | **Ölçülerek elendi.** P1'i düzeltiyor (4/8 → 0/8) ama **P2'de 1/5 ihlal bırakıyor**. Sebep yapısal: her iki terim de cm'de lineer, dolayısıyla sonlu hiçbir K değeri garanti vermez — yalnızca affedilen taşma eşiğini `500 cm/cm`'den `0,5 cm/cm`'ye çeker. |
+| **Koşulsuz sert eleme** (bölge dışı adayı `continue` ile atmak) | **Ölçülerek elendi.** `Lifo_KumelemeKapali` senaryosunda araç uzunluğu 100, 2 bölge → `zoneSize = 50`, kutu uzunluğu 100; **hiçbir aday bölge içinde değil**. Koşulsuz elemede FillRate **0,5 → 0** olurdu ve snapshot bozulurdu. İki kademeli biçim tam da bunun için seçildi ve o snapshot'ı bit-birebir korudu. |
+| **`ScoringWeights.Zone > Gravity` sıra testi eklemek** | İnvaryantın kendisini değil vekilini test eder: P2'de bu assert yeşil yanarken plan bozuktu. Ayrıca önerinin kendi kaynağının dayattığı `Gravity > Zone` sırasının tersini kilitliyordu. |
+| **Bölgeleri grup hacmine orantılı bölmek** (`zoneSize = vehicleLength / orders.Count` yerine) | Kanıt yetersiz. Bu yolu savunan iki bağımsız analiz de kendi risk bölümlerinde karşı-örnek verdi: biri 8 → 4 yerleşime düşen bir kombinasyon, diğeri ihlali **artıran** bir kombinasyon. Ayrı iş kalemi olarak bırakıldı. |
+| **Hiçbir şey yapmamak / snapshot'ları yeni davranışa göre yenilemek** | Bugün sessizce yanlış olan davranış hiçbir snapshot'ta kayıtlı değildi (5/5 snapshot tek katmanlı, tümü `Y: 0`). Snapshot yenilemek, `GroupZoneTests`'in sert içerme sözleşmesiyle çelişen davranışı kalıcılaştırırdı. |
+
+## Neden bu karar doğru zamanda alındı
+
+PR #997 (`fix/koordinat-z-ekseni`) bölge **geometrisini** ters çevirirken grup **yerleştirme
+sırasını** (`ItemOrdering.SortForGroupPlacement`) değiştirmiyordu. Kendi dalında yeşildi, çünkü
+o dalda sert kısıt yoktu ve iki LIFO snapshot'ı yeni davranışa göre yeniden üretilmişti.
+`dev` ile birleştirildiğinde `LifoBolgeKisitiTests` her iki senaryoda **P1 8/8 ve P2 5/5** ihlal
+ölçtü — yani kutuların %100'ü kendi bölgesinin dışındaydı, tam ters yükleme.
+
+Yumuşak ceza altında bu hata görünmez olurdu: snapshot yeniden üretilir, ters yükleme sabitlenirdi.
+Sert kısıt onu derleme sonrası ilk test koşusunda görünür kıldı.
+
+## Açık konular
+
+- **Kapsam yalnız `LoadingType.Rear`.** `LifoPlacement.cs`'te bölge hesabı arka kapı dışında
+  hiç çalışmıyor; 5 yükleme tipinin 4'ünde bölge oluşmuyor. LIFO vaadi bu karardan sonra da
+  kısmi (OPT-10).
+- **Eşit bölme kusuru duruyor.** `LifoPlacement.cs:80` `zoneSize = vehicleLength / orders.Count`
+  grup hacmini görmüyor. Bölge kutudan dar kaldığında yedek kademe devreye girer ve ihlal
+  sessizce sürer.
+- **Sessiz yedek kademe.** `OptimizationEngine.cs:167`'de `bestInZone` null kalıp yedek kademeye
+  düşen yerleşim raporlanmıyor. Çözüm yeni bir `UnplacedReason` değildir (kutu düşmüyor);
+  `LoadingPlanWarnings` üzerinden uyarı gerekir.
+- **Sentinel kusuru (OPT-14).** `OptimizationEngine.cs:85`
+  `groupZones.TryGetValue(item.UnloadingOrder ?? -1, out var zone)` — bölge sözlüğü
+  `GroupId + UnloadingOrder` ikilisinden kuruluyor ama arama anahtarı yalnız `UnloadingOrder`.
+  İki kademeli biçimde zararsız, semantik olarak yanlış.
+- **Ölçüm kapsamı:** iki senaryo ölçüldü, geniş bir senaryo taraması yapılmadı. Yön kesin
+  (0 ihlal, 0 kutu kaybı); greedy yol bağımlılığının genel olarak zararsız olduğu
+  **kanıtlanmadı**.
+- **Karar sonrası değişiklik:** PR #1013 (koordinat standardı) bölge geometrisini
+  `LifoPlacement.cs:93-94`'te yeniden yazdı (`zStart = isLast ? 0m : vehicleLength - (i+1)*zoneSize`).
+  Bu ADR'nin kararı — bölgenin *sert* olması — değişmedi; değişen, bölgenin nerede olduğudur.

--- a/docs/adr/ADR-0004-denge-takasi-cift-yonlu-dogrulama.md
+++ b/docs/adr/ADR-0004-denge-takasi-cift-yonlu-dogrulama.md
@@ -1,0 +1,204 @@
+# ADR-0004 — Denge Takasında Çift Yönlü Doğrulama
+
+- **Durum:** Kabul edildi
+- **Tarih:** 2026-08-15 *(karar tarihi; ADR 2026-08-17'de geriye dönük yazıldı)*
+- **Kapsam:** OPT-01 · PR #989 (`72e9fdfa`) · **Sonradan sınandı:** PR #997 (`62be448f`)
+- **Etkilediği kod:** `CargoPilot.Application/Common/Optimization/BalanceScoring.cs`,
+  `.../PlacementValidator.cs`
+
+> **Geriye dönük kayıt.** Karar 2026-08-15'te alınıp uygulandı; bu ADR sonradan yazıldı.
+> Ölçümler gerçek `dotnet test` koşularından alınmıştır (.NET 8.0.419, izole çalışma kopyası).
+
+## Bağlam
+
+`WeightBalance` kriterinde greedy faz bittikten sonra ikinci bir geçiş çalışır: kutu çiftleri
+takas edilerek ağırlık merkezi sapması azaltılır (`BalanceScoring.ImproveBalance`). Her aday
+takas `SwapIsValid` ile fiziksel kısıtlara karşı doğrulanır.
+
+`SwapIsValid` içindeki üst-kutu destek doğrulaması tek bir `if`'in içine hapsedilmişti
+(düzeltme öncesi `BalanceScoring.cs:178`):
+
+```csharp
+if (a.H != b.H)
+{
+    var oldATopY = b.Y + a.H;
+    var oldBTopY = a.Y + b.H;
+    foreach (var c in others) { … HasSupportFor(c, …) … }
+}
+```
+
+**Koşul yanlıştı.** Destek kaybının koşulu yükseklik farkı değil, **taban alanı farkıdır.**
+İki kutu aynı yükseklikte ama farklı genişlikte olduğunda takas sonrası eski üst yüzeyler aynı
+Y'de kalır; buna rağmen o seviyede duran kutunun **altındaki destek alanı** değişir.
+`a.H == b.H` durumunda döngü hiç çalışmıyor, destek kontrolü tamamen atlanıyordu → havada kutu.
+
+İki ek kör nokta aynı fonksiyondaydı:
+
+1. `others` listesi `k != i && k != j` ile kuruluyordu, yani **a ve b birbirine karşı hiçbir
+   kısıtta test edilmiyordu** — ne çakışma, ne destek, ne istif, ne kırılganlık.
+2. `ViolatesStackability` / `StackCount` / `StackWeight` / `Fragility` yalnızca **aşağı**
+   bakıyordu. Takas bir kutuyu mevcut bir yığının **altına** taşıdığında o kutunun kendi
+   `IsStackable` / `FragilityType` / `MaxStackCount` / `MaxWeightOnTop` kısıtları hiçbir yerde
+   değerlendirilmiyordu.
+
+Hata sentetik değildi. 500 kutuluk gerçekçi `WeightBalance` yükünde taban çizgisinde
+**1 kutu havada** kalıyordu:
+
+```
+[Buyuk500_WeightBalance] 1 kutu havada (gereken destek 0.80):
+318. kutu destek oranı 0.6667 — …@(180,110,415) 60x35x50
+```
+
+## Karar
+
+### 1. Yükseklik koşulu kaldırıldı; destek doğrulaması her takasta çalışır
+
+`if (a.H != b.H)` koşulu ve süslü parantezleri silindi. İki eski üst yüzey seviyesi
+(`oldATopY`, `oldBTopY`) her takasta taranır.
+
+Gerekçe koda yazıldı (`BalanceScoring.cs:189-190`):
+*"…yükseklikler eşit olsa bile kontrol atlanamaz çünkü kutuların taban ALANI birbirinden farklı
+olabilir."*
+
+Sonuçları:
+
+- Bu, kararın **maliyet üreten** tek maddesidir: eşit yükseklikli çiftlerde daha önce atlanan
+  destek taraması artık her çiftte koşuyor (ölçüm aşağıda).
+- Üst kutu destek döngüsü indeks tabanlı yazıldı (`BalanceScoring.cs:194-202`,
+  `placements.Where((_, m) => m != k)`), böylece eski ifadedeki `record` değer-eşitliği
+  bağımlılığı ortadan kalktı — aynı boyut/ağırlıktaki iki kutu artık birbirine karışmıyor.
+
+### 2. `others` ikiye bölündü: `othersA` / `othersB`
+
+`BalanceScoring.cs:152-153`:
+
+```csharp
+var othersA = placements.Where((_, k) => k != i).ToList();   // b'yi YENİ konumunda içerir
+var othersB = placements.Where((_, k) => k != j).ToList();   // a'yı YENİ konumunda içerir
+```
+
+16 kısıt çağrısının argümanı yönüne göre `othersA`/`othersB` olarak değiştirildi
+(`BalanceScoring.cs:157-177`).
+
+Gerekçe:
+
+- Tek değişiklikle a↔b kör noktası **altı kısıtın tamamında** aynı anda kapanır; kısıt başına
+  ayrı bir özel durum yazmaya gerek kalmaz.
+
+Sonuçları:
+
+- Daha önce sessizce kabul edilen bazı takaslar artık reddediliyor. Denge kalitesindeki kayıp
+  **ölçülemedi**: mevcut snapshot korpusu tek tip 100×100×100 küplerden ibaret olduğu için
+  reddedilme koşulları o geometride tetiklenmiyor. 500 kutuluk senaryoda doluluk değişmedi
+  (%58,4) — iyiye işaret, ama tek gözlem.
+
+### 3. `ViolatesLoadAbove` eklendi
+
+`PlacementValidator.cs:226` — kutunun **üstündeki** yükü kutunun kendi kısıtlarına karşı soran
+tek geçişli O(n) fonksiyon. `BalanceScoring.cs:182-183`'te her iki yön için çağrılıyor.
+
+Gerekçe:
+
+- Mevcut dört kısıt fonksiyonunun hepsi aşağı bakıyordu; yukarı bakan aynası yoktu. Takas bir
+  kutuyu yığının altına taşıyabildiği için bu ayna zorunluydu.
+- Semantik, aşağı bakan aynalarıyla birebir hizalandı: istiflenebilirlik tam temasla,
+  kırılganlık/istif adedi/üst ağırlık sütun geneliyle değerlendirilir; örtüşme formülü aynıdır.
+
+Sonuçları:
+
+- Kısıtsız kutuda erken çıkışla maliyet sıfırdır (`IsStackable && !Fragile && MaxStackCount <= 0
+  && MaxWeightOnTop <= 0m` → `false`).
+- Fonksiyonun **doğrudan birim testi yok**; dolaylı olarak `InvariantTests` ve
+  `KirilganlikTests` kapsıyor. Kalan boşluk.
+
+### 4. %43 yavaşlama bilinçli olarak kabul edildi
+
+500 kutu, aynı makine, izole çalışma kopyası:
+
+| Kriter | Öncesi | Sonrası | Oran |
+|---|---|---|---|
+| VolumeFirst | 9 785 ms | 10 017 ms | 1,02× (gürültü) |
+| **WeightBalance** | **20 562 ms** | **29 453 ms** | **1,43×** |
+| Lifo | 9 662 ms | 9 771 ms | 1,01× (gürültü) |
+
+Gerekçe:
+
+- Yavaşlamanın kaynağı doğrudan kararın 1. maddesidir; ucuzlatmanın tek yolu atlanan kontrolü
+  geri koymaktır, yani hatayı geri getirmektir.
+- Yalnızca `WeightBalance` etkilenir; `ImproveBalance` diğer iki kriterde hiç çağrılmıyor.
+- En yavaş kriter 29,5 sn ile `PerformansTabanCizgisiTests`'in **120 000 ms** üst sınırının çok
+  altında; sınır değiştirilmedi ve zorlanmadı.
+- Yerleşen kutu, dışarıda kalan ve doluluk üç kriterde de değişmedi (`yerlesen=500 disarida=0
+  doluluk=%58,4`). Bedel süredir, plan kalitesi değil.
+
+Sonuçları:
+
+- Tek tip paletli gerçek yüklerde artış daha büyük olabilir; performans testi bu yükü temsil
+  etmiyor. **Tahmin — ölçülmedi.**
+- Motorun bu bölgesine dokunacak bir sonraki iş (ör. yerinde takas + delta ceza) bu maliyetin
+  üstüne gelir; süre bütçesi oradan yeniden değerlendirilmelidir.
+
+### 5. Bu ADR olmasaydı düzeltme geri gelirdi — ve neredeyse geldi
+
+PR #997 (`fix/koordinat-z-ekseni`) `dev`'in 9 commit gerisinden dallanmıştı ve OPT-01'i
+görmüyordu. Kendi dalında `BalanceScoring.SwapIsValid`'in **eski** hâlini taşıyordu: tek `others`
+listesi ve `if (a.Height != b.Height)` kapısı — yani düzeltmenin kaldırdığı koşul, yalnızca
+ölçü alanları yeniden adlandırılmış (`.W/.H/.D` → `.Width/.Height/.Length`) hâliyle.
+
+Git bu iki değişikliği çakışmasız birleştirebiliyordu. Kapı, yeni alan adlarıyla ve
+"koordinat standardı uyumu" başlığı altında, davranışsal bir geri alma olarak görünmeden geri
+gelebilirdi. Birleştirmede bilinçli olarak `dev` tarafı korundu, #997 tarafı atıldı ve yalnız
+alan adları çevrildi.
+
+Doğrulama (`dev` @ `628c55d4`):
+
+- `grep -c 'a.H != b.H' BalanceScoring.cs` → `0`
+- `grep -c 'a.Height != b.Height' BalanceScoring.cs` → `0`
+- `ViolatesLoadAbove` çağrıları yerinde: `BalanceScoring.cs:182-183`
+
+**Bu ADR'nin varlık sebebi budur.** Yazılı bir karar kaydı olsaydı, o hunk'ın ne olduğu
+birleştirmeyi yapan kişiye tartışmasız görünürdü. Bundan sonra bu dosyanın destek doğrulama
+bölgesine dokunan her PR, bu ADR'ye atıf yapmadan yükseklik tabanlı bir kapı geri getiremez.
+
+## Kanıt — kırmızıdan yeşile
+
+| Ölçüm | Düzeltme ÖNCESİ | Düzeltme SONRASI |
+|---|---|---|
+| Toplam test | 59 | 59 |
+| Geçen | 57 | **59** |
+| Kırmızı | **2** | **0** |
+| Golden-master (6 VolumeFirst + 5 Lifo + 5 WeightBalance) | — | **16/16 yeşil** |
+| Değişen snapshot dosyası | — | **0** (`git status --porcelain .../Snapshots` → boş) |
+
+Kırmızıdan yeşile dönen iki test:
+
+1. `BalanceSwapSupportTests.WeightBalance_EsitYukseklikteFarkliTabanliTakas_UsttekiKutuyuHavadaBirakmaz`
+   — araç 200×200×100; A (0,0,0) 100×50×100, B (100,0,0) 50×50×100, C (0,50,0) 100×50×100.
+   `A.H == B.H == 50` olduğu için eski kapı bloğu atlanıyor; takas sonrası C'nin altında yalnız B
+   kalıyor → örtüşme 50×100 = 5 000, taban 100×100 = 10 000 → **destek oranı 0,50 < 0,80**.
+   Denge cezası 0,4375 → 0,3125 düştüğü için takas kabul ediliyordu.
+2. `InvariantTests.Motor_UretilenPlan_FizikselDegismezleriKorur(senaryo: "Buyuk500_WeightBalance")`
+   — 500 kutuluk gerçekçi yükte 1 kutu havada (destek oranı 0,6667).
+
+Üretim kodu değişikliği **2 dosya** (`BalanceScoring.cs` +51/−38, `PlacementValidator.cs` +53/−0).
+
+## Alternatifler
+
+| Alternatif | Neden seçilmedi |
+|---|---|
+| **Koşulu `a.H != b.H` yerine `a.Width != b.Width \|\| a.Length != b.Length` yapmak** | Aynı hatanın daha dar hâli. Taban alanı eşit ama **konumu** farklı iki kutuda da destek değişir; koşul yine yanlış negatif üretirdi. Doğru koşul yoktur — kontrol her takasta çalışmalıdır. |
+| **Plan geneli ihlal sayacı** (`CountViolations` + `baselineViolations`, "yeni ihlal yok" kapısı) | Takas başına O(n²) tam tarama demektir; ikinci geçiş zaten O(n²) ve 3 tur çalışıyor. Ölçülen %43 yerine kat kat daha büyük bir maliyet üretirdi. Ayrıca "önceden var olan ihlali koru" semantiği, hatayı gizlemenin başka bir biçimidir. |
+| **İkinci geçişi (`ImproveBalance`) tamamen kapatmak** | Hatayı kesin olarak ortadan kaldırırdı ama `WeightBalance` kriterinin tek ağırlık merkezi iyileştirme mekanizması odur; kriter işlevsiz kalırdı. Beş `WeightBalance` golden-master'ının tamamı bu geçişin çıktısını kilitliyor. |
+| **Yavaşlamayı önlemek için kontrolü örnekleme ile yapmak** (her N takasta bir) | Fiziksel geçerlilik olasılıksal olamaz: tek bir kaçak takas havada kutu üretir ve bu üretimde operatörün karşısına çıkar. Ölçülen 29,5 sn zaten 120 sn sınırının altında. |
+
+## Açık konular
+
+- **Denge kalitesi bedeli ölçülemedi.** Snapshot korpusu tek tip küplerden ibaret; reddedilen
+  takasların ağırlık merkezine etkisi mevcut testlerle görünmüyor. Farklı taban alanlı kutulardan
+  oluşan bir `WeightBalance` senaryosu eklenmeli.
+- **`ViolatesLoadAbove` doğrudan test edilmiyor.** Kırılganlık ve `MaxWeightOnTop` odaklı iki
+  takas testi yazılmadı.
+- **Kapsam sınırı:** bu karar yalnız takasın *yeni* ihlal yaratmasını engeller. Greedy fazın
+  ürettiği yerleşimde önceden var olan bir ihlal varsa düzeltmez. Bilinçli.
+- **Gerçek yük profili ölçülmedi.** Tek tip paletli yüklerde eşit yükseklikli çift oranı çok daha
+  yüksek olacağı için yavaşlama 1,43×'in üzerine çıkabilir (**tahmin**).

--- a/docs/adr/ADR-0005-modul-bayraklari-disa-kapali.md
+++ b/docs/adr/ADR-0005-modul-bayraklari-disa-kapali.md
@@ -1,0 +1,133 @@
+# ADR-0005 — Modül Bayraklarının API'ye ve Arayüze Açılmaması
+
+- **Durum:** Kabul edildi
+- **Tarih:** 2026-08-11 *(karar tarihi; ADR 2026-08-17'de geriye dönük yazıldı)*
+- **Kapsam:** ALG-01…ALG-07 · PR #935 (`caab495d`) · **İlgili:** ADR-0002
+- **Etkilediği kod:** `CargoPilot.Application/Common/Models/OptimizationInput.cs`,
+  `.../Features/Plans/CreatePlan/`, `.../Features/Plans/ReOptimizePlan/`
+
+> **Geriye dönük kayıt.** Karar 2026-08-11'de motorun modülerleştirilmesiyle birlikte alındı;
+> bu ADR sonradan, kodun üzerinden doğrulanarak yazıldı.
+
+## Bağlam
+
+ADR-0002 ile motor modüllere bölününce, modülleri tek tek açıp kapatan dört `bool` bayrak
+ortaya çıktı (`OptimizationInput.cs:52-56`):
+
+```csharp
+public sealed record OptimizationModules(
+    bool UseVolume, bool UseWeightBalance, bool UseLifo, bool UseContamination)
+```
+
+Bayraklar motorun içinde gerçekten kullanılıyor: `OptimizationEngine.cs:17-19` bunları sıcak
+döngüden önce çözüp yerel `bool`lere okuyor, `ComputeScore` hangi terimin toplanacağını bu
+bayraklarla belirliyor, ikinci geçiş `OptimizationEngine.cs:202-207`'de `useWeightBalance` ile
+koşullu.
+
+Yani mekanizma hazır. Doğal beklenti, bunu bir API alanı ve arayüzde dört onay kutusu olarak
+kullanıcıya açmaktır — "hacim terimini kapat", "kontaminasyon filtresini atla" gibi. Bu ADR
+bunun **neden yapılmadığını** kayıt altına alır.
+
+## Karar
+
+### 1. Bayraklar hiçbir API sözleşmesine bağlanmaz
+
+`OptimizationModules` hiçbir request DTO'sunda, komutta, validator'da veya Swagger şemasında
+görünmez. Kaynak kod bunu tipin kendi XML dokümantasyonunda yazılı hale getirir
+(`OptimizationInput.cs:46-50`):
+
+> *"Bilinçli olarak dışarıya kapalıdır: skor katsayıları yalnızca mevcut üç kriter için kalibre
+> edilmiştir, dört bayrağın ürettiği on altı kombinasyonun çoğu kalibre edilmemiştir. Bu yüzden
+> hiçbir API sözleşmesine (request DTO, komut, validator, Swagger şeması) bağlanmaz; yalnızca
+> motorun içinden ve testlerden kullanılır."*
+
+Gerekçe:
+
+- **4 bayrak = 16 kombinasyon.** Skor katsayıları (`GravityCoefficient = 1_000_000`,
+  `LengthCoefficient = 1_000`, `WeightBalanceCoefficient = 900_000`, `VolumeFirstCoefficient = 500`,
+  `ZoneOverflowPenaltyPerCm = 2_000`) yalnızca mevcut **üç** kriterin ürettiği üç kombinasyon
+  için kalibre edildi. Kalan 13 kombinasyonun hiçbiri ölçülmedi.
+- Kalibre edilmemiş bir kombinasyon derleme hatası ya da çalışma zamanı hatası vermez —
+  **anlamsız ama geçerli görünen bir plan üretir.** Operatör bunu ancak sahada fark eder.
+- Katsayıların büyüklük farkı (1 000 000 ile 500 arasında 2 000× fark) terimlerin birbirini
+  bastırma sırasına dayanır. Bir terimi kapatmak, kalanların göreli ağırlığını kalibre edilmemiş
+  bir orana taşır; bu, ADR-0003'te ölçülen "500× zayıf terim" sorununun aynısını başka bir yerde
+  üretir.
+
+Sonuçları:
+
+- Bayraklar `internal` erişimle sınırlı: `FromCriteria` ve `Resolve` fonksiyonları
+  (`OptimizationInput.cs:64,72`) `internal static`. Testler bunlara `InternalsVisibleTo`
+  üzerinden erişiyor (`AssemblyInfo.cs:8`).
+- Kullanıcıya görünen tek kaldıraç `LoadingPlanOptimizationCriteria` enum'ıdır (VolumeFirst /
+  WeightBalance / Lifo) — yani kalibre edilmiş üç kombinasyon.
+
+### 2. Komut işleyicileri bayrak vermez; varsayılan kriterden türetilir
+
+Her iki üretim çağrı yolu bayrağı açıkça `null` geçer:
+
+- `CreatePlanCommandHandler.cs:259` → `Modules: null,`
+- `ReOptimizePlanCommandHandler.cs:184` → `Modules: null,`
+
+Motor bunu `OptimizationModules.Resolve(input)` ile çözer (`OptimizationEngine.cs:17`);
+`Modules` null olduğunda `FromCriteria(input.Criteria)` devreye girer
+(`OptimizationInput.cs:64-69`) ve türetme, kodun daha önce hangi modülü hangi koşulda
+çalıştırdığının birebir aynısıdır:
+
+| Bayrak | Türetme | Karşılığı |
+|---|---|---|
+| `UseVolume` | `criteria != WeightBalance` | hacim terimleri WeightBalance dışında |
+| `UseWeightBalance` | `criteria != Lifo` | denge katsayısı Lifo dışında |
+| `UseLifo` | `criteria == Lifo` | bölge hesabı yalnızca Lifo'da |
+| `UseContamination` | `true` | kontaminasyon filtresi her zaman |
+
+Gerekçe:
+
+- Modülerleştirme bir **davranış değişikliği değildi**; bayrak mekanizmasının eklenmesi üretim
+  planlarını değiştirmemeliydi. `Modules: null` bunu garanti eder.
+- Bu, ADR-0002'nin 16 snapshot testinin bölme boyunca yeşil kalabilmesinin de ön koşuluydu.
+
+Sonuçları:
+
+- **Üretim davranışı değişmedi.** Bayraklar kodda mevcut olduğu hâlde üretimde hiçbir zaman
+  varsayılandan farklı bir değer almadı.
+- Mekanizma testlerde kullanılıyor ve orada değerini kanıtlıyor:
+  `ModulBayraklariTests.AcikBayraklar_VarsayilanTuretmeyle_AyniPlaniUretir` türetmenin doğruluğunu,
+  `DengeKapali_WeightBalanceKriterinde_DahaDengesizPlanUretir` ve
+  `LifoKapali_GrupluSenaryoda_BolgeAyrimiUygulanmaz` ise modüllerin gerçekten etkili olduğunu
+  gösteriyor. Bayrakları test dışında kullanmadan bu üç iddia doğrulanamazdı.
+- Bayrak alanı `OptimizationInput` üzerinde durduğu için, açılmasına karar verilirse tek bir
+  DTO alanı yeterlidir. Karar geri alınabilir; şu an bilinçli olarak alınmamıştır.
+
+## Açılmasının ön koşulları
+
+Bu karar sonsuza kadar geçerli değildir. Bayrakların dışa açılması için, yeni bir ADR ile:
+
+1. Açılacak **her kombinasyon** için katsayı kalibrasyonu yapılmış ve ölçümü kayıt altına
+   alınmış olmalı (kalan 13 kombinasyonun tamamı değil, yalnızca açılacak olanlar).
+2. Her açılan kombinasyon için en az bir golden-master snapshot'ı bulunmalı — aksi hâlde
+   kombinasyonun davranışı hiçbir yerde kilitli olmaz.
+3. Kullanıcıya kombinasyonun ne yaptığı anlatılabilir olmalı. "Denge modülünü kapat" bir
+   operasyon kullanıcısı için anlamlı bir cümle değildir; kalibre edilmiş bir **kriter adı**
+   anlamlıdır. Yeni bir kombinasyon gerekiyorsa doğru yol, bayrak açmak değil,
+   `LoadingPlanOptimizationCriteria`'ya kalibre edilmiş yeni bir üye eklemektir.
+
+## Alternatifler
+
+| Alternatif | Neden seçilmedi |
+|---|---|
+| **Dört bayrağı request DTO'suna ekleyip arayüzde onay kutusu yapmak** | 16 kombinasyonun 13'ü kalibre edilmemiş. Kalibre edilmemiş kombinasyon hata vermez, **sessizce anlamsız plan üretir**; operatör bunu ancak sahada fark eder. Ayrıca üretimde her kombinasyonun destek yükünü doğurur. |
+| **Yalnızca `UseContamination`'ı açmak** (görece bağımsız görünen tek bayrak) | Kontaminasyon filtresi skor terimi değil, ürün eleme filtresidir ve motorun içinden değil komut işleyicilerinden çağrılıyor (`CreatePlanCommandHandler.cs:162`, `ReOptimizePlanCommandHandler.cs:93`). Kapatılması `stackGroup` / `incompatibleGroups` ile tanımlanan uyumsuz yük ayrımını devre dışı bırakır (`ContaminationFilter.cs:6-11`); bu bir optimizasyon tercihi değil, yük güvenliği kısıtıdır. |
+| **Bayrakları hiç eklememek, modülleri `criteria` üzerinden koşullamak** | Kod bugün bunu zaten yapıyor (`FromCriteria`), ama bayrak katmanı olmadan `ModulBayraklariTests`'in üç testi yazılamazdı; modüllerin gerçekten ayrılabildiği ve türetmenin bugünkü davranışa eşit olduğu doğrulanamazdı. Bayrak, **test edilebilirlik** için var. |
+| **Bayrakları feature-flag altında yalnızca test ortamında açmak** | Ortama göre farklı plan üreten bir motor demektir; test ortamında doğrulanan plan üretimde farklı çıkabilirdi. Motorun determinizm sözleşmesiyle (`DeterminizmTests`) çelişir. |
+
+## Açık konular
+
+- `UseContamination` bayrağı bugün hiçbir kod yolunda `false` olmuyor; `FromCriteria` onu
+  koşulsuz `true` döndürüyor. Bayrak, ileride bir muafiyet ihtiyacı doğarsa diye duruyor —
+  bugün ölü kaldıraç.
+- Kalibre edilmemiş 13 kombinasyonun hiçbirinin **ne ürettiği ölçülmedi**. "Anlamsız plan
+  üretebilir" iddiası katsayı yapısından türetilen bir çıkarımdır, ölçüm değildir.
+- Bayrakların testlerde kullanımı `internal` görünürlüğe ve `InternalsVisibleTo`'ya bağlıdır.
+  Motor ileride ayrı bir derlemeye taşınırsa (ADR-0002'de elenen alternatif) bu erişim yolu
+  yeniden düşünülmelidir.

--- a/docs/adr/ADR-0006-uc-dalli-terfi-modeli.md
+++ b/docs/adr/ADR-0006-uc-dalli-terfi-modeli.md
@@ -1,0 +1,183 @@
+# ADR-0006 — Üç dallı terfi modeli ve Terfi workflow'u
+
+- **Durum:** Kabul edildi
+- **Tarih:** 2026-08-03 (model) · 2026-08-08 (`branching.md` güncellemesi) · terfi otomasyonu INFRA-01
+- **Kapsam:** `docs/conventions/branching.md`, `.github/workflows/promote.yml`, `dev`/`test`/`main` ruleset'leri
+- **Not:** Bu ADR geriye dönük yazılmıştır; karar 2026-08-03'te uygulanmaya başlamış, gerekçeleri
+  o tarihten beri yalnızca `branching.md` ve `promote.yml` başlığındaki yorum bloğunda dağınık
+  hâlde duruyordu.
+
+## Bağlam
+
+Cargo Pilot üç kalıcı dal kullanıyor: `dev` (günlük entegrasyon), `test` (QA/gösterim ortamı,
+test sunucusuna deploy edilir), `main` (production'a hazır sürüm). İş dalları `dev`'den açılır,
+`dev`'den `test`'e ve `test`'ten `main`'e **terfi** edilir (`docs/conventions/branching.md:14-25`).
+
+Eski modelde 1000+ commit geride kalan iş dalları birikmiş, hiçbiri rebase edilememiş ve hepsi
+silinmek zorunda kalmıştı (`branching.md:56-59`). Ayrıca bir kez `feat/*` dalı `dev`'i atlayıp
+doğrudan `test`'e girmiş (#482) ve dalları ayrıştırmıştı; düzeltmek için `sync/test-to-dev`
+yaması gerekti (`branching.md:186-189`).
+
+Model kurulduktan sonra iki teknik tuzak ortaya çıktı ve bunlar birkaç kez "CI/ruleset arızası"
+sanılarak yanlış teşhis edildi. Bu ADR'nin asıl amacı bu iki tuzağı kalıcı olarak kayda geçirmektir.
+
+## Karar
+
+### 1. Terfi zinciri tek yönlüdür: `dev → test → main`
+
+Tüm iş dalları `dev`'den açılır. `test`'e yalnızca `dev`'den, `main`'e yalnızca `test`'ten veya
+`hotfix/*`'ten PR açılabilir; CI ve ruleset bunu zorunlu kılar (`branching.md:28-34`).
+`test` ve `main` üzerinde **hiç commit üretilmez** — içerikleri yalnızca terfi ile değişir
+(`branching.md:36-39`).
+
+Gerekçe:
+
+- Test ortamında bulunan bir hata `test` dalında düzeltilirse dallar ayrışır; düzeltme `dev`'de
+  açılıp yeniden terfi edilmelidir (`branching.md:177-190`).
+- Sıra dışı bir terfi gerektiğinde `dev`'deki **her şey** birlikte gider; bu yüzden yarım kalan iş
+  `dev`'e merge edilmez, feature flag kullanılır (`branching.md:61-65`).
+
+Sonuçları:
+
+- İş dalı ömrü ≤ 3 gün hedefi bir stil tercihi değil, "dev her an çıkılabilir olmalı"
+  kuralının doğrudan sonucudur.
+- Hotfix sonrası geri-merge (`main → test → dev`) zorunludur; atlanırsa bir sonraki terfi
+  düzeltmeyi geri alır (`branching.md:203-211`).
+
+### 2. `feat/*` → `dev` **squash**, terfiler **merge commit**
+
+| PR | Yöntem |
+|---|---|
+| `feat/*`/`fix/*`/`chore/*`/`infra/*` → `dev` | Squash |
+| `dev` → `test` | Merge commit |
+| `test` → `main` | Merge commit |
+| `hotfix/*` → `main` | Merge commit |
+
+Gerekçe:
+
+- İş dalında squash, iş başına tek okunabilir commit üretir.
+- Terfide squash yapılırsa `test`, `dev`'de olmayan **yeni bir commit** alır ve dallar kalıcı
+  olarak ayrışır (`branching.md:140-141`). Merge commit, commit kimliğini korur ve geri-merge'ü
+  mümkün kılar.
+
+Sonuçları:
+
+- Ruleset her dalda yalnızca doğru merge yöntemini açık bırakır; yanlış seçim yapılamaz
+  (`branching.md:224`).
+- Bir sonraki maddedeki `BEHIND` görünümü bu tercihin doğrudan sonucudur.
+
+### 3. Terfi PR'ları kalıcı olarak `BEHIND` görünür — bu bir arıza DEĞİLDİR
+
+Merge-commit ile terfi eden bir PR'da hedef dal (`test`/`main`), kaynak dalda (`dev`/`test`)
+bulunmayan bir merge commit içerir. Bu nedenle terfi PR'ının `mergeStateStatus` değeri **kalıcı
+olarak `BEHIND`** kalır ve `gh pr merge`'ün **istemci tarafı** kontrolü merge'i reddeder:
+
+```
+X Pull request #928 is not mergeable: the head branch is not up to date with the base branch.
+```
+
+Gerekçe:
+
+- Bu bir ruleset arızası değildir: üç ruleset'in hiçbirinde
+  `strict_required_status_checks_policy` açık değildir (`branching.md:165-167`).
+- Sorun yalnızca `gh pr merge`'ün istemci tarafı kontrolündedir. GitHub REST API'sinin merge uç
+  noktası aynı kontrolü uygulamaz ve PR'ı sorunsuz merge eder (`promote.yml:5-12`).
+
+Sonuçları:
+
+- Terfi PR'ları **elle `gh pr merge` ile merge EDİLMEZ**. Doğru yol `Terfi` workflow'udur
+  (`.github/workflows/promote.yml`); workflow kullanılamıyorsa REST API
+  (`gh api repos/<org>/<repo>/pulls/<PR>/merge -X PUT -f merge_method=merge`) veya GitHub
+  arayüzündeki "Merge pull request" düğmesi kullanılır.
+- **Korumaları atlamak için `--admin` veya bypass kullanılmaz** (`branching.md:171-172`,
+  `promote.yml:152-154`).
+- `BEHIND` görünümünü "düzeltmek" için terfiyi squash'a çevirmek veya kaynak dalı hedefe rebase
+  etmek modeli bozar; bu görünüm kabul edilmiş bir maliyettir.
+
+### 4. Merge adımı `GITHUB_TOKEN` ile değil, `PROMOTION_PAT` ile yapılır
+
+`Terfi` workflow'unda PR'ı bulan ve zorunlu kontrolleri bekleyen adımlar `GITHUB_TOKEN`
+kullanır (`promote.yml:97`, `:131`); **merge adımı ise ayrı bir PAT secret'ı** (`PROMOTION_PAT`)
+kullanır (`promote.yml:142`).
+
+Gerekçe:
+
+- GitHub'ın özyineleme koruması gereği, `GITHUB_TOKEN` ile yapılan bir merge'ün hedef dala
+  ittiği merge commit `GITHUB_TOKEN` kaynaklı sayılır ve `test`/`main` üzerindeki
+  **push tetikleyicili workflow'ları çalıştırmaz**: `test-deploy.yml` (test sunucusuna deploy)
+  ve `release-tag.yml` (`main`'de `v0.<n>.0` sürüm etiketi) (`promote.yml:24-32`).
+- Bu, terfiyi "başarılı" gösterip deploy ve sürüm otomasyonunu **sessizce** kırardı — en tehlikeli
+  arıza biçimi, çünkü hiçbir job kırmızıya dönmez.
+
+Sonuçları:
+
+- Workflow'un ilk adımı PAT varlığını kontrol eder ve yoksa açık hata mesajıyla durur
+  (`promote.yml:69-74`). PAT süresi dolarsa terfi başlamadan durur, yarım kalmaz.
+- `PROMOTION_PAT` bir işletim ön koşuludur: `contents:write` + `pull-requests:write`
+  (classic: `repo` scope; fine-grained: Contents RW, Pull requests RW).
+- Merge adımı 3 denemeye kadar tekrar eder (`promote.yml:146-159`); başarısız olursa kök neden
+  incelenir, bypass edilmez.
+
+### 5. Terfi workflow'u PR **açmaz**, yalnız açık PR'ı merge eder
+
+PR'ı insan `gh pr create --base test --head dev` ile açar; workflow yalnızca açık terfi PR'ını
+bulur (`promote.yml:94-127`), zorunlu kontrollerin geçmesini bekler (`:129-138`) ve merge eder.
+
+Gerekçe:
+
+- Aynı özyineleme koruması: `GITHUB_TOKEN` ile açılan PR'lar `pull_request` tetiklenen job'ları
+  çalıştırmaz. Workflow PR açsaydı zorunlu kontroller sonsuza kadar `pending` kalır ve merge
+  hiç gerçekleşmezdi (`promote.yml:14-22`).
+- Tasarım kararı alındığında repoda repo yazma yetkili bir PAT secret'ı da yoktu; sonradan
+  eklenen `PROMOTION_PAT` yalnız merge adımı içindir ve PR açma tasarımını değiştirmez.
+
+Sonuçları:
+
+- Terfi iki adımlıdır: önce `gh pr create`, CI çalışmaya başladıktan sonra
+  Actions → Terfi → Run workflow (hedef: `dev-test` ya da `test-main`).
+- Workflow aynı yön için birden fazla açık PR bulursa hata verir ve `pr_numarasi` girdisiyle
+  belirtilmesini ister (`promote.yml:118-122`) — yanlış PR'ı merge etme riski kapalıdır.
+
+### 6. İzin verilen dal türleri sabittir
+
+`feat/*`, `fix/*`, `chore/*`, `infra/*` (hepsi `dev`'den) ve `hotfix/*` (sürüm tag'inden)
+(`branching.md:45-55`). İsimlendirme `<tür>/<iş-kodu>-<kısa-açıklama>`; `chore/` ve `infra/`
+için iş kodu zorunlu değildir (`branching.md:99`).
+
+Sonuçları:
+
+- **`docs/*` diye bir dal türü YOKTUR.** Doküman işi `chore/*` altında açılır
+  (`branching.md:52`: "chore — Doküman, bağımlılık, temizlik").
+- Büyük harf, boşluk ve Türkçe karakter kullanılmaz (`branching.md:87-97`).
+
+## Zorunlu kontroller ve ortam eşlemesi
+
+| Hedef dal | Zorunlu kontroller |
+|---|---|
+| `dev` | `Frontend CI`, `Backend CI` |
+| `test` | `Frontend CI`, `Backend CI`, `Terfi Zinciri Kontrolü`, `Pending Migration Kontrolü`, `Image Build`, `Deploy (Test)` |
+| `main` | `Frontend CI`, `Backend CI`, `Terfi Zinciri Kontrolü`, `Pending Migration Kontrolü` |
+
+`main`'de image build ve deploy koşmaz; içerik `test`'te zaten build edilip çalıştırılmıştır
+(`branching.md:240-245`). `main`'e terfi bugün deploy tetiklemez, yalnızca sürüm etiketi üretir —
+production ortamı henüz kurulmamıştır (`branching.md:265-275`).
+
+## Alternatifler
+
+| Alternatif | Neden seçilmedi |
+|---|---|
+| Tek dal (trunk-based) + ortam etiketleri | QA'nın üzerinde çalıştığı içeriğin dondurulması gerekiyor; `test` sunucusu her `dev` commit'iyle değişemez |
+| Terfilerde de squash | `test`, `dev`'de olmayan yeni commit alır; dallar kalıcı ayrışır ve geri-merge imkânsızlaşır (`branching.md:140-141`) |
+| Terfi PR'larını `gh pr merge` ile elle merge etmek | Merge-commit modelinde PR kalıcı `BEHIND` görünür; `gh pr merge` istemci tarafı kontrolüyle reddeder (`promote.yml:5-12`) |
+| `gh pr merge --admin` ile korumaları atlamak | Zorunlu kontroller devre dışı kalır; açıkça yasaklandı (`branching.md:171-172`) |
+| Terfi workflow'unun PR'ı da açması | `GITHUB_TOKEN` ile açılan PR `pull_request` job'larını tetiklemez; zorunlu kontroller sonsuza kadar `pending` kalır (`promote.yml:14-22`) |
+| Merge'ü `GITHUB_TOKEN` ile yapmak | `test`/`main` push tetikleyicileri (deploy, sürüm etiketi) çalışmaz; terfi yeşil görünürken otomasyon sessizce kırılır (`promote.yml:24-32`) |
+| Kaynak dalı hedefe rebase/merge ederek `BEHIND`'ı gidermek | `dev`'e terfi kaynaklı commit sokar, tek yönlü zinciri bozar |
+
+## Açık konular
+
+- Production ortamı kurulunca `main → production` deploy'u `production` GitHub Environment'ı
+  üzerinden zorunlu onaylayıcı ile çalışacak; `PROD_SSH_HOST`/`PROD_SSH_PRIVATE_KEY`,
+  `.env.prod`, `prod-deploy.yml` eksikleri `docs/devops/devops-backlog.md` 2.1–2.3'te.
+- `PROMOTION_PAT`'in süresi ve sahibi belgelenmedi; PAT bir kişiye bağlı olduğu sürece terfi o
+  kişiye bağımlıdır. Fine-grained PAT'in yenilenme takvimi kararlaştırılmalı.

--- a/docs/adr/ADR-0007-docker-build-cache-asimetrisi.md
+++ b/docs/adr/ADR-0007-docker-build-cache-asimetrisi.md
@@ -1,0 +1,145 @@
+# ADR-0007 — Docker build cache asimetrisi: backend `mode=min`, frontend `mode=max`
+
+- **Durum:** Kabul edildi
+- **Tarih:** 2026-08-15 (K3 panel kararı ve PR #992)
+- **Kapsam:** `.github/workflows/ci.yml`, `.github/workflows/test-deploy.yml`,
+  `apps/backend/Dockerfile`, `apps/frontend/Dockerfile`
+- **Not:** Bu ADR geriye dönük yazılmıştır. Karar PR #992 ile uygulandı; gerekçesi yalnızca
+  panel kararında ve uygulama raporunda duruyordu, bu yüzden "tutarsızlık" olarak birkaç kez
+  yeniden gündeme geldi (bkz. D-13(d)).
+
+## Bağlam
+
+GitHub Actions cache bütçesi repo başına 10 GiB'dir. 2026-08-15'te canlı ölçüldüğünde
+(`gh api /repos/Divizyon/cargo-pilot/actions/cache/usage` + sayfalanmış `actions/caches` listesi):
+
+| Metrik | Değer |
+|---|---|
+| Toplam giriş | 228 (GH sayacı 229) |
+| Toplam boyut | **9,652 GiB** |
+| 10 GiB bütçe doluluğu | **%96,5** |
+
+Byte'ın tamamına yakınını `buildkit` blob'ları tutuyordu (196 giriş / 7,350 GiB); `infra`
+prefix'i 3 giriş / 1,983 GiB, `node` 3 giriş / 0,318 GiB, scope'lu `index` girişleri 26 adet
+ve toplam ~0,0002 GiB idi. Bütçe dolduğunda GitHub en eski girişleri atar; yani cache
+büyüklüğü doğrudan cache **isabet oranını** düşürür.
+
+Aynı anda dört ayrı `cache-to` satırı vardı ve **dördü de `mode=max`** yazıyordu. `mode=max`
+nihai imaj katmanlarına ek olarak tüm ara katmanları da dışa aktarır — en pahalı moddur.
+Kararın konusu: bu dört satırın modu nasıl seçilmeli?
+
+Bugünkü hâl (asimetrik):
+
+| Konum | Scope | Mod |
+|---|---|---|
+| `ci.yml:229` | `cargo-pilot-backend-ci` | `mode=min` |
+| `ci.yml:240` | `cargo-pilot-frontend-ci` | `mode=max` |
+| `test-deploy.yml:127` | `backend-test` | `mode=min` |
+| `test-deploy.yml:145` | `frontend-test` | `mode=max` |
+
+## Karar
+
+### 1. Backend `cache-to` `mode=min` kullanır
+
+Gerekçe — `apps/backend/Dockerfile` yapısından doğrudan çıkar:
+
+- `apps/backend/Dockerfile:7` tek bir `COPY . .` ile tüm backend ağacını kopyalar.
+- `apps/backend/Dockerfile:12-21` **tek bir `RUN` içinde** `dotnet restore` **ve**
+  `dotnet publish` çalıştırır (Web API projesini `find`/`grep` ile bulup yayınlar).
+- Sonuç: ayrılabilir, çapraz-commit yeniden kullanılabilir bir `restore` katmanı **yoktur**.
+  `apps/backend` içeriği değiştiğinde build stage'in tamamı geçersiz olur; değişmediğinde ise
+  `mode=min`'in zaten dışa aktardığı nihai katmanlar tam isabet verir.
+- Yani backend'de `mode=max`'ın sakladığı ara katmanların çapraz-commit değeri ~0'dır, buna
+  karşılık maliyeti yüksektir: ölçülen en büyük blob'lar 347–358 MB bandındadır (16 adet
+  > 200 MB).
+
+Sonuçları:
+
+- Backend'de `mode=min` neredeyse kayıpsız, yüksek byte tasarrufu sağlar.
+- "`mode=min` dotnet restore cache'ini kaybettirir" itirazı backend için **geçersizdir**;
+  kaybedilecek ayrı bir restore katmanı yoktur.
+- Backend Dockerfile'ı ileride `restore` ve `publish`'i ayrı `RUN` katmanlarına bölerse bu
+  madde yeniden değerlendirilmelidir — o zaman `mode=max`'ın gerçek bir karşılığı olur.
+
+### 2. Frontend `cache-to` `mode=max` kullanır
+
+Gerekçe — `apps/frontend/Dockerfile` yapısından doğrudan çıkar:
+
+- `apps/frontend/Dockerfile:1-5` ayrı bir `deps` stage tanımlar: `COPY package*.json ./`
+  ardından `npm install --ignore-scripts --no-audit --no-fund`.
+- Bu, `package-lock.json` değişmedikçe **çapraz-commit yeniden kullanılabilen tek gerçek ara
+  katmandır** ve nihai imajda yer almaz (nihai imaj `nginx:1.31-alpine` üzerine yalnız
+  `dist/` kopyalar — `Dockerfile:21-23`).
+- `mode=min` bu katmanı dışa aktarmaz; sonuç her build'de sıfırdan `npm install` olur.
+
+Sonuçları:
+
+- Frontend'de `mode=max` bir israf değil, tek anlamlı cache kazancının ön koşuludur.
+- Frontend blob'ları backend'inkilerden belirgin biçimde küçüktür; `mode=max`'ın byte maliyeti
+  burada karşılanabilir.
+
+### 3. Asimetri bir tutarsızlık değil, Dockerfile yapısının yansımasıdır
+
+Cache modu bir stil tercihi değil, **imajın katman yapısına verilen cevaptır**. İki Dockerfile
+farklı yapıda olduğu için modları da farklıdır.
+
+Sonuçları:
+
+- Bu asimetri sonradan D-13(d) olarak "eksiklik/borç" biçiminde raporlandı. **Borç değildir**;
+  K3'ün kabul kriteri bunu açıkça doğru sayar ve 4/4 geçmiştir
+  (`SCRATCH/out/k3-cache.md:96` — "Asimetrik mod: backend=min ×2, frontend=max ×2 → 4/4 doğru").
+  Backlog'da eksiklik olarak duran satır düşülmelidir.
+- Dört satırı `mode=max`'a "hizalamak" bütçeyi tekrar şişirir; dördünü `mode=min`'e
+  "hizalamak" frontend'de her build'de `npm install`'ı geri getirir. İki yönde de hizalama
+  bir gerileme olur.
+
+### 4. Deploy job'u cache **okur**, cache **yazmaz**
+
+Deploy job'undaki `cache-to` satırları kaldırıldı; yalnız `cache-from` kaldı
+(`test-deploy.yml:221`, `:237` ve e2e job'unda `:337`, `:351`).
+
+Gerekçe:
+
+- Ölçülen 6,56 GB'lık en büyük tek kaynak, build job'un hiç çalışmadığı uzun ömürlü bir iş
+  dalıydı; o blob'ları yazan tek şey deploy job'unun `cache-to` satırlarıydı.
+- Deploy job'u zaten build job'un yazdığı katmanları tüketir; ikinci kez yazması aynı içeriği
+  farklı ref altında çoğaltır.
+
+Sonuçları:
+
+- Cache yazımı tek noktada (build job) toplandı; bütçe tüketimi öngörülebilir hâle geldi.
+- `cache-from`'un isabet alabilmesi için deploy'un build'den **sonra** koşması şarttır
+  (`needs: [migration-check, build]`); sıralama aynı PR'da düzeltildi.
+
+## Ölçüm — kararın dayandığı sayılar
+
+| Ölçüm | Değer | Kaynak |
+|---|---|---|
+| Cache doluluğu (2026-08-15 13:34 UTC) | 9,652 GiB / 10 GiB = **%96,5** | `SCRATCH/out/k3-cache.md:13-18` |
+| `buildkit` blob payı | 196 giriş / 7,350 GiB | `k3-cache.md:31-36` |
+| `infra-images` payı | 3 giriş / 1,983 GiB (bütçenin %20,5'i) | `k3-cache.md:34,56` |
+| En büyük tek ref | 4,16 GiB / 111 giriş (tek iş dalı) | `k3-cache.md:22` |
+| Net satır değişimi (PR #992) | −5 satır (33 ekleme / 38 silme) | `k3-cache.md:81-88` |
+| `ci.yml` kopya build tasarrufu | başarılı push başına ~210,6 sn runner (n=5) | `k3-cache.md:108` |
+
+## Alternatifler
+
+| Alternatif | Neden seçilmedi |
+|---|---|
+| Dört satırın hepsi `mode=max` (mevcut hâl) | Ölçülen bütçe %96,5 doluydu; backend'de `mode=max`'ın çapraz-commit değeri ~0 iken blob'ları 347–358 MB bandında |
+| Dört satırın hepsi `mode=min` | `apps/frontend/Dockerfile:1-5`'teki `deps` stage dışa aktarılmaz; her build'de sıfırdan `npm install` — frontend'de gerçek gerileme |
+| **Cache scope'larını birleştirme** (4 scope → 2) | **Ölçümle çürütüldü.** Byte'ı tutan girişler `buildkit-blob-1-sha256:<digest>` biçiminde, **içerik adresli ve scope'suz**; scope'a bağlı `index-*` girişlerinin ölçülen boyutu ~0 byte. Üstelik GHA cache **ref-izole**, scope-izole değil. Birleştirme byte kazandırmaz. Ayrıca frontend build-arg'ları `ci.yml` ile `test-deploy.yml` arasında farklı (`VITE_API_BASE_URL` vd.) ve buildkit cache anahtarı build-arg'ı içerdiği için scope birleştirilse de blob'lar ayrışmaya devam eder. Zamanlama tarafında da aynı scope'u paylaşan ikinci build daha yavaş ölçüldü (Image Build 95 sn / 100 sn'e karşılık Deploy 118 sn / 112 sn) |
+| NuGet paket cache'i eklemek (D-13(b)) | Cache bütçesi %96,5 doluyken durumu kötüleştirir; açık "yapma" listesinde |
+| Deploy için ayrı GHCR-pull dallanması | Gereksiz: `Deploy (Test Server)` zaten `needs: [migration-check, build]` ve GHCR'dan `image_tag` ile çekiyor; ölçümde geçici doğrulamadan 100 sn önce bitiyor. Saf karmaşıklık |
+| `infra-images` cache'ini korumak | 1,983 GiB = bütçenin %20,5'i. `docker-compose.test.yml`'de `mssql` ve `minio` servislerinin `build:` bölümü yok; `up -d --no-build --wait` varsayılan `--pull missing` ile bu imajları kendisi çeker. Kaldırıldı |
+
+## Açık konular
+
+- Kaldırılan `infra` prefix'indeki 3 giriş (1,983 GiB) anında silinmez; artık hiç okunmadığı
+  için GitHub'ın yerleşik "7 gün erişilmezse sil" politikasıyla ~1 hafta içinde organik olarak
+  düşer.
+- `cache-cleanup.yml` yaş kriteri `last_accessed_at` alanına bakar (`created_at`'e değil);
+  bu kriterle ölçüm anında **0 giriş** siliniyordu. Boyut eşiği bu yüzden eklendi; eşiğin
+  gerçek etkisi bir `test` push'uyla ölçülmedi.
+- Sıralama düzeltmesinin (`deploy` artık `build`'den sonra) beklenen ~200 sn/test-push kazancı
+  **tahmindir**, ölçülmedi.

--- a/docs/adr/ADR-0008-sha-pinleme-surum-yukseltmeden-ayri.md
+++ b/docs/adr/ADR-0008-sha-pinleme-surum-yukseltmeden-ayri.md
@@ -1,0 +1,120 @@
+# ADR-0008 — SHA pinleme, sürüm yükseltmesinden ayrılır
+
+- **Durum:** Kabul edildi
+- **Tarih:** 2026-08-15 (PR #1008)
+- **Kapsam:** `.github/workflows/test-deploy.yml` (e2e job'u), `.github/dependabot.yml`,
+  `docs/devops/denetim-raporu-2026-08-13.md`
+- **Not:** Bu ADR geriye dönük yazılmıştır. Karar PR #1008 ile uygulandı; gerekçesi hiçbir yerde
+  yazılı olmadığı için sonradan D-13(a) olarak **"borç"** biçiminde raporlandı (bkz. Karar 3).
+
+## Bağlam
+
+Denetim raporunun ilk turu GitHub Actions referanslarının tamamının SHA'ya pinli olduğunu
+söylüyordu ("28/28", panoramada "32/32 ✅"). İkinci turda ölçüldüğünde gerçek durum farklı çıktı:
+
+`.github/workflows/*.yml` içindeki **45 `uses:` referansının 38'i** 40 haneli SHA'ya pinliydi;
+kalan **7'si mutable tag'deydi ve hepsi `test-deploy.yml`'in e2e job'undaydı**
+(`docs/devops/denetim-raporu-2026-08-13.md:39-45`):
+
+| Action | Eski hâl | Konum |
+|---|---|---|
+| `actions/checkout` | `@v4` | `:314` |
+| `docker/setup-buildx-action` | `@v3` | `:317` |
+| `docker/login-action` | `@v3` | `:320` |
+| `docker/build-push-action` | `@v5` | `:327`, `:340` |
+| `actions/setup-node` | `@v4` | `:354` |
+| `actions/upload-artifact` | `@v4` | `:397` |
+
+Rapordaki eski sayılar, e2e job'u eklenmeden önceki duruma aitti — job sonradan geldi ve
+pinleme disiplini o job'a uygulanmadı.
+
+Mutable tag riski: `@v4` gibi bir tag hareket ettirilebilir. Tag'in işaret ettiği commit
+değiştiğinde workflow, hiçbir PR açılmadan, farklı kod çalıştırmaya başlar (tedarik zinciri
+saldırı yüzeyi).
+
+## Karar
+
+### 1. Yedi action SHA'ya pinlendi, sürümleri **yükseltilmedi**
+
+PR #1008 yalnızca referans biçimini değiştirdi: `@v4` → `@11d5960a…  # v4.4.0`. Diff **7 ekleme /
+7 silme**, tek dosya. Hiçbir action'ın davranışı değişmedi.
+
+Gerekçe:
+
+- Pinleme bir **güvenlik/tekrarlanabilirlik** işidir; yükseltme bir **davranış değişikliği**dir.
+  Aynı PR'a sıkıştırıldıklarında, CI davranışı değişirse hangisinin sebep olduğu belirsizleşir.
+- Ayrışma küçük değil, üç majöre varıyor: `docker/build-push-action` e2e'de v5.4.0 iken
+  `ci.yml`'de **v7.3.0** (`ci.yml:220`, `:232`); `actions/checkout` v4.4.0'a karşı **v7.0.1**
+  (`ci.yml:72`); `setup-buildx-action` v3.12.0'a karşı **v4.2.0** (`ci.yml:210`);
+  `login-action` v3.7.0'a karşı **v4.6.0** (`ci.yml:213`).
+- Bu ölçekte bir yükseltmenin kırma potansiyeli yüksektir ve e2e job'u zaten Playwright +
+  compose + sahte ERP MSSQL'e bağlı, gürültülü bir job'dur. Kırıldığında pinleme PR'ı geri
+  alınırsa güvenlik kazancı da geri alınır.
+
+Sonuçları:
+
+- Pinleme sonrası ölçüm: 45 `uses:` referansının **45'i** SHA'ya pinli
+  (`grep -rhn "uses:" .github/workflows/*.yml | grep -cE "@[0-9a-f]{40}"` → 45).
+- e2e job'u bilinçli olarak eski ama **sabit** sürümlerde bırakıldı. "Sabit ve eski",
+  "hareketli ve yeni"den daha güvenlidir.
+
+### 2. Yükseltmeyi Dependabot devralır
+
+Pinleme `@<sha> # vX.Y.Z` biçiminde yapıldı — SHA'nın yanında sürümü belirten yorum satırı var.
+
+Gerekçe:
+
+- Dependabot bu biçimi tanır: yorumdaki sürümü okur, yeni sürümün SHA'sını bulur ve **SHA + yorum
+  çiftini birlikte** güncelleyen bir PR açar. Yani pinleme, yükseltmeyi engellemez — yükseltmeyi
+  otomatikleştirir.
+- `.github/dependabot.yml:117-125` `github-actions` ekosistemini `dev` hedef dalıyla, haftalık
+  (pazartesi) olarak zaten tanımlı tutuyor.
+
+Sonuçları:
+
+- Sürüm hizalaması ayrı, gözden geçirilebilir, tek tek geri alınabilir PR'lar hâlinde gelir.
+- Elle yükseltme turu gerekirse, o da ayrı bir PR olarak açılır — pinleme PR'ına eklenmez.
+
+### 3. Bu ayrım borç değildir; "düzeltme" girişimi pinlemeyi bozar
+
+Bu karar sonradan denetim bulgusu **D-13(a)** olarak "e2e job'unun action'ları geride kalmış"
+biçiminde raporlandı ve borç listesine alındı. Bu etiket yanlıştır.
+
+Sonuçları:
+
+- Biri bu "borcu" pinleme PR'ının kapsamına geri sokarak kapatmaya kalkarsa, pinlemenin tek
+  değerli özelliği — **hangi commit'in tam olarak ne çalıştırdığının doğrulanabilir olması** —
+  bozulur; diff artık "biçim değişikliği" olmaktan çıkıp "üç majör atlayan davranış
+  değişikliği"ne dönüşür ve geri alınabilirliği kaybeder.
+- D-13(a) "borç" değil, **"bilinçli · pinleme sonrası sürüm hizalama turu"** olarak
+  etiketlenmelidir; şiddeti düşürülmeli ve kapsamı backlog'da yazdığı gibi 2 satır değil,
+  **7 action** olarak düzeltilmelidir (backlog satırı yalnız `:327` ve `:340`'ı gösteriyor).
+- Yükseltme turu yapıldığında ayrı bir PR açılır ve bu ADR'ye ek karar olarak işlenir.
+
+### 4. Yeni eklenen her job pinleme disiplinine tabidir
+
+e2e job'u pinlenmemiş olarak eklenebildiği için denetim raporu iki tur boyunca yanlış sayı
+taşıdı.
+
+Sonuçları:
+
+- Doğrulama komutu tektir ve tekrarlanabilir:
+  `grep -rn "uses: " .github/workflows/*.yml | grep -v "@[0-9a-f]\{40\}"` → **0 satır** dönmelidir.
+- Pinleme oranı iddiası, ölçülmeden dokümana yazılmaz.
+
+## Alternatifler
+
+| Alternatif | Neden seçilmedi |
+|---|---|
+| Pinleme + yükseltmeyi aynı PR'da yapmak | Üç majör atlayan bir yükseltme davranışı değiştirirse, sebebin pinleme mi yükseltme mi olduğu ayırt edilemez; PR geri alınırsa güvenlik kazancı da geri alınır |
+| Mutable tag'de bırakıp yalnızca yükseltmek (`@v5` → `@v7`) | Tedarik zinciri riski sürer: tag hareket ettirildiğinde workflow hiçbir PR açılmadan farklı kod çalıştırır |
+| SHA'yı sürüm yorumu olmadan pinlemek (`@11d5960a…`) | Dependabot yükseltmeyi öneremez ve insan da hangi sürümde olduğunu okuyamaz; pin kalıcı olarak donar |
+| Repo genelinde tek seferde hem pinleyip hem tüm sürümleri hizalamak | Aynı belirsizlik, daha geniş yüzeyde; e2e job'u compose + Playwright + sahte ERP MSSQL'e bağlı ve zaten gürültülü |
+| Pinlemeyi hiç yapmayıp yalnızca Dependabot'a bırakmak | Dependabot mutable tag'i de günceller ama tag'in hareket etmesine karşı koruma sağlamaz; pinleme ön koşuldur |
+
+## Açık konular
+
+- Sürüm hizalama turu henüz yapılmadı. Dependabot'un `github-actions` PR'ları geldikçe
+  e2e job'u kendiliğinden hizalanacak; hizalanmazsa ayrı bir `chore/*` PR'ı açılır.
+- Dependabot'un `@sha # vX.Y.Z` biçimini bu repoda fiilen güncellediği bir PR henüz
+  gözlenmedi — beklenen davranış, ölçülmüş değil.

--- a/docs/adr/ADR-0009-otomatik-geri-alma-sessizce-basarili-donmez.md
+++ b/docs/adr/ADR-0009-otomatik-geri-alma-sessizce-basarili-donmez.md
@@ -1,0 +1,174 @@
+# ADR-0009 — Otomatik geri alma sessizce başarılı dönmez
+
+- **Durum:** Kabul edildi
+- **Tarih:** 2026-08-17 (PR #1017, Dalga 2b — D-24, D-26, D-27, D-28)
+- **Kapsam:** `.github/workflows/test-deploy.yml` (`deploy-test-server` job'u),
+  `docs/devops/rollback-runbook.md`, `infra/scripts/rollback.sh`
+- **Not:** Bu ADR geriye dönük yazılmıştır; karar PR #1017 ile uygulandı ve aynı gün yapılan
+  `dev → test` terfisinde canlı doğrulandı.
+
+## Bağlam
+
+`test` dalına her push'ta `deploy-test-server` job'u sunucuya bağlanıp GHCR'dan yeni image'ı
+çekiyor ve stack'i güncelliyor. Deploy sonrası loopback health kontrolü var
+(`test-deploy.yml:500-506`).
+
+PR #1017 öncesinde health düştüğünde job kırmızıya dönüyordu **ama sunucu bozuk image ile
+çalışmaya devam ediyordu**. Yani test ortamı, birileri elle müdahale edene kadar bozuk kalıyordu.
+
+Aynı PR'da iki ön koşul da düzeltildi:
+
+- `docker compose down --remove-orphans` adımı kaldırıldı; artık tek `up -d --no-build
+  --remove-orphans` çağrısı var (`test-deploy.yml:494-498`). Eski hâl `mssql` ve `minio` dahil
+  tüm stack'i kapatıyor ve her deploy'da 2–3 dakikalık kesinti üretiyordu — oysa deploy edilen
+  yalnız `backend` ve `frontend`. (D-26)
+- `docker image prune -f` health kontrolünün **sonrasına** alındı (`test-deploy.yml:534-538`).
+  Önceden prune health'ten önce çalışıyor, geri dönülecek image o an diskte olmayabiliyordu.
+  Bu, otomatik geri almanın ön koşuludur. (D-28)
+
+## Karar
+
+### 1. Health düşerse bir önceki image'a otomatik geri dönülür
+
+Pull'dan **önce**, çalışan backend konteynerinin image referansından mevcut tag türetilip çıpa
+olarak saklanır (`test-deploy.yml:458-459`):
+
+```bash
+PREV_IMAGE_REF="$(docker inspect --format '{{.Config.Image}}' cargo-pilot-backend-test 2>/dev/null || true)"
+PREV_IMAGE_TAG="${PREV_IMAGE_REF##*:}"
+```
+
+Health düşerse bu tag ile **tek seferlik** `up -d --no-build --remove-orphans` çalıştırılır
+(`test-deploy.yml:511-522`).
+
+Gerekçe:
+
+- Çıpa, sunucuda **zaten var olan gerçeği** okur: ek durum dosyası, `latest-good` tag'i veya
+  GHCR sorgusu gerektirmez.
+- Konteyner yoksa (ilk deploy) çıpa boş kalır — doğal bir "ilk deploy" koruması.
+- Yalnız `backend` konteyneri sorgulanır: backend ve frontend her zaman aynı `IMAGE_TAG` ile
+  (aynı `needs.build.outputs.image_tag`) deploy edilir; ikisini ayrı izlemek ayrışamayacak bir
+  durumu modellemek olurdu.
+
+Sonuçları:
+
+- Geri alma denenmeyen iki durum var (`test-deploy.yml:512`): çıpa boş, ya da
+  `PREV_IMAGE_TAG == IMAGE_TAG` (aynı tag yeniden deploy — geri dönülecek yer yok). İki hâlde de
+  stack olduğu gibi bırakılır, açık mesaj basılır.
+- Geri alınacak image'ın diskte olması D-28'in yeni prune sırasına bağlıdır; sunucuda başka bir
+  prune cron'u varsa bu varsayım kırılabilir.
+
+### 2. Geri alma başarılı olsa bile job **`exit 1`** verir
+
+Geri alma sonucundan bağımsız olarak job kırmızı bırakılır (`test-deploy.yml:529-530`).
+
+Gerekçe:
+
+- **Geri alma bir onarım değil, hasar sınırlamasıdır.** Ortam kurtarılır; bozuk commit hâlâ
+  bozuktur.
+- "Sessizce yeşil" dönmek, D-27'nin çözdüğü sorundan daha tehlikeli bir durum üretirdi: bozuk
+  commit `test`'e gömülür, pipeline yeşil görünür ve kimse bakmaz. Bir sonraki terfide
+  `main`'e taşınır.
+- `test` dalına giren içerik yalnız terfi ile değişir (ADR-0006); bozuk bir commit'in kırmızı
+  bir sinyal bırakmadan orada durması, terfi zincirinin tek doğrulama noktasını iptal eder.
+
+Sonuçları:
+
+- Deploy job'unun yeşil olması "sunucu ayakta" değil, "bu commit sağlıklı" anlamına gelir —
+  ikisi karıştırılmaz.
+- Geri alma sonrası çalışan health döngüsü (`test-deploy.yml:519-525`) yalnızca **raporlar**,
+  çıkış kodunu değiştirmez.
+
+### 3. Geri almanın kendisi için ikinci bir geri alma denenmez
+
+Gerekçe:
+
+- Özyinelemeli ya da çok adımlı bir geri alma zinciri, sonsuz döngü ve çift geri alma üretebilir.
+- Geri alma tek adımdır ve tek `up` çağrısıdır; başarısız olursa mesaj basılır
+  (`|| echo "Geri alma komutu hata verdi."`) ve akış devam eder.
+
+Sonuçları:
+
+- Döngü riski yapısal olarak kapalıdır; hiçbir senaryoda ikinci `up` çağrısı üretilmez.
+- Geri alma da başarısızsa insan müdahalesi gerekir; prosedür `docs/devops/rollback-runbook.md`
+  içindedir.
+
+### 4. Çıpa, **kullanılmadan önce doğrulanır**
+
+`${PREV_IMAGE_REF##*:}` ayrıştırması her zaman geçerli bir tag üretmez: `.Config.Image` digest
+biçiminde (`ghcr.io/…@sha256:abc…`) ya da tag'siz dönebilir. Bu yüzden çıpa iki `case` bloğuyla
+elenir (`test-deploy.yml:467-475`):
+
+| Gelen `.Config.Image` biçimi | Sonuç |
+|---|---|
+| `ref:tag` (beklenen) | Çıpa kabul edilir |
+| `ref@sha256:…` (digest referansı) | Çıpa boşaltılır |
+| `:` içermeyen ref (tag belirtilmemiş) | Çıpa boşaltılır |
+| Boş (konteyner yok / ilk deploy) | Çıpa boşaltılır |
+| `/` içeren değer (yol parçası) | Çıpa boşaltılır |
+| Boşluk içeren değer | Çıpa boşaltılır |
+
+Gerekçe:
+
+- Çıpa şüpheliyse geri alma **hiç denenmez**. Aksi hâlde `up`, var olmayan bir image arar ve
+  ortam bugünkünden **daha kötü** duruma düşer: mevcut (bozuk ama çalışan) konteynerler de gider.
+- Doğrulama başarısız olduğunda davranış mevcut hâle eşitlenir: stack olduğu gibi kalır,
+  job yine `exit 1` verir.
+
+Sonuçları:
+
+- Altı biçim senaryosunun tamamında en kötü sonuç "geri alma atlandı" olur, "ortam bozuldu"
+  olmaz.
+- Çıpanın gerçek biçimi log'a basılır (`==> Geri alma çıpası: …`), böylece bir dahaki deploy'da
+  varsayım gözle doğrulanabilir.
+
+## Doğrulama
+
+**Kabuk davranışı** — script YAML'dan çıkarılıp `set -e` altında `curl`/`docker` stub'larıyla
+koşturuldu:
+
+| Senaryo | Çıktı | Çıkış kodu |
+|---|---|---|
+| Health fail + önceki image var | `==> Otomatik geri alma: test-old` + tek `up` çağrısı | **1** |
+| Health fail + ilk deploy (çıpa boş) | `Geri donulecek onceki image yok; stack oldugu gibi birakildi.` | **1** |
+| Health fail + aynı tag | Aynı mesaj, geri alma yok | **1** |
+| Health OK | `Backend loopback health OK.` + prune | 0 |
+
+Hiçbir senaryoda ikinci `up` çağrısı ya da döngü gözlenmedi.
+
+**Canlı doğrulama** — 2026-08-17 `dev → test` terfisi (PR #1017 sonrası ilk gerçek deploy):
+
+| Gözlem | Sonuç |
+|---|---|
+| Çıpa çıktısı | `test-faf7cb0` — beklenen `ref:tag` biçimi, doğrulamadan geçti |
+| Yeniden yaratılan servisler | Yalnız `backend` + `frontend` |
+| Ayakta kalan servisler | `mssql`, `minio` (ağ ve volume'lara dokunulmadı) |
+| Konteyner takası | **2,8 sn** (önceki `down` + `up` modelinde 2–3 dk) |
+
+Yani D-26'nın kesinti kısaltması ve D-27'nin çıpa varsayımı aynı koşumda birlikte doğrulandı.
+
+## Alternatifler
+
+| Alternatif | Neden seçilmedi |
+|---|---|
+| Geri alma başarılıysa job'u **yeşil** bırakmak | Bozuk commit `test`'e sessizce gömülür ve bir sonraki terfide `main`'e taşınır; geri alma bir onarım değil, hasar sınırlamasıdır |
+| Hiç geri alma yapmamak (eski hâl) | Job kırmızı olur ama sunucu bozuk image ile çalışmaya devam eder; test ortamı elle müdahaleye kadar bozuk kalır |
+| Deploy edilen tag'i sunucuda bir **durum dosyasına** yazmak | Dosya bayatlar ve elle müdahaleyle uyumsuz düşer; çalışan konteynerin `.Config.Image`'ı her zaman gerçeği söyler |
+| Backend ve frontend için **iki ayrı çıpa** | İkisi her zaman aynı `needs.build.outputs.image_tag` ile deploy ediliyor; ayrışamayacak bir durumu modellemek olurdu |
+| Özyinelemeli / çok adımlı geri alma zinciri | Sonsuz döngü ve çift geri alma riski; tek adımlı geri alma bu riski yapısal olarak kapatır |
+| Çıpayı doğrulamadan kullanmak | `.Config.Image` digest ya da tag'siz dönerse `##*:` geçersiz bir tag üretir; `up` var olmayan image arar ve ortam bugünkünden daha kötü duruma düşer |
+| `down` + `up` sırasını korumak (eski hâl) | `mssql` ve `minio` dahil tüm stack kapanıyor, her deploy 2–3 dk kesinti üretiyordu; ölçülen yeni takas 2,8 sn |
+| Prune'u health'ten önce çalıştırmak (eski hâl) | Geri dönülecek image o an diskte olmayabilir; geri alma GHCR'dan yeniden pull gerektirir |
+
+## Açık konular
+
+- **Kod rollback'i DB şemasını geri almaz:** `DbInitializer.MigrateAsync()` yalnız ileri
+  yönlüdür ve `infra/scripts/rollback.sh` migration'a hiç dokunmaz. Migration'ın geri alınması
+  gerekiyorsa yedekten dönüş prosedürü uygulanır (`docs/devops/rollback-runbook.md`).
+- Geri almanın **kendisi** ancak bilerek bozuk bir image deploy edilerek görülebilir
+  (runbook §6 senaryo 2). Bu bir tatbikat işidir, CI işi değil; henüz yapılmadı.
+- `infra/scripts/rollback.sh` bugüne kadar hiç çalıştırılmadı (D-29); PR #1017'deki yeni
+  sıralama (yedek → checkout → pull → down → up → health) yalnız `bash -n` seviyesinde
+  doğrulandı.
+- Geri alınacak image'ın diskte bulunması D-28'in prune sırasına bağlıdır; sunucuda başka bir
+  disk temizliği varsa `docker images | grep cargo-pilot` ile teyit edilmelidir.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,100 @@
+# Mimari Karar Kayıtları (ADR)
+
+**Son güncelleme:** 2026-08-17 · **Durum:** Aktif
+
+Bu klasör, Cargo Pilot'ta geri alınması pahalı olan teknik kararların gerekçesini tutar.
+Kod "ne yapıldığını" söyler; ADR "neden böyle yapıldığını" ve **hangi alternatiflerin
+neden elendiğini** söyler.
+
+---
+
+## İndeks
+
+| No | Karar | Durum | Tarih |
+|----|-------|-------|-------|
+| [ADR-0001](ADR-0001-erp-baglanti-mimarisi.md) | ERP bağlantı mimarisi | Kabul edildi | 2026-08-11 |
+| [ADR-0002](ADR-0002-optimizasyon-motoru-modulerlestirme.md) | Optimizasyon motorunun Application katmanına taşınması ve modüllere bölünmesi | Kabul edildi | 2026-08-11 |
+| [ADR-0003](ADR-0003-lifo-bolge-sert-kisiti.md) | LIFO bölge kısıtı: iki kademeli sert kısıt | Kabul edildi | 2026-08-15 |
+| [ADR-0004](ADR-0004-denge-takasi-cift-yonlu-dogrulama.md) | Denge takasında çift yönlü doğrulama | Kabul edildi | 2026-08-15 |
+| [ADR-0005](ADR-0005-modul-bayraklari-disa-kapali.md) | Modül bayraklarının API'ye ve arayüze açılmaması | Kabul edildi | 2026-08-11 |
+| [ADR-0006](ADR-0006-uc-dalli-terfi-modeli.md) | Üç dallı terfi modeli ve Terfi workflow'u | Kabul edildi | 2026-08-03 |
+| [ADR-0007](ADR-0007-docker-build-cache-asimetrisi.md) | Docker build cache asimetrisi: backend `mode=min`, frontend `mode=max` | Kabul edildi | 2026-08-15 |
+| [ADR-0008](ADR-0008-sha-pinleme-surum-yukseltmeden-ayri.md) | SHA pinleme, sürüm yükseltmesinden ayrılır | Kabul edildi | 2026-08-15 |
+| [ADR-0009](ADR-0009-otomatik-geri-alma-sessizce-basarili-donmez.md) | Otomatik geri alma sessizce başarılı dönmez | Kabul edildi | 2026-08-17 |
+
+[ADR-0000](ADR-0000-sablon.md) numara değil, boş şablondur; indekste karar olarak sayılmaz.
+
+---
+
+## Ne zaman ADR yazılır
+
+ADR, her PR için değil, **geri dönüşü pahalı** kararlar için yazılır. Aşağıdakilerden
+en az biri geçerliyse ADR yazılır:
+
+- Katman/klasör sınırı, bağımlılık yönü veya dağıtım topolojisi değişiyor.
+- Bir davranış bilinçli olarak **yapılmıyor** ya da erteleniyor (ertelenen iş, ADR olmadan
+  altı ay sonra "unutulmuş eksik" gibi görünür).
+- Ölçülerek elenmiş bir alternatif var; ölçüm ADR'de saklanmazsa aynı alternatif tekrar önerilir.
+- Karar, ilk bakışta "yanlış" görünen bilinçli bir tercih içeriyor (ör. daha yavaş ama daha
+  doğru bir yol, ya da "düzgün mimari" görünen bir soyutlamanın kasten eklenmemesi).
+- Bir kalibrasyon, katsayı ya da eşik değeri "neden bu sayı" sorusuna açık cevap gerektiriyor.
+
+Yazılmaz: rutin hata düzeltmeleri, bağımlılık yükseltmeleri, tek dosyalık yeniden adlandırmalar,
+kod okunarak bir dakikada anlaşılabilen tercihler.
+
+## Numaralandırma
+
+- Biçim `ADR-NNNN`, **dört hane**, sıfırdan doldurulur (`ADR-0007`, `ADR-0042`).
+- Numaralar sıfırdan artan tek bir diziden verilir; boşluk bırakılmaz.
+- **Bir numara asla geri kullanılmaz.** Reddedilen, terk edilen ya da yerini başkasına bırakan
+  ADR'nin numarası da o ADR'de kalır; dosya silinmez.
+- Dosya adı: `ADR-NNNN-kisa-slug.md` — kebab-case, Türkçe karakter kullanılmaz.
+- Numara **paralel çalışmada önden ayrılabilir**: indekse `*(ayrılmış — konu)*` satırı eklenir,
+  dosya sonradan gelir.
+
+## Durum değerleri
+
+| Durum | Anlamı |
+|---|---|
+| `Önerildi` | Tartışmaya açık; kod bu kararı henüz uygulamıyor. |
+| `Kabul edildi` | Yürürlükte; kod bu kararı uyguluyor. |
+| `Reddedildi` | Değerlendirildi ve uygulanmamasına karar verildi. Dosya, gerekçesi için durur. |
+| `Yerini aldı: ADR-XXXX` | Yürürlükten kalktı; yerine geçen ADR'nin numarası yazılır. |
+
+## Bir ADR nasıl değiştirilir
+
+**Kabul edilmiş bir ADR'nin gövdesi düzenlenmez.** Karar değiştiyse:
+
+1. Yeni bir ADR yazılır; `## Bağlam` bölümünde eski ADR'ye ve neyi değiştirdiğine atıf yapar.
+2. Eski ADR'nin **yalnızca `Durum` satırı** `Yerini aldı: ADR-XXXX` olarak güncellenir.
+3. Bu klasörün indeksi ve `SUMMARY.md` güncellenir.
+
+İzin verilen tek gövde düzenlemesi: yazım/bağlantı düzeltmesi ve kararın anlamını değiştirmeyen
+kanıt tazelemesi (ör. taşınmış bir dosya yolunun düzeltilmesi).
+
+## Yapı
+
+Yeni ADR [ADR-0000-sablon.md](ADR-0000-sablon.md) kopyalanarak açılır. Zorunlu bölümler:
+
+- `# ADR-NNNN — <Konu>` başlığı
+- **Durum / Tarih / Kapsam** metadata satırları
+- `## Bağlam` — karar öncesi durum ve sorun
+- `## Karar` — numaralı alt kararlar; **her alt karar `Gerekçe` ve `Sonuçları` içerir**
+- `## Alternatifler` — tablo; **en az iki elenen alternatif** ve neden elendiği.
+  Ölçülerek elendiyse ölçüm sayısı yazılır.
+- `## Açık konular` — bilinçli olarak bu karara girmeyenler
+
+Aralarına konuya özel bölümler eklenebilir.
+
+## Kanıt disiplini
+
+Her iddia `dosya:satır`, komut çıktısı, ölçüm ya da PR numarasıyla desteklenir. Ölçülmemiş bir
+sayı "tahmin" olarak etiketlenir. Geriye dönük (kararın alınmasından sonra) yazılan ADR bunu
+metninde açıkça belirtir ve `Tarih` alanına **kararın alındığı** tarihi yazar, yazıldığı tarihi değil.
+
+---
+
+## İlgili Dokümanlar
+
+- [ADR Kuralı (konvansiyon)](../conventions/adr.md)
+- [Doküman Haritası](../context/doc-map.md)

--- a/docs/archive/devops-iyilestirme-analizi-2026-08.md
+++ b/docs/archive/devops-iyilestirme-analizi-2026-08.md
@@ -35,6 +35,11 @@ Bu dosya artık yalnızca kanıt gövdesini ve 2026-08-03 tablosunu saklar.
 > **45'i açık** ve D-kodları korunarak
 > [`devops-backlog.md`](../devops/devops-backlog.md) **Kategori 6**'ya taşındı — canlı takip artık orada.
 > Bu dosya bundan sonra yalnızca 2026-08-03'teki tabloyu ve kanıt gövdesini saklar.
+>
+> **2026-08-18 notu:** Triyajdan sonra 10 bulgu daha kapandı (D-14, D-18, D-21, D-22, D-23,
+> D-24, D-25, D-26, D-27, D-28 · PR #1012, #1016, #1017). Aşağıdaki gövdede bunlar hâlâ
+> 2026-08-03'teki hâlleriyle duruyor — **bu dosyadaki durum işaretleri o günün fotoğrafıdır.**
+> Güncel sayı: 51'den 16'sı kapalı, **35'i açık**.
 
 Bu doküman dört paralel tarama (CI/CD süresi · Docker image · Altyapı & observability · Sunucu operasyonu) ile tespit edilen 51 maddelik DevOps bulgu listesini, doğrulama durumlarını ve uygulama sırasını içerir.
 

--- a/docs/context/doc-map.md
+++ b/docs/context/doc-map.md
@@ -22,14 +22,25 @@ orada tek nüsha duruyordu ve dosya listesiyle birlikte iki ayrı yerde bayatlı
 
 ---
 
-**Toplam 47 dosya / 12.342 satır** (git ile izlenen tüm `.md` dosyaları).
-Son tarama: **2026-08-16 (konsolidasyon turu)**. Ölçüm komutu — bir sonraki okuyucu bayatlığı böyle kontrol eder:
+**Toplam 57 dosya / 14.071 satır** (git ile izlenen tüm `.md` dosyaları).
+Son tarama: **2026-08-17 (ADR pratiği turu)**. Ölçüm komutu — bir sonraki okuyucu bayatlığı böyle kontrol eder:
 
 ```bash
-git ls-files '*.md' | wc -l                 # → 47
-git ls-files '*.md' | xargs wc -l | tail -1 # → 12342
+git ls-files '*.md' | wc -l                 # → 57
+git ls-files '*.md' | xargs wc -l | tail -1 # → 14071
 ```
 
+> Önceki ölçüm 2026-08-16'da **47 / 12.342** idi. Aradaki fark yalnız ADR turundan gelmiyor:
+> bu tur 7 dosya ekledi (`docs/adr/` altında 6 + `docs/conventions/adr.md`), kalan 3 dosya
+> `dev`'e bu iki ölçüm arasında giren işlerden geliyor.
+
+> **Revizyon 2026-08-17 (ADR pratiği):** `docs/adr/` açıldı. Tek mevcut ADR
+> (`apps/backend/docs/erp-integration/adr-baglanti-mimarisi.md`) içeriği değiştirilmeden
+> `docs/adr/ADR-0001-erp-baglanti-mimarisi.md`'ye taşındı (yalnız başlığa numara eklendi);
+> gelen 3 bağlantı düzeltildi. Yeni dosyalar: `docs/adr/README.md` (indeks + kurallar),
+> `docs/adr/ADR-0000-sablon.md`, `ADR-0002`…`ADR-0005` (motor kararları),
+> `docs/conventions/adr.md`. Başlıktaki sayım bu turda yeniden ölçüldü: 47/12.342 → **57/14.071**.
+>
 > **Revizyon 2026-08-16 (konsolidasyon):** dosya sayısı değişmedi (**47**), yerleşim değişti.
 > `docs/COORDINATE_AUDIT.md`, `docs/devops/iyilestirme-analizi-2026-08.md` ve
 > `docs/context/branch-audit.md` `docs/archive/`'a taşındı (üçü de kendini bayat ilan etmişti);
@@ -105,6 +116,22 @@ Kökte yalnızca konvansiyonel dosyalar durur. `devops-audit-raporu.md` 2026-08-
 |-------|------:|------|--------------|
 | `branching.md` | 298 | **Yürürlükteki** model: üç dallı terfi `dev` → `test` → `main` (2026-08-03'ten itibaren). İş branch'leri `dev`'den açılır, `test`'e yalnızca `dev`'den PR, `main`'e yalnızca `test`/`hotfix`'ten PR; branch türleri ve ≤3 gün ömür kuralı, doğrudan push yasağı (ruleset), PR onay kuralları | Branch/PR açarken. **Tarihsel öneri:** `../archive/branching-proposal-2026-08.md` |
 | `commits.md` | 107 | Sade + açıklayıcı mesaj, atomic commit (1 değişiklik = 1 commit), Türkçe tercih, "fix/update/son" gibi mesajlar yasak, PR öncesi geçmiş temizliği | Commit atmadan önce |
+| `adr.md` | 43 | ADR kuralı: ne zaman ADR yazılır, `ADR-NNNN` numaralandırma (numara geri kullanılmaz), 4 durum değeri, "eski ADR düzenlenmez, yenisi yazılır" kuralı. Ayrıntı ve indeks `docs/adr/README.md` | Mimari bir karar alırken |
+
+## docs/adr
+
+Geri alınması pahalı teknik kararların gerekçe kaydı. Kod "ne", ADR "neden" ve
+"hangi alternatif neden elendi" sorusunu cevaplar.
+
+| Dosya | Satır | Özet | Şu soruda aç |
+|-------|------:|------|--------------|
+| `README.md` | 100 | **ADR indeksi (0001–0009) + pratiğin kuralları:** ne zaman ADR yazılır, numaralandırma (numara geri kullanılmaz), durum değerleri, değiştirme yordamı, zorunlu bölümler, kanıt disiplini | ADR yazmadan / ararken önce burası |
+| `ADR-0000-sablon.md` | 56 | Boş ADR şablonu — yeni ADR bu dosya kopyalanarak açılır | Yeni ADR açarken |
+| `ADR-0001-erp-baglanti-mimarisi.md` | 133 | ERP bağlantı mimarisi: MVP'de doğrudan MSSQL okuma, geri yazımın doğrudan tabloya yapılmaması, resmî API'lerin ertelenmesi, salt-okunur hesap. 2026-08-17'de `apps/backend/docs/erp-integration/adr-baglanti-mimarisi.md`'den taşındı | ERP bağlantı yaklaşımı sorgulanınca |
+| `ADR-0002-optimizasyon-motoru-modulerlestirme.md` | 151 | Motorun Infrastructure → Application taşınması ve 7 dosyaya bölünmesi. **Bölme biçimi arayüz/plugin değil, statik fonksiyonlardır** — sıcak döngüye dolaylı çağrı eklenmedi. Bölmeden önce 16 snapshot yazıldı | Motora soyutlama/interface eklemek akla geldiğinde |
+| `ADR-0003-lifo-bolge-sert-kisiti.md` | 156 | LIFO bölge cezası (2 000) yerçekiminden (1 000 000) 500× zayıftı. Çözüm: iki kademeli sert kısıt, katsayı 2 000'de kaldı. Katsayı büyütme ve koşulsuz eleme **ölçülerek** elendi | LIFO bölge katsayısı / sert kısıt tartışılınca |
+| `ADR-0004-denge-takasi-cift-yonlu-dogrulama.md` | 204 | `if (a.H != b.H)` eşit yükseklikli takaslarda destek kontrolünü atlıyordu → havada kutu. `othersA`/`othersB` + `ViolatesLoadAbove`. %43 yavaşlama bilinçli kabul. PR #997 düzeltmeyi neredeyse geri getiriyordu | `BalanceScoring.SwapIsValid`'e dokunmadan önce — **zorunlu** |
+| `ADR-0005-modul-bayraklari-disa-kapali.md` | 133 | `OptimizationModules` bayrakları kodda hazır ama API/arayüze açılmadı: 4 bayrak 16 kombinasyon üretir, katsayılar yalnız 3 kriter için kalibre. Handler'lar `Modules: null` verir → üretim davranışı değişmedi | "Bu bayrakları neden kullanıcıya açmıyoruz?" sorusunda |
 
 ## docs/setup
 
@@ -165,7 +192,6 @@ güncel davranışın kaynağı değildir.
 | `environment-variables.md` | 165 | `Section__SubSection__Key` naming standardı ve neden `__`, yapılandırma öncelik sırası, ortam bazlı secret kaynakları, User Secrets kurulumu, prod bağlantı akışı, secret policy, zorunlu/opsiyonel değişken tablosu | Env var eklerken |
 | `database-migrations.md` | 248 | `dotnet-ef` kurulumu, connection string kaynakları, migration üretme/uygulama/geri alma, isimlendirme, ortam bazlı akış, SQL script üretme, 6 yaygın hata | Migration işleri |
 | `user-story-tracker.md` | 541 | 17 story'nin alt iş bazında durum takibi (✅/🟡/⬜) + kanıt dosya listesi. Açık kalanlar: Story 8 "validation hatalarını envelope'a bağla", Story 9 correlation id + exception testleri | Backend ilerleme durumu |
-| `erp-integration/adr-baglanti-mimarisi.md` | 133 | ERP bağlantı mimarisi kararı (ADR) | ERP bağlantı yaklaşımı sorgulanınca |
 | `erp-integration/erp-export-kontrati.md` | 91 | ERP'ye dışa aktarım sözleşmesi (alanlar, format) | ERP export uçlarında |
 | `erp-integration/logo-schema-referans.md` | 455 | Logo ERP şema referansı (tablo/kolon envanteri) | Logo alan eşlemesi yaparken |
 | `erp-integration/data-model.md` | 102 | `Integration`, `SyncLog`, `ErpUserMapping` entity'leri + `Item`/`Vehicle`'a eklenecek alanlar | ERP entegrasyonu |
@@ -195,5 +221,5 @@ güncel davranışın kaynağı değildir.
 | ~~Branch konvansiyonu entegrasyon dalı modelini tarif ediyor, `known-issues.md` #6 bu modelin ayrışma ürettiğini kayıt altına almış~~ | ✅ Çözüldü — `branching.md` üç dallı terfi modelini tarif ediyor, `known-issues.md` #6'nın "Uygulanan çözüm" bölümü `Terfi Zinciri Kontrolü` job'unu ve terfi PR'larında squash yasağını belgeliyor; çelişki kalmadı |
 | ~~Algoritma tasarım dokümanları sadece `feature/3D_Packing_Algorithm` branch'inde~~ | ✅ Çözüldü — 1.160 satır PR #888 ile kurtarıldı; 2026-08-08'de `docs/archive/algoritma-tasarimi/` altına taşındı |
 | ~~`SUMMARY.md` (GitBook ToC) backend ve ERP dokümanlarını hiç listelemiyor~~ | ✅ Çözüldü (2026-08-08) — SUMMARY 7 bölümle yeniden üretildi; backend, devops ve arşiv dokümanları dahil edildi |
-| `SUMMARY.md` indeksi 47 dosyanın 36'sını kapsıyor | 🟡 **Açık, düşük öncelik** (ölçüm 2026-08-16: `grep -oE '\]\([^)]+\)' SUMMARY.md \| wc -l` → 36 bağlantı; `git ls-files '*.md'` → 47). `docs/` altındaki **24 dosyanın tamamı artık ToC'de** — `KOORDINAT-UYUM-RAPORU.md` bu turda eklendi. Kapsam dışı kalan 10 dosya: 4 `CLAUDE.md` (AI asistan talimatı), `pull_request_template.md`, `apps/frontend/e2e/README.md`, `apps/algorithm-test-ui/README.md`, 3 ERP dokümanı (`adr-baglanti-mimarisi`, `erp-export-kontrati`, `logo-schema-referans`). İlk yedisi bilinçli dışlama; 3 ERP dokümanı **eklenmeli** |
+| `SUMMARY.md` indeksi 47 dosyanın 36'sını kapsıyor | 🟡 **Açık, düşük öncelik** (ölçüm 2026-08-16: `grep -oE '\]\([^)]+\)' SUMMARY.md \| wc -l` → 36 bağlantı; `git ls-files '*.md'` → 47). `docs/` altındaki **24 dosyanın tamamı artık ToC'de** — `KOORDINAT-UYUM-RAPORU.md` bu turda eklendi. Kapsam dışı kalan 10 dosya: 4 `CLAUDE.md` (AI asistan talimatı), `pull_request_template.md`, `apps/frontend/e2e/README.md`, `apps/algorithm-test-ui/README.md`, 3 ERP dokümanı (`adr-baglanti-mimarisi`, `erp-export-kontrati`, `logo-schema-referans`). İlk yedisi bilinçli dışlama; 3 ERP dokümanı **eklenmeli**. **2026-08-17 yeniden ölçüm:** `grep -oE '\]\([^)]+\)' SUMMARY.md \| wc -l` → **44** bağlantı / `git ls-files '*.md'` → **57** dosya. ERP ADR'si `docs/adr/ADR-0001-erp-baglanti-mimarisi.md` olarak taşındı ve ToC'ye girdi; yeni `docs/adr/` (6 dosya) ve `docs/conventions/adr.md` de eklendi. Kalan 2 ERP dokümanı (`erp-export-kontrati`, `logo-schema-referans`) hâlâ açık |
 | ~~PR şablonunda ekran görüntüsü alanı yok~~ | ✅ Çözüldü (2026-08-08) — `pull_request_template.md`'ye "Ekran Görüntüleri" bölümü eklendi (UI PR'larında zorunlu) |

--- a/docs/conventions/adr.md
+++ b/docs/conventions/adr.md
@@ -1,0 +1,43 @@
+# ADR Kuralı
+
+**Son güncelleme:** 2026-08-17 · **Durum:** Aktif
+
+Geri alınması pahalı teknik kararlar `docs/adr/` altında ADR (Architecture Decision Record)
+olarak kayıt altına alınır. Bu sayfa kuralın özetidir; **tek yetkili kaynak**
+[`docs/adr/README.md`](../adr/README.md)'dir — indeks, şablon ve ayrıntılı yordam oradadır.
+
+---
+
+## Kural
+
+1. **ADR yazılır** eğer: katman/bağımlılık sınırı değişiyorsa, bir şey bilinçli olarak
+   *yapılmıyor* ya da erteleniyorsa, ölçülerek elenmiş bir alternatif varsa, karar ilk bakışta
+   yanlış görünen bilinçli bir tercih içeriyorsa, ya da bir katsayı/eşik "neden bu sayı"
+   sorusunu doğuruyorsa. Rutin hata düzeltmesi, bağımlılık yükseltmesi ve tek dosyalık yeniden
+   adlandırma için yazılmaz.
+2. **Numaralandırma** `ADR-NNNN` biçimindedir; dört hane, sıfırdan doldurulur, sıfırdan artan
+   tek diziden verilir. **Bir numara asla geri kullanılmaz** — reddedilen ya da yerini bırakan
+   ADR'nin dosyası silinmez, numarası boşa çıkmaz.
+3. **Durum** dört değerden biridir: `Önerildi`, `Kabul edildi`, `Reddedildi`,
+   `Yerini aldı: ADR-XXXX`.
+4. **Kabul edilmiş ADR'nin gövdesi düzenlenmez.** Karar değiştiyse yeni ADR yazılır, eskisinin
+   yalnızca `Durum` satırı `Yerini aldı: ADR-XXXX` olarak güncellenir. İzin verilen tek istisna
+   yazım/bağlantı düzeltmesidir.
+5. **Alternatifler bölümü zorunludur:** en az iki elenen alternatif ve neden elendiği.
+   Ölçülerek elendiyse ölçüm sayısı yazılır.
+6. **Kanıt disiplini:** her iddia `dosya:satır`, komut çıktısı, ölçüm ya da PR numarasıyla
+   desteklenir; ölçülmemiş sayı "tahmin" olarak etiketlenir.
+7. Yeni ADR [`docs/adr/ADR-0000-sablon.md`](../adr/ADR-0000-sablon.md) kopyalanarak açılır ve
+   `docs/adr/README.md` indeksi ile `SUMMARY.md` aynı PR'da güncellenir.
+
+---
+
+## İlgili Dokümanlar
+
+{% content-ref url="../adr/README.md" %}
+[ADR İndeksi ve Kuralları](../adr/README.md)
+{% endcontent-ref %}
+
+{% content-ref url="commits.md" %}
+[Commit Kuralları](commits.md)
+{% endcontent-ref %}

--- a/docs/devops/devops-backlog.md
+++ b/docs/devops/devops-backlog.md
@@ -1,6 +1,6 @@
 # DevOps Backlog
 
-**Son güncelleme:** 2026-08-16 · **Durum:** Aktif · **Oluşturulma:** 2026-05-10 · **Sorumlu:** DevOps Chapter Lead
+**Son güncelleme:** 2026-08-18 · **Durum:** Aktif · **Oluşturulma:** 2026-05-10 · **Sorumlu:** DevOps Chapter Lead
 
 Bu doküman DevOps ekibinin açık ve tamamlanmış iyileştirme maddelerini önceliklendirilmiş şekilde takip eder.
 
@@ -41,10 +41,10 @@ kayıt orada, plan burada; ikisi arasında tekrar bırakılmaz.
 | 15 | Yedekleme veri kaybı kümesi — D-03 (MinIO yedeği), D-04 (off-site), D-20 (bildirim) | 🔴 Kritik | ⚠️ Açık |
 | 16 | Kaynak limitleri — D-38 (limit yok), D-39 (`MSSQL_MEMORY_LIMIT_MB`) | 🔴 Kritik | ⚠️ Açık |
 | 17 | Prod öncesi zorunlular — D-47 (prod nginx conf), D-50 (port/path uyumsuzluğu) | 🟠 Yüksek | ⚠️ Açık |
-| 18 | Rollback güvenliği — D-24 (migration geri alınmıyor), D-25, D-27, D-29 (tatbikat) | 🟠 Yüksek | ⚠️ Açık |
+| 18 | Rollback güvenliği — D-24, D-25, D-27 ✅ (#1012, #1017); kalan **D-29 (tatbikat)** | 🟠 Yüksek | ⚠️ Açık |
 
-Kategori 6, 2026-08-03 taramasının **45 açık** D-bulgusunu D-kodlarıyla birlikte listeler;
-yukarıdaki matris yalnızca kritik kümeleri özetler.
+Kategori 6, 2026-08-03 taramasının **35 açık** D-bulgusunu D-kodlarıyla birlikte listeler
+(51'den 16'sı kapandı); yukarıdaki matris yalnızca kritik kümeleri özetler.
 
 ---
 
@@ -115,7 +115,10 @@ Sunucuda production ortamı hiç kurulmamış. `.env.prod` yok, compose hiç ça
 **Çözüm:** `.env.prod.example` → `.env.prod` oluşturulmalı, değerler doldurulmalı, prod compose ayağa kaldırılmalı.
 
 **Ön koşul:** Kategori 6.8 — D-38, D-39, D-47, D-50 bu maddeden önce kapatılmalı.
-Ayrıca `.env.prod` yokluğu D-21'deki gece cron hatalarının da kaynağıdır.
+
+`.env.prod` yokluğunun yan etkisi olan gece cron hataları (D-21) **#1012 ile ayrıca kapatıldı**:
+`setup-backup-cron.sh` prod cron'larını yalnız `.env.prod` varsa kuruyor. Yani bu madde artık
+alarm yorgunluğu üretmiyor; kurulum gerçekleştiğinde cron'lar kendiliğinden devreye girer.
 
 ---
 
@@ -340,17 +343,22 @@ izlenebilirlik için **D-kodları korunarak** buraya taşındı (triyaj tarihi: 
 Her satırın kanıtı `dosya:satır` düzeyinde yeniden doğrulandı — kapananlar aşağıda değil,
 kaynak dokümanda `✅` ile işaretlidir.
 
-**Triyaj sonucu:** 51 bulgudan **6'sı kapandı** (D-01, D-05, D-07, D-10, D-11, D-16),
+**Triyaj sonucu (2026-08-16):** 51 bulgudan **6'sı kapandı** (D-01, D-05, D-07, D-10, D-11, D-16),
 **45'i açık** (6'sı kısmen kapandı, kalan kapsamıyla listede duruyor).
+
+**Güncel durum (2026-08-18):** Triyajdan sonra **10 bulgu daha kapandı** — Dalga 1
+(D-18, D-21, D-22, D-23, D-25 · #1012) ve Dalga 2 (D-14 · #1016; D-24, D-26, D-27, D-28 · #1017).
+Kapanan satırlar aşağıdaki tablolardan çıkarıldı ve [Tamamlananlar](#tamamlananlar-tarih-sırası)
+bölümüne taşındı. **Kalan: 35 açık bulgu** — 6 kritik, 13 yüksek, 11 orta, 5 düşük.
+Kapananların hiçbiri kritik değildi; altı kritiğin dördü sunucuya SSH erişimi olmadan kapanmıyor.
 
 ### 6.1 Güvenlik
 
 | Kod | Bulgu | Bugünkü kanıt (2026-08-16) | Öncelik |
 |---|---|---|---|
-| D-02 | Servis portları internete açık — **kısmen kapandı** (#991) | Kalan: `infra/compose/docker-compose.monitoring.test.yml:89` Grafana `3002:3000`, `infra/compose/docker-compose.test.yml:127` ERP MSSQL `1435:1433` | 🔴 Kritik |
-| D-14 | `rollback.yml`'de shell injection | `.github/workflows/rollback.yml:40,62,74` — `${{ github.event.inputs.target_ref }}` doğrudan shell gövdesinde; sunucuda root olarak koşar | 🟠 Yüksek |
-| D-15 | Workflow'da hardcoded fallback parolalar | `.github/workflows/test-deploy.yml:172,176,179,181,183` — `gh secret list`'te `TEST_MSSQL_SA_PASSWORD`/`TEST_MINIO_*`/`SEED_*` yok → fallback'ler her koşuda fiilen kullanılıyor | 🟠 Yüksek |
-| D-17 | MSSQL container'ı root çalışıyor | `docker-compose.test.yml:90,118,147`, `docker-compose.prod.yml:92` — `user: root`. Prod'a geçmeden düzeltilmeli | 🟢 Düşük |
+| D-02 | Servis portları internete açık — **kısmen kapandı (#991), sonra kısmen yeniden açıldı** | Kalan: `docker-compose.monitoring.test.yml:89` Grafana `3002:3000`; `docker-compose.test.yml:127` ERP MSSQL `1435:1433` — bu ikincisi **#938 ile geldi** ve loopback'e bağlanmamış tek port (diğer 5'i `127.0.0.1:` önekli). `profiles: ["e2e"]` arkasında ama `--profile e2e` verilirse dışarı açılır | 🔴 Kritik |
+| D-15 | Workflow'da hardcoded fallback parolalar | `.github/workflows/test-deploy.yml:172,176,179,181,183` — `gh secret list`'te `TEST_MSSQL_SA_PASSWORD`/`TEST_MINIO_*`/`SEED_*` yok (2026-08-18: repoda tanımlı 6 secret var, bunlar arasında değil) → fallback'ler her koşuda fiilen kullanılıyor | 🟠 Yüksek |
+| D-17 | MSSQL container'ı root çalışıyor — **kapsam büyüdü** | `docker-compose.test.yml:90,118,147`, `docker-compose.prod.yml:92` — `user: root`. Sayı 2'den **4'e** çıktı: `:118` (`erp-mssql`) ve `:147` (`erp-mssql-init`) #938 ile eklendi. Prod'a geçmeden düzeltilmeli | 🟢 Düşük |
 
 ### 6.2 Yedekleme ve veri kaybı
 
@@ -358,23 +366,14 @@ kaynak dokümanda `✅` ile işaretlidir.
 |---|---|---|---|
 | D-03 | MinIO verisi hiç yedeklenmiyor | `infra/scripts/*.sh` içinde `minio` geçmiyor; yedeklenen tek şey MSSQL. DB restore edilse bile görsel/PDF referansları kırık gelir | 🔴 Kritik |
 | D-04 | Yedeklerin off-site kopyası yok | `restic`/`rclone`/`s3 sync` repoda hiç geçmiyor; yedekler DB ile aynı diskte, retention 7 gün → fiili RPO = ∞ | 🔴 Kritik |
-| D-18 | ERP `DIVIZYON` veritabanı yedek kapsamı dışında | `infra/scripts/backup-db.sh:21,25` tek DB adı (`CargoPilot`/`CargoPilotTest`); `DIVIZYON` aynı container'da ama yedeklenmiyor | 🟠 Yüksek |
 | D-19 | Yedek doğrulaması yüzeysel — **kısmen kapandı** (#994) | `WITH CHECKSUM` eklendi (`backup-db.sh:61`, `verify-backup.sh:98`). Kalan: gerçek restore tatbikatı yok, yalnızca **en son** yedek kontrol ediliyor | 🟠 Yüksek |
 | D-20 | Yedek başarısızlığında hiçbir bildirim yok | Script'lerde `node_exporter`/textfile metriği yok, Prometheus'ta yedek alert kuralı yok, `MAILTO` yok → 42 günlük olay sessizce tekrar edebilir. **Ön koşul:** D-41 | 🔴 Kritik |
-| D-21 | Prod cron'ları her gece hata basıyor | `infra/scripts/setup-backup-cron.sh:41-55` prod için 3 cron kuruyor; `.env.prod` sunucuda yok (madde 2.1 / known-issues #2) → alarm yorgunluğu | 🟠 Yüksek |
-| D-22 | Ölü hata blokları — parola okunamazsa sessiz çıkış | `backup-db.sh:36`, `restore-db.sh:41`, `verify-backup.sh:42` — `set -euo pipefail` altında grep boş dönerse atama satırında ölünür, alttaki `if` bloğuna hiç gelinmez. Düzeltme: `$(grep … \|\| true)` | 🟡 Orta |
-| D-23 | Yedek dosya izinleri sıkı değil | `backup-db.sh:48` `mkdir -p` varsayılan umask ile; `.bak` tüm müşteri verisini içeriyor. Düzeltme: dizin `700`, dosya `600` | 🟡 Orta |
 
 ### 6.3 Rollback ve deploy güvenliği
 
 | Kod | Bulgu | Bugünkü kanıt | Öncelik |
 |---|---|---|---|
-| D-24 | DB migration'ları geri alınmıyor ve hiçbir yerde yazmıyor | `DbInitializer.cs` `MigrateAsync()` yalnız ileri yönlü; `infra/scripts/rollback.sh` içinde "migration" kelimesi hiç geçmiyor, rollback runbook'u yok | 🟠 Yüksek |
-| D-25 | Yedeksiz rollback devam ediyor | `infra/scripts/rollback.sh:53-55` — `backup-db.sh … \|\| { echo "[WARN] Yedek alınamadı, devam ediliyor..."; }` | 🟠 Yüksek |
-| D-26 | Deploy'da `down` + `up` → her seferinde 2-3 dk kesinti | `.github/workflows/test-deploy.yml:465` `down --remove-orphans` mssql ve minio'yu da kapatıyor. `up -d --no-build --remove-orphans` yeterli → kesinti ~10-20 sn | 🟠 Yüksek |
-| D-27 | Health check başarısızsa otomatik geri alma yok | `test-deploy.yml:476-483` — health başarısızsa job kırmızı olur, sunucu bozuk image ile çalışmaya devam eder | 🟠 Yüksek |
-| D-28 | `docker image prune` health check'ten önce çalışıyor | `test-deploy.yml:474` prune, `476`'daki health check'ten önce → hızlı geri dönüş için GHCR'dan tekrar pull gerekir | 🟡 Orta |
-| D-29 | Rollback hiç denenmedi | `rollback.yml` bugüne kadar hiç çalıştırılmadı; D-24 + D-25 + `pull`'un `down`'dan sonra gelmesi (`rollback.sh:65` → `:80`) birlikte ilk gerçek olayda ortamı bozar. **Planlı tatbikat gerekli** | 🟠 Yüksek |
+| D-29 | Rollback hiç denenmedi | `rollback.yml` bugüne kadar hiç çalıştırılmadı (2026-08-18 doğrulaması: `gh run list --workflow=rollback.yml` boş). Ön koşulları D-24/D-25 ile kapandı — runbook yazıldı, yedeksiz devam engellendi — yani **tatbikatın önünde artık teknik engel yok**. Kalan: planlı tatbikat, `target_ref=v0.15.0` ile denenebilir | 🟠 Yüksek |
 
 ### 6.4 CI/CD süresi
 
@@ -383,7 +382,7 @@ kaynak dokümanda `✅` ile işaretlidir.
 | D-06 | Default branch'te GHA cache hiç yazılmıyor | Default branch `main`; hiçbir workflow `main` push'unda build etmiyor (`ci.yml:6-20`, `test-deploy.yml:13`) → `cache-from` iş branch'lerinde soğuk başlar. Düzeltme: nightly veya `main` push'unda seed job | 🟡 Orta |
 | D-09 | `ci.yml`'daki `docker-build` job'u — **kısmen kapandı** (#992) | Artık yalnızca `dev` PR'ında koşuyor (`ci.yml:204`); iş branch'i push'undaki kopya build kaldırıldı. Kalan soru: `dev` kapısındaki build'in değeri | 🟢 Düşük |
 | D-12 | Gereksiz seri `needs:` zinciri | `ci.yml:196` — `docker-build`, `needs: [frontend-ci, backend-ci]`; docker build bu job'ların çıktısına bağımlı değil | 🟢 Düşük |
-| D-13 | Küçük CI kalemleri | (a) `test-deploy.yml:327,340` hâlâ `build-push-action` **v5.4.0**, diğer 6 kullanım v7.3.0 — sürüm ayrışması; (b) `setup-dotnet`'te NuGet cache yok (`ci.yml:168`, `test-deploy.yml:48`); (c) `migration-check` + `backend-ci` aynı solution'ı Release'de iki kez derliyor; (d) frontend scope'ları hâlâ `mode=max` (`ci.yml:240`, `test-deploy.yml:145`) | 🟡 Orta |
+| D-13 | Küçük CI kalemleri | (a) `test-deploy.yml:327,340` hâlâ `build-push-action` **v5.4.0**, diğer 6 kullanım v7.3.0 — sürüm ayrışması. **PR #1032 (Dependabot) bunu ve 6 action'ı daha hizalıyor; ADR-0008'in öngördüğü devralma**; (b) `setup-dotnet`'te NuGet cache yok (`ci.yml:168`, `test-deploy.yml:48`); (c) `migration-check` + `backend-ci` aynı solution'ı Release'de iki kez derliyor; (d) frontend scope'ları hâlâ `mode=max` (`ci.yml:240`, `test-deploy.yml:145`) | 🟡 Orta |
 
 ### 6.5 Docker image ve build
 
@@ -429,7 +428,7 @@ kaynak dokümanda `✅` ile işaretlidir.
 | — | `server-requirements.md:43` | "MSSQL × 2 ≈ 4 GB" varsayımı D-39 ile çelişiyor | ⚠️ Açık |
 | — | `secret-management.md:107-114` | `TEST_GHCR_*`'ı aktif secret olarak listeliyor — secret'lar silindi (D-07) | ⚠️ Açık |
 | — | `server-access.md` | `SSH_HOST`/`SSH_PRIVATE_KEY` diyor; gerçek adlar `TEST_SSH_*` | ⚠️ Açık |
-| D-24 | — | Rollback runbook'u yok | ⚠️ Açık |
+| D-24 | [`rollback-runbook.md`](rollback-runbook.md) | Rollback runbook'u yok | ✅ Yazıldı (#1017) |
 
 ### 6.8 Prod sunucusu kurulmadan önce zorunlu
 
@@ -455,3 +454,13 @@ Madde 2.1 (Production Stack Deploy) bu dördüne bağımlıdır.
 | 2026-05-10 | `docker-compose.prod.yml` GHCR image | #488 |
 | 2026-05-10 | GHA cache cleanup | #489/#492 |
 | 2026-05-10 | `dev` branch hizalandı | #493 |
+| 2026-08-16 | **D-18** ERP `DIVIZYON` yedek kapsamına alındı — `backup-db.sh:41` `DATABASES` dizisi | #1012 |
+| 2026-08-16 | **D-21** Prod cron'ları yalnız ortam hazırsa kuruluyor — `setup-backup-cron.sh:49` `ortam_hazir()` | #1012 |
+| 2026-08-16 | **D-22** Parola okunamazsa sessiz çıkış kalktı — üç script'te `$(grep … \|\| true)` | #1012 |
+| 2026-08-16 | **D-23** Yedek izinleri sıkılaştırıldı — `umask 077`, dizin `700`, dosya `600` | #1012 |
+| 2026-08-16 | **D-25** Yedeksiz rollback artık duruyor; `--skip-backup` bilinçli kaçış yolu | #1012 |
+| 2026-08-16 | **D-14** `rollback.yml` girdileri `env:` üzerinden geçiyor, shell injection kapandı | #1016 |
+| 2026-08-17 | **D-24** Rollback runbook'u yazıldı — migration matrisi ve tatbikat senaryoları | #1017 |
+| 2026-08-17 | **D-26** Deploy `down`'sız tek `up` — kesinti 2-3 dk'dan **2,8 sn**'ye | #1017 |
+| 2026-08-17 | **D-27** Health başarısızsa otomatik geri alma — `PREV_IMAGE_REF` çıpası, ADR-0009 | #1017 |
+| 2026-08-17 | **D-28** `docker image prune` health OK'ten sonraya alındı | #1017 |

--- a/docs/devops/rollback-runbook.md
+++ b/docs/devops/rollback-runbook.md
@@ -1,0 +1,199 @@
+# Rollback Runbook
+
+**Son güncelleme:** 2026-08-16 · **Durum:** Aktif
+
+Bu doküman bir deploy'un geri alınması gerektiğinde izlenecek adımları tanımlar.
+Kod geri alma ile veritabanı geri alma **aynı şey değildir**; en kritik nokta budur.
+
+> ⚠️ **Temel kısıt:** `DbInitializer.MigrateAsync()` yalnız ileri yönlüdür. `rollback.sh`
+> yalnız **kodu ve image'ı** eski sürüme döndürür, **DB şemasını geri almaz.**
+> Şema geri alınacaksa tek yol yedekten dönüştür (§4).
+
+---
+
+## 1. Ne zaman rollback edilir
+
+| Durum | Aksiyon |
+|---|---|
+| Deploy sonrası backend health düşük, sunucu bozuk image ile çalışıyor | Otomatik geri alma devreye girer (§2). Girmemişse §3. |
+| Deploy başarılı ama uygulama işlevsel olarak bozuk (5xx, kritik akış çalışmıyor) | Manuel rollback (§3) |
+| Migration uygulandı ve veri bozuyor | **Önce §4** (yedekten dönüş), sonra §3 |
+| Yalnız bir konfigürasyon/env hatası | Rollback etme; env'i düzeltip `up -d` yeterli |
+| Frontend'de görsel/kozmetik hata | Rollback etme; ileri yönlü düzeltme (fix-forward) tercih edilir |
+
+**Karar kuralı:** Sorun **veri bütünlüğüne** dokunuyorsa rollback; yalnız davranışa
+dokunuyorsa fix-forward genelde daha ucuzdur. Rollback her zaman migration riski taşır.
+
+---
+
+## 2. Otomatik geri alma (test ortamı, deploy sırasında)
+
+`.github/workflows/test-deploy.yml` → `deploy-test-server` job'u:
+
+1. Pull'dan **önce** çalışan `cargo-pilot-backend-test` konteynerinin image referansından
+   mevcut tag saklanır (geri alma çıpası).
+2. Yeni image çekilir, `up -d --no-build --remove-orphans` ile stack güncellenir.
+3. Sunucu içinden `http://127.0.0.1:8081/health` loopback probu ile en fazla 100 sn beklenir.
+4. Health düşerse çıpa tag'i ile **tek seferlik** `up -d` çalıştırılıp önceki image'a dönülür.
+5. Geri alma başarılı olsa bile **job kırmızı bırakılır.**
+
+**Sınırları — bunları bilerek kullanın:**
+- Yalnız **image**'ı geri alır. `git checkout test` adımı geri alınmaz; sunucudaki çalışma
+  ağacı yeni commit'te kalır. Bu, compose dosyası veya `.env.test` değiştiyse önemlidir.
+- **DB migration'ını geri almaz.** Yeni sürüm migration uyguladıysa eski image yeni şemaya
+  karşı çalışır. Uyumsuzsa geri alma da health veremez → §4.
+- İlk deploy'da (önceki konteyner yok) veya tag aynıysa geri alma denenmez.
+- Prod'da bu mekanizma **yoktur**; prod deploy pipeline'ı henüz yok.
+
+---
+
+## 3. Manuel rollback
+
+### 3a. Workflow üzerinden (tercih edilen)
+
+GitHub Actions → **Rollback** workflow → `Run workflow`:
+- `environment`: `test` | `prod`
+- `target_ref`: hedef tag/SHA (boş bırakılırsa bir önceki `v*` tag'ine dönülür)
+
+### 3b. Sunucudan doğrudan
+
+```bash
+ssh root@<sunucu>
+cd /opt/cargo-pilot
+./infra/scripts/rollback.sh test v1.2.3      # veya: ./infra/scripts/rollback.sh prod
+```
+
+`rollback.sh` sırası:
+1. Rollback öncesi DB yedeği (`backup-db.sh`)
+2. `git fetch --tags` + hedef ref'e `checkout`
+3. **Image'ları GHCR'dan çek** (test ortamı)
+4. `down --remove-orphans`
+5. `up -d` (test: `--no-build`, prod: `--build`)
+6. Health kontrolü — düşerse çıkış kodu 1
+
+Adım 3'ün adım 4'ten **önce** olması bilinçlidir: image çekilemezse (GHCR erişimi yok,
+tag yok) ortam hiç kapatılmamış olur ve elde kalır.
+
+### 3c. Rollback sonrası doğrulama
+
+```bash
+docker compose -f infra/compose/docker-compose.test.yml ps
+curl -sf http://127.0.0.1:8081/health
+docker compose -f infra/compose/docker-compose.test.yml logs --tail=100 backend
+```
+
+Beklenen: tüm servisler `Up`, health 200, backend loglarında migration hatası yok.
+
+---
+
+## 4. Migration geri alınamıyorsa
+
+Bu bölüm **her rollback'te değil**, yalnız yeni sürüm DB şemasını değiştirmişse geçerlidir.
+
+**Önce tespit et:** Rollback edilecek aralıkta migration var mı?
+
+```bash
+cd /opt/cargo-pilot
+git diff --name-only <hedef-ref>..HEAD -- apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/
+```
+
+Çıktı boşsa şema değişmemiştir → §3 tek başına yeterli, bu bölümü atla.
+
+**Çıktı boş değilse — şema değişmiştir. Seçenekler:**
+
+| Migration türü | Geri alınabilir mi | Yapılacak |
+|---|---|---|
+| Yalnız ekleme (yeni tablo/kolon, nullable) | Genelde gerek yok | Eski sürüm fazla kolonu görmez; §3 yeterli. Doğrula. |
+| Kolon/tablo silme veya yeniden adlandırma | **Hayır** | Yedekten dönüş (§4a) zorunlu |
+| Veri dönüştüren migration (backfill, tip değişimi) | **Hayır** | Yedekten dönüş (§4a) zorunlu |
+
+### 4a. Yedekten dönüş adımları
+
+1. **Uygulamayı durdur** — geri yükleme sırasında yazma olmamalı:
+   ```bash
+   docker compose -f infra/compose/docker-compose.test.yml stop backend
+   ```
+2. **Kullanılacak yedeği seç ve doğrula:**
+   ```bash
+   ls -lt /opt/cargo-pilot/backups/mssql/test/
+   ./infra/scripts/verify-backup.sh test
+   ```
+   Deploy'dan **önce** alınmış bir yedek seçin. `rollback.sh` kendi başlangıcında da bir
+   yedek alır — o yedek **bozuk şemayı içerir**, geri dönüş için onu kullanmayın.
+3. **Geri yükle:**
+   ```bash
+   ./infra/scripts/restore-db.sh test /opt/cargo-pilot/backups/mssql/test/<dosya>.bak
+   ```
+4. **Kodu eski sürüme al** (§3) — şema ile image sürümü uyumlu olmalı.
+5. **Backend'i başlat ve doğrula:**
+   ```bash
+   docker compose -f infra/compose/docker-compose.test.yml up -d backend
+   curl -sf http://127.0.0.1:8081/health
+   ```
+6. **Veri kaybını hesapla ve kaydet:** son yedek ile olay anı arasındaki yazmalar kayıptır.
+   Bu aralığı olay kaydına yazın.
+
+### 4b. Yedek yoksa
+
+Yedek yoksa şema geri alınamaz. Bu durumda tek seçenek **ileri yönlü düzeltme**:
+sorunu gideren yeni bir migration yazıp normal deploy akışıyla göndermek.
+Rollback denemeyin — eski image yeni şemayla çalışmaz ve ortamı daha da bozarsınız.
+
+---
+
+## 5. `skip_backup` / `--skip-backup` ne zaman kullanılır
+
+`rollback.sh` normalde rollback'ten önce DB yedeği alır ve yedek alınamazsa durur.
+Kaçış yolu `--skip-backup` bayrağı (ya da `SKIP_BACKUP=1`), workflow tarafında
+`skip_backup` input'udur.
+
+> **Not:** Bu kaçış yolu script sertleştirme çalışmasıyla (backlog D-25) birlikte geliyor.
+> Elinizdeki `rollback.sh` sürümünde `--skip-backup` yoksa yedek adımı yalnız uyarı verip
+> devam ediyordur; aşağıdaki "kullanma" maddeleri o durumda **daha da** bağlayıcıdır.
+
+**Kullan:**
+- Yedek alma adımı takılıyor ve **kesinti maliyeti veri riskinden yüksek** (disk dolu,
+  MSSQL yanıt vermiyor, ortam zaten yazma alamıyor).
+- Rollback edilen ortam **test** ve içindeki veri feda edilebilir.
+- Zaten elde deploy öncesinden **taze ve doğrulanmış** bir yedek var.
+
+**Kullanma:**
+- Prod'da, elde deploy öncesi doğrulanmış bir yedek yokken. Bu durumda yedek hatasını
+  çözmek rollback'i geciktirmekten daha ucuzdur.
+- Migration içeren bir rollback'te (§4) — geri dönüş noktanız kalmaz.
+
+Kullanıldığında karar log'a yazılır. Olay sonrası incelemede "yedek var mıydı" sorusu
+bu satırdan cevaplanır; kararı olay kaydına da düşün.
+
+---
+
+## 6. Tatbikat prosedürü
+
+Rollback bugüne kadar **hiç gerçek koşulda denenmedi** (backlog D-29). İlk kez gerçek bir
+olayda denenmesi kabul edilebilir bir risk değil. Tatbikat çeyrekte bir, **test ortamında**,
+planlı bir pencerede yapılır.
+
+**Ön koşullar:** test ortamında en az iki farklı sürüm tag'i, taze ve `verify-backup.sh` ile
+doğrulanmış bir yedek, tatbikat penceresinde test ortamını kullanan kimse olmaması.
+
+**Senaryolar:**
+
+| # | Senaryo | Beklenen sonuç |
+|---|---|---|
+| 1 | Migration'sız sürüm arasında `rollback.sh test <onceki-tag>` | Health OK, veri değişmez |
+| 2 | Bilerek bozuk bir image ile deploy | Otomatik geri alma devreye girer, job kırmızı, ortam eski image'da sağlıklı |
+| 3 | GHCR erişimi engelli (`docker logout` + geçersiz tag) | Pull hatası, **stack ayakta kalır** (§3, adım 3-4 sırası) |
+| 4 | Migration'lı sürümden yedekten dönüş (§4a) | Şema eski hâline döner, backend eski image ile kalkar |
+
+**Her tatbikat için kaydedilecekler:** başlangıç/bitiş zamanı, ölçülen kesinti süresi,
+takılan adım, doküman ile gerçek davranış arasındaki fark, sonuç (başarılı/başarısız).
+Doküman ile gerçek arasında fark çıkarsa bu runbook aynı gün güncellenir.
+
+---
+
+## İlgili dokümanlar
+
+- [`deployment.md`](deployment.md) — deploy akışı ve ortam adresleri
+- [`devops-backlog.md`](devops-backlog.md) — D-24, D-26, D-27, D-28, D-29
+- [`server-access.md`](server-access.md) — sunucu erişimi, yedek cron'ları
+- [`known-issues.md`](known-issues.md) — bilinen açık sorunlar

--- a/infra/scripts/backup-db.sh
+++ b/infra/scripts/backup-db.sh
@@ -4,28 +4,51 @@
 # Kullanım:
 #   ./backup-db.sh [ortam]        ortam: prod (varsayılan) | test
 #
+# Ortam başına birden fazla veritabanı yedeklenir (aşağıdaki DATABASES dizisi).
+# Liste `BACKUP_DATABASES` ile ezilebilir (boşlukla ayrılmış):
+#   BACKUP_DATABASES="CargoPilotTest MUSTERI_ERP" ./backup-db.sh test
+#
 # Cron örneği (her gece 02:00):
 #   0 2 * * * /opt/cargo-pilot/infra/scripts/backup-db.sh prod >> /var/log/cargo-pilot/backup.log 2>&1
 
 set -euo pipefail
+
+# Yedek dosyalari tum musteri verisini icerir. Varsayilan umask ile dizin 755,
+# .bak 644 olur; host'taki her kullanici okuyabilir. 077 ile bu script'in
+# urettigi her sey sahibine ozel (dizin 700, dosya 600) yaratilir.
+umask 077
 
 ENVIRONMENT="${1:-prod}"
 TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
 BACKUP_DIR="/opt/cargo-pilot/backups/mssql/${ENVIRONMENT}"
 RETENTION_DAYS=7
 
-# Ortama göre değişkenler
+# Ortama göre değişkenler.
+# DATABASES dizisinin İLK elemanı birincil (uygulama) veritabanıdır: yoksa hata,
+# yedeklenemezse çıkış kodu 1. Sonraki elemanlar ek veritabanlarıdır; sunucuda
+# yoklarsa uyarıyla atlanır — varlıkları ortama göre değişebilir, yokluğu
+# uygulama yedeğini bloke etmemeli.
 if [[ "${ENVIRONMENT}" == "prod" ]]; then
     CONTAINER="cargo-pilot-mssql-prod"
     ENV_FILE="/opt/cargo-pilot/infra/env/.env.prod"
-    DATABASE="CargoPilot"
+    DATABASES=("CargoPilot")
 elif [[ "${ENVIRONMENT}" == "test" ]]; then
     CONTAINER="cargo-pilot-mssql-test"
     ENV_FILE="/opt/cargo-pilot/infra/env/.env.test"
-    DATABASE="CargoPilotTest"
+    # DIVIZYON: müşteri ERP veritabanı, 2026-05-16'da aynı container'a elle
+    # restore edildi (docs/devops/server-access.md "ERP Veritabanı (DIVIZYON)").
+    # Kaynağı bir .bak dosyası; yedeklenmezse geri getirilemez.
+    DATABASES=("CargoPilotTest" "DIVIZYON")
 else
     echo "[ERROR] Geçersiz ortam: ${ENVIRONMENT}. 'prod' veya 'test' kullanın."
     exit 1
+fi
+
+# Müşteri ERP veritabanının adı kuruluma göre değişir; listeyi dışarıdan ezmek
+# için script'i düzenlemek gerekmesin.
+if [[ -n "${BACKUP_DATABASES:-}" ]]; then
+    read -r -a DATABASES <<< "${BACKUP_DATABASES}"
+    echo "[$(date)] Veritabanı listesi BACKUP_DATABASES ile ezildi: ${DATABASES[*]}"
 fi
 
 # Env dosyasından SA şifresini oku
@@ -33,7 +56,11 @@ if [[ ! -f "${ENV_FILE}" ]]; then
     echo "[ERROR] Env dosyası bulunamadı: ${ENV_FILE}"
     exit 1
 fi
-SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'")
+# `|| true` şart: `set -euo pipefail` altında grep eşleşme bulamazsa (satır yoksa)
+# pipeline 1 döner ve script tam bu atama satırında, hiçbir mesaj basmadan ölür.
+# Aşağıdaki anlamlı hata bloğuna hiç gelinmez. `|| true` ile boş değer atanır,
+# hatayı `if [[ -z ]]` kontrolü açıkça raporlar.
+SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'" || true)
 
 if [[ -z "${SA_PASSWORD}" ]]; then
     echo "[ERROR] MSSQL_SA_PASSWORD env dosyasında bulunamadı."
@@ -46,32 +73,113 @@ fi
 export SQLCMDPASSWORD="${SA_PASSWORD}"
 
 mkdir -p "${BACKUP_DIR}"
+# umask yalnizca yeni yaratilanlari kapsar; onceki kosumlardan kalan gevsek
+# izinli dizinleri de her calismada duzeltiyoruz.
+chmod 700 "${BACKUP_DIR}"
 
-BACKUP_FILE="${BACKUP_DIR}/${DATABASE}_${TIMESTAMP}.bak"
+# Veritabanı container'da var mı?
+#   0 = var · 1 = yok · 2 = sorgulanamadı (container kapalı, parola yanlış vb.)
+# "yok" ile "sorgulayamadım" ayrımı önemli: ikincisi sessizce atlanacak bir durum
+# değil, hatadır.
+db_exists() {
+    local database="$1" answer
+    answer=$(docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
+        /opt/mssql-tools18/bin/sqlcmd \
+        -S localhost -U sa -C -h -1 \
+        -Q "SET NOCOUNT ON; SELECT CASE WHEN DB_ID('${database}') IS NULL THEN 0 ELSE 1 END;" \
+        2>/dev/null | tr -d ' \r\n' || true)
+    case "${answer}" in
+        1) return 0 ;;
+        0) return 1 ;;
+        *) return 2 ;;
+    esac
+}
 
-echo "[$(date)] Yedek başlatılıyor: ${DATABASE} → ${BACKUP_FILE}"
+# Tek bir veritabanının yedeğini alır. `set -e` fonksiyon koşul bağlamında
+# çağrıldığında askıya alındığı için her kritik adım açıkça `|| return 1` ile
+# korunur; aksi halde başarısız BACKUP'tan sonra kopyalamaya devam edilirdi.
+backup_one() {
+    local database="$1"
+    local remote_file="/var/opt/mssql/backup/${database}_${TIMESTAMP}.bak"
+    local backup_file="${BACKUP_DIR}/${database}_${TIMESTAMP}.bak"
+    local backup_size
 
-# Container içinde yedek klasörü oluştur ve BACKUP al
+    echo "[$(date)] Yedek başlatılıyor: ${database} → ${backup_file}"
+
+    # CHECKSUM: yedeğe sayfa checksum'ları yazar; verify-backup.sh bozulmayı bununla yakalar.
+    docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
+        /opt/mssql-tools18/bin/sqlcmd \
+        -S localhost -U sa -C \
+        -Q "BACKUP DATABASE [${database}] TO DISK = N'${remote_file}' WITH NOFORMAT, INIT, CHECKSUM, STATS=10" \
+        || { echo "[ERROR] BACKUP DATABASE başarısız: ${database}"; return 1; }
+
+    # Container'dan host'a kopyala
+    if ! docker cp "${CONTAINER}:${remote_file}" "${backup_file}"; then
+        echo "[ERROR] Yedek host'a kopyalanamadı: ${database}"
+        docker exec "${CONTAINER}" rm -f "${remote_file}" >/dev/null 2>&1 || true
+        return 1
+    fi
+    # `docker cp` dosya iznini kaynaktan taşıyabilir; umask'e güvenmeyip açıkça daraltıyoruz.
+    chmod 600 "${backup_file}"
+
+    # Container içindeki geçici yedeği temizle
+    docker exec "${CONTAINER}" rm -f "${remote_file}" || true
+
+    backup_size=$(du -sh "${backup_file}" | cut -f1)
+    echo "[$(date)] Yedek tamamlandı: ${backup_file} (${backup_size})"
+}
+
+# Container içinde yedek klasörünü hazırla
 docker exec "${CONTAINER}" mkdir -p /var/opt/mssql/backup
 
-# CHECKSUM: yedeğe sayfa checksum'ları yazar; verify-backup.sh bozulmayı bununla yakalar.
-docker exec -e SQLCMDPASSWORD "${CONTAINER}" \
-    /opt/mssql-tools18/bin/sqlcmd \
-    -S localhost -U sa -C \
-    -Q "BACKUP DATABASE [${DATABASE}] TO DISK = N'/var/opt/mssql/backup/${DATABASE}_${TIMESTAMP}.bak' WITH NOFORMAT, INIT, CHECKSUM, STATS=10"
+SUCCEEDED=()
+SKIPPED=()
+FAILED=()
 
-# Container'dan host'a kopyala
-docker cp "${CONTAINER}:/var/opt/mssql/backup/${DATABASE}_${TIMESTAMP}.bak" "${BACKUP_FILE}"
+for index in "${!DATABASES[@]}"; do
+    database="${DATABASES[${index}]}"
 
-# Container içindeki geçici yedeği temizle
-docker exec "${CONTAINER}" rm -f "/var/opt/mssql/backup/${DATABASE}_${TIMESTAMP}.bak"
+    exists_status=0
+    db_exists "${database}" || exists_status=$?
 
-# Dosya boyutunu logla
-BACKUP_SIZE=$(du -sh "${BACKUP_FILE}" | cut -f1)
-echo "[$(date)] Yedek tamamlandı: ${BACKUP_FILE} (${BACKUP_SIZE})"
+    if [[ "${exists_status}" -eq 2 ]]; then
+        echo "[ERROR] ${CONTAINER} sorgulanamadı (${database}). Container ayakta mı, parola doğru mu?"
+        exit 1
+    fi
+
+    if [[ "${exists_status}" -eq 1 ]]; then
+        if [[ "${index}" -eq 0 ]]; then
+            # Birincil veritabanının yokluğu yapılandırma hatasıdır; sessizce geçilemez.
+            echo "[ERROR] Birincil veritabanı ${CONTAINER} içinde bulunamadı: ${database}"
+            exit 1
+        fi
+        echo "[WARN] Veritabanı ${CONTAINER} içinde yok, atlanıyor: ${database}"
+        SKIPPED+=("${database}")
+        continue
+    fi
+
+    if backup_one "${database}"; then
+        SUCCEEDED+=("${database}")
+    else
+        FAILED+=("${database}")
+    fi
+done
+
+echo "[$(date)] Özet — başarılı: ${#SUCCEEDED[@]} · atlanan: ${#SKIPPED[@]} · başarısız: ${#FAILED[@]}"
+if [[ "${#SKIPPED[@]}" -gt 0 ]]; then
+    echo "[$(date)]   Atlanan  : ${SKIPPED[*]}"
+fi
 
 # Eski yedekleri temizle
 echo "[$(date)] ${RETENTION_DAYS} günden eski yedekler temizleniyor..."
 find "${BACKUP_DIR}" -name "*.bak" -mtime +${RETENTION_DAYS} -delete
 REMAINING=$(find "${BACKUP_DIR}" -name "*.bak" | wc -l)
 echo "[$(date)] Kalan yedek sayısı: ${REMAINING}"
+
+# Çıkış kodu en sonda veriliyor ki tek bir veritabanının hatası diğerlerinin
+# yedeğini ve temizliği engellemesin. Kod yine de 1: cron log'u ve rollback.sh
+# bu koda bakıyor, kısmi başarı "başarılı" sayılmamalı.
+if [[ "${#FAILED[@]}" -gt 0 ]]; then
+    echo "[ERROR] Yedeği alınamayan veritabanı(lar): ${FAILED[*]}"
+    exit 1
+fi

--- a/infra/scripts/restore-db.sh
+++ b/infra/scripts/restore-db.sh
@@ -38,7 +38,11 @@ if [[ ! -f "${ENV_FILE}" ]]; then
     echo "[ERROR] Env dosyası bulunamadı: ${ENV_FILE}"
     exit 1
 fi
-SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'")
+# `|| true` şart: `set -euo pipefail` altında grep eşleşme bulamazsa (satır yoksa)
+# pipeline 1 döner ve script tam bu atama satırında, hiçbir mesaj basmadan ölür.
+# Aşağıdaki anlamlı hata bloğuna hiç gelinmez. `|| true` ile boş değer atanır,
+# hatayı `if [[ -z ]]` kontrolü açıkça raporlar.
+SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'" || true)
 
 if [[ -z "${SA_PASSWORD}" ]]; then
     echo "[ERROR] MSSQL_SA_PASSWORD env dosyasında bulunamadı."
@@ -50,15 +54,23 @@ fi
 # `docker exec -e SQLCMDPASSWORD` (değersiz form) değeri bu kabuktan devralır.
 export SQLCMDPASSWORD="${SA_PASSWORD}"
 
-# Yedek dosyası belirtilmemişse en son yedeği bul
+# Yedek dosyası belirtilmemişse en son yedeği bul.
+# Arama hedef veritabanının adıyla sınırlı: backup-db.sh artık aynı dizine birden
+# fazla veritabanının yedeğini yazıyor (ör. test'te DIVIZYON). Filtre olmasaydı
+# "en son yedek" başka bir veritabanının .bak'ı olabilir ve yanlış veri
+# CargoPilot üzerine geri yüklenirdi.
 if [[ -z "${BACKUP_FILE}" ]]; then
-    BACKUP_FILE=$(find "${BACKUP_DIR}" -name "*.bak" -printf '%T@ %p\n' 2>/dev/null \
+    BACKUP_FILE=$(find "${BACKUP_DIR}" -name "${DATABASE}_*.bak" -printf '%T@ %p\n' 2>/dev/null \
         | sort -n | tail -1 | cut -d' ' -f2-)
     if [[ -z "${BACKUP_FILE}" ]]; then
-        echo "[ERROR] ${BACKUP_DIR} dizininde yedek dosyası bulunamadı."
+        echo "[ERROR] ${BACKUP_DIR} dizininde ${DATABASE} yedeği bulunamadı."
         exit 1
     fi
     echo "[$(date)] En son yedek seçildi: ${BACKUP_FILE}"
+elif [[ "$(basename "${BACKUP_FILE}")" != "${DATABASE}_"* ]]; then
+    # Elle verilen dosya başka bir veritabanına ait görünüyor. Bilinçli bir işlem
+    # olabilir (ör. DIVIZYON.bak'ı elle yükleme), o yüzden engellemiyoruz.
+    echo "[WARN] Dosya adı hedef veritabanıyla eşleşmiyor: $(basename "${BACKUP_FILE}") → ${DATABASE}"
 fi
 
 # Yedek dosyası var mı?

--- a/infra/scripts/rollback.sh
+++ b/infra/scripts/rollback.sh
@@ -2,22 +2,40 @@
 # rollback.sh — Önceki başarılı deploy'a geri döner.
 #
 # Kullanım:
-#   ./rollback.sh [ortam] [git-ref]
+#   ./rollback.sh [ortam] [git-ref] [--skip-backup]
 #
-#   ortam   : prod | test (varsayılan: prod)
-#   git-ref : geri dönülecek tag veya commit SHA
-#             belirtilmezse bir önceki tag'e döner
+#   ortam        : prod | test (varsayılan: prod)
+#   git-ref      : geri dönülecek tag veya commit SHA
+#                  belirtilmezse bir önceki tag'e döner
+#   --skip-backup: rollback öncesi DB yedeği alınamazsa yine de devam et
+#                  (eşdeğeri: SKIP_BACKUP=1 ortam değişkeni)
 #
 # Örnekler:
 #   ./rollback.sh prod                  # prod'da önceki tag'e dön
 #   ./rollback.sh prod v1.2.3           # prod'da belirli tag'e dön
 #   ./rollback.sh test abc1234          # test'te belirli commit'e dön
+#   ./rollback.sh prod v1.2.3 --skip-backup   # yedek alınamıyor, yine de dön
 
 set -euo pipefail
 
-ENVIRONMENT="${1:-prod}"
-TARGET_REF="${2:-}"
 DEPLOY_DIR="/opt/cargo-pilot"
+
+# Bayrak, konumdan bağımsız okunur; mevcut çağrılar (`rollback.sh test "${TARGET}"`,
+# TARGET boş olabilir) aynen çalışmaya devam eder.
+SKIP_BACKUP="${SKIP_BACKUP:-0}"
+POSITIONAL=()
+for arg in "$@"; do
+    case "${arg}" in
+        --skip-backup) SKIP_BACKUP=1 ;;
+        *) POSITIONAL+=("${arg}") ;;
+    esac
+done
+
+ENVIRONMENT="${POSITIONAL[0]:-prod}"
+TARGET_REF="${POSITIONAL[1]:-}"
+
+# Boş pozisyonel argüman (workflow hedef ref'i boş geçebilir) varsayılana düşsün.
+ENVIRONMENT="${ENVIRONMENT:-prod}"
 
 if [[ "${ENVIRONMENT}" == "prod" ]]; then
     COMPOSE_FILE="${DEPLOY_DIR}/infra/compose/docker-compose.prod.yml"
@@ -49,10 +67,41 @@ fi
 echo "[$(date)] Rollback başlatılıyor: ${ENVIRONMENT} → ${TARGET_REF}"
 
 # Yedek al (rollback öncesi güvenlik)
-echo "[$(date)] Rollback öncesi DB yedeği alınıyor..."
-"${DEPLOY_DIR}/infra/scripts/backup-db.sh" "${ENVIRONMENT}" || {
-    echo "[WARN] Yedek alınamadı, devam ediliyor..."
-}
+#
+# Tasarım kararı: yedek alınamazsa VARSAYILAN DAVRANIŞ DURMAKTIR.
+# Rollback, şema ve veriye dokunan geri dönülemez bir işlemdir; güvenlik ağı
+# yokken devam etmek, kurtarmaya çalıştığımız olayı veri kaybına çevirebilir.
+# Eski davranış (uyarı basıp devam) bu riski sessizce alıyordu.
+#
+# Ancak rollback bir ACİL DURUM aracıdır: yedek altyapısının kendisi bozukken
+# (disk dolu, MSSQL kapalı) sert durmak operatörü kilitleyebilir. Bu yüzden
+# bilinçli bir kaçış yolu bırakılıyor: `--skip-backup` / `SKIP_BACKUP=1`.
+# Bayrak yalnız operatörün açıkça verdiği durumda geçerlidir ve log'a çok
+# görünür bir uyarı basar — kararın kayıt altına alınması amaçlı.
+if [[ "${SKIP_BACKUP}" == "1" ]]; then
+    echo "==============================================================="
+    echo "[UYARI] YEDEK ADIMI ATLANDI (--skip-backup / SKIP_BACKUP=1)"
+    echo "[UYARI] Rollback, DB yedeği OLMADAN yapılıyor: ${ENVIRONMENT}"
+    echo "[UYARI] Veri kaybı geri alınamaz. Bu bilinçli bir operatör kararıdır."
+    echo "[UYARI] Zaman: $(date)"
+    echo "==============================================================="
+else
+    echo "[$(date)] Rollback öncesi DB yedeği alınıyor..."
+    if ! "${DEPLOY_DIR}/infra/scripts/backup-db.sh" "${ENVIRONMENT}"; then
+        echo "==============================================================="
+        echo "[ERROR] Rollback öncesi DB yedeği ALINAMADI — rollback durduruldu."
+        echo "[ERROR] Ortam: ${ENVIRONMENT} · Hedef: ${TARGET_REF}"
+        echo ""
+        echo "Önce yedeklemenin neden başarısız olduğunu inceleyin:"
+        echo "  bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh ${ENVIRONMENT}"
+        echo ""
+        echo "Yedek alınamıyor ve rollback ertelenemiyorsa, veri kaybı riskini"
+        echo "bilerek kabul ederek şu şekilde tekrar çalıştırın:"
+        echo "  ${DEPLOY_DIR}/infra/scripts/rollback.sh ${ENVIRONMENT} ${TARGET_REF} --skip-backup"
+        echo "==============================================================="
+        exit 1
+    fi
+fi
 
 # Kodu hedef ref'e çek
 echo "[$(date)] Kod ${TARGET_REF} sürümüne getiriliyor..."
@@ -91,7 +140,16 @@ fi
 echo "[$(date)] Sağlık kontrolü bekleniyor (60s)..."
 sleep 20
 
-BACKEND_PORT=$(grep -E '^BACKEND_PORT=' "${ENV_FILE}" | cut -d= -f2 | tr -d '"')
+# `|| true` şart: `set -euo pipefail` altında grep eşleşme bulamazsa pipeline 1 döner
+# ve script tam burada, stack yeniden başlatıldıktan sonra sessizce ölür — operatör
+# rollback'in nerede kaldığını göremez. Boş değeri aşağıda açıkça raporluyoruz.
+BACKEND_PORT=$(grep -E '^BACKEND_PORT=' "${ENV_FILE}" | cut -d= -f2 | tr -d '"' || true)
+if [[ -z "${BACKEND_PORT}" ]]; then
+    echo "[ERROR] BACKEND_PORT ${ENV_FILE} içinde bulunamadı — sağlık kontrolü yapılamıyor."
+    echo "        Stack ${TARGET_REF} sürümüyle başlatıldı; durumu elle doğrulayın."
+    exit 1
+fi
+
 for i in $(seq 1 8); do
     if curl -sf "http://localhost:${BACKEND_PORT}/health" > /dev/null 2>&1; then
         echo "[$(date)] Rollback başarılı — backend sağlıklı (${TARGET_REF})"

--- a/infra/scripts/rollback.sh
+++ b/infra/scripts/rollback.sh
@@ -108,11 +108,8 @@ echo "[$(date)] Kod ${TARGET_REF} sürümüne getiriliyor..."
 git fetch --tags origin
 git checkout "${TARGET_REF}"
 
-# Stack'i yeniden başlat
-echo "[$(date)] Stack yeniden başlatılıyor..."
-docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
-    down --remove-orphans
-
+# Image'lar ortam KAPATILMADAN ÖNCE çekilir. Aksi hâlde GHCR erişilemezse ya da
+# tag yoksa stack zaten kapanmış olur ve ortam elde kalır.
 if [[ "${ENVIRONMENT}" == "test" ]]; then
     # Test ortamı: GHCR'dan immutable tag ile çek (--build yapılmaz)
     # Türetme release-tag.yml ile birebir aynı olmalı: sürüm tag'i main'deki merge
@@ -128,6 +125,14 @@ if [[ "${ENVIRONMENT}" == "test" ]]; then
     echo "[$(date)] GHCR'dan image çekiliyor: IMAGE_TAG=${IMAGE_TAG}"
     IMAGE_TAG="${IMAGE_TAG}" docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
         pull backend frontend
+fi
+
+# Stack'i yeniden başlat
+echo "[$(date)] Stack yeniden başlatılıyor..."
+docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
+    down --remove-orphans
+
+if [[ "${ENVIRONMENT}" == "test" ]]; then
     IMAGE_TAG="${IMAGE_TAG}" docker compose -f "${COMPOSE_FILE}" --env-file "${ENV_FILE}" \
         up -d --no-build
 else

--- a/infra/scripts/setup-backup-cron.sh
+++ b/infra/scripts/setup-backup-cron.sh
@@ -13,6 +13,10 @@ mkdir -p "${LOG_DIR}"
 mkdir -p "${BACKUP_DIR}/mssql/prod"
 mkdir -p "${BACKUP_DIR}/mssql/test"
 
+# Yedek dizinleri tüm müşteri verisini barındırır; host'taki diğer kullanıcılara
+# kapalı olmalı (backup-db.sh de her koşumda aynı izni uygular).
+chmod 700 "${BACKUP_DIR}" "${BACKUP_DIR}/mssql" "${BACKUP_DIR}/mssql/prod" "${BACKUP_DIR}/mssql/test"
+
 # Scriptleri çalıştırılabilir yap
 chmod +x "${DEPLOY_DIR}/infra/scripts/backup-db.sh"
 chmod +x "${DEPLOY_DIR}/infra/scripts/rollback.sh"
@@ -35,30 +39,61 @@ ${entry}"
     fi
 }
 
+# Bir ortamın cron'u yalnızca o ortam sunucuda gerçekten varsa kurulur.
+# backup-db.sh / verify-backup.sh ilk iş olarak .env.<ortam> dosyasını okur ve
+# yoksa hata verir. Prod stack henüz deploy edilmediği için (.env.prod yok)
+# kurulan prod cron'ları her gece hata basıyor ve alarm yorgunluğu üretiyordu —
+# gerçek bir yedekleme arızasını gizleyecek gürültü. Bu yüzden ortam hazır
+# değilse cron kurulmaz; ama sessizce değil, açık bir mesajla atlanır.
+ortam_hazir() {
+    [[ -f "${DEPLOY_DIR}/infra/env/.env.$1" ]]
+}
+
+ortam_atlandi() {
+    local environment="$1"
+    echo "[ATLANDI] ${environment} ortamı hazır değil: ${DEPLOY_DIR}/infra/env/.env.${environment} yok."
+    echo "          ${environment} cron'ları KURULMADI (kurulsalardı her gece hata basarlardı)."
+    echo "          Ortam deploy edildikten sonra bu script'i tekrar çalıştırın."
+    if echo "${CRON_CONTENT}" | grep -qF "backup-db.sh ${environment}"; then
+        echo "[UYARI]  crontab'da ${environment} girdisi ZATEN VAR ama ortam hazır değil."
+        echo "         Bu girdi şu anda her gece hata basıyor; 'crontab -e' ile elle kaldırın."
+    fi
+}
+
 # Cron satırlarında `bash ` öneki ikinci savunma hattıdır: repo'dan gelen dosyada
 # execute biti düşerse yedekleme sessizce "permission denied" ile durmaz.
 
-# Prod DB — her gece 02:00
-add_cron \
-    "0 2 * * * bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh prod >> ${LOG_DIR}/backup-prod.log 2>&1" \
-    "Cargo Pilot - Prod DB yedek"
+if ortam_hazir prod; then
+    # Prod DB — her gece 02:00
+    add_cron \
+        "0 2 * * * bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh prod >> ${LOG_DIR}/backup-prod.log 2>&1" \
+        "Cargo Pilot - Prod DB yedek"
 
-# Test DB — her gece 03:00
-add_cron \
-    "0 3 * * * bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh test >> ${LOG_DIR}/backup-test.log 2>&1" \
-    "Cargo Pilot - Test DB yedek"
+    # Prod yedek doğrulaması — her Pazar 04:00
+    add_cron \
+        "0 4 * * 0 bash ${DEPLOY_DIR}/infra/scripts/verify-backup.sh prod >> ${LOG_DIR}/verify-backup.log 2>&1" \
+        "Cargo Pilot - Prod yedek doğrulama"
+else
+    ortam_atlandi prod
+fi
 
-# Prod yedek doğrulaması — her Pazar 04:00
-add_cron \
-    "0 4 * * 0 bash ${DEPLOY_DIR}/infra/scripts/verify-backup.sh prod >> ${LOG_DIR}/verify-backup.log 2>&1" \
-    "Cargo Pilot - Prod yedek doğrulama"
+if ortam_hazir test; then
+    # Test DB — her gece 03:00
+    add_cron \
+        "0 3 * * * bash ${DEPLOY_DIR}/infra/scripts/backup-db.sh test >> ${LOG_DIR}/backup-test.log 2>&1" \
+        "Cargo Pilot - Test DB yedek"
+else
+    ortam_atlandi test
+fi
 
 # Crontab'a yaz
 echo "${CRON_CONTENT}" | crontab -
 
 echo ""
 echo "Cron kurulumu tamamlandı:"
-crontab -l | grep -A1 "Cargo Pilot"
+# `|| true`: hiçbir ortam hazır değilse grep eşleşme bulamaz ve `set -e` altında
+# script tam burada, kurulum özetini basmadan hata koduyla ölürdü.
+crontab -l | grep -A1 "Cargo Pilot" || echo "(kurulu Cargo Pilot cron girdisi yok)"
 echo ""
 echo "Yedek dizini: ${BACKUP_DIR}"
 echo "Log dizini  : ${LOG_DIR}"

--- a/infra/scripts/verify-backup.sh
+++ b/infra/scripts/verify-backup.sh
@@ -26,9 +26,11 @@ BACKUP_DIR="${DEPLOY_DIR}/backups/mssql/${ENVIRONMENT}"
 if [[ "${ENVIRONMENT}" == "prod" ]]; then
     CONTAINER="cargo-pilot-mssql-prod"
     ENV_FILE="${DEPLOY_DIR}/infra/env/.env.prod"
+    DATABASE="CargoPilot"
 elif [[ "${ENVIRONMENT}" == "test" ]]; then
     CONTAINER="cargo-pilot-mssql-test"
     ENV_FILE="${DEPLOY_DIR}/infra/env/.env.test"
+    DATABASE="CargoPilotTest"
 else
     echo "[ERROR] Geçersiz ortam: ${ENVIRONMENT}. 'prod' veya 'test' kullanın."
     exit 1
@@ -39,7 +41,11 @@ if [[ ! -f "${ENV_FILE}" ]]; then
     echo "[ERROR] Env dosyası bulunamadı: ${ENV_FILE}"
     exit 1
 fi
-SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'")
+# `|| true` şart: `set -euo pipefail` altında grep eşleşme bulamazsa (satır yoksa)
+# pipeline 1 döner ve script tam bu atama satırında, hiçbir mesaj basmadan ölür.
+# Aşağıdaki anlamlı hata bloğuna hiç gelinmez. `|| true` ile boş değer atanır,
+# hatayı `if [[ -z ]]` kontrolü açıkça raporlar.
+SA_PASSWORD=$(grep -E '^MSSQL_SA_PASSWORD=' "${ENV_FILE}" | cut -d= -f2- | tr -d '"' | tr -d "'" || true)
 
 if [[ -z "${SA_PASSWORD}" ]]; then
     echo "[ERROR] MSSQL_SA_PASSWORD env dosyasında bulunamadı."
@@ -51,12 +57,16 @@ fi
 # `docker exec -e SQLCMDPASSWORD` (değersiz form) değeri bu kabuktan devralır.
 export SQLCMDPASSWORD="${SA_PASSWORD}"
 
-# Yedek dosyası belirtilmemişse en son yedeği bul
+# Yedek dosyası belirtilmemişse en son yedeği bul.
+# Arama uygulama veritabanının adıyla sınırlı: backup-db.sh aynı dizine birden
+# fazla veritabanının yedeğini yazıyor (ör. test'te DIVIZYON). Filtresiz arama,
+# başka bir veritabanının yedeğini doğrulayıp uygulama yedeği sağlıklıymış gibi
+# rapor verebilirdi. Başka bir .bak'ı doğrulamak için dosya yolu argümanı verilir.
 if [[ -z "${BACKUP_FILE}" ]]; then
-    BACKUP_FILE=$(find "${BACKUP_DIR}" -name "*.bak" -printf '%T@ %p\n' 2>/dev/null \
+    BACKUP_FILE=$(find "${BACKUP_DIR}" -name "${DATABASE}_*.bak" -printf '%T@ %p\n' 2>/dev/null \
         | sort -n | tail -1 | cut -d' ' -f2-)
     if [[ -z "${BACKUP_FILE}" ]]; then
-        echo "[ERROR] ${BACKUP_DIR} dizininde yedek dosyası bulunamadı."
+        echo "[ERROR] ${BACKUP_DIR} dizininde ${DATABASE} yedeği bulunamadı."
         exit 1
     fi
     echo "[$(date)] En son yedek seçildi: ${BACKUP_FILE}"


### PR DESCRIPTION
İki terfi turunun birikimi — 17 commit, dört küme. `main` en son 16 Ağustosta (#1015, v0.15.0) güncellendi.

## 1 · DevOps Dalga 1 ve 2 — 10 bulgu kapandı

| PR | Bulgu | Kanıt |
|---|---|---|
| #1012 | D-18, D-21, D-22, D-23, D-25 | Yedekleme scriptleri sertleştirildi: ERP DB yedek kapsamına alındı, prod cronları yalnız ortam hazırsa kuruluyor, sessiz çıkışlar kalktı, izinler `700`/`600`, yedeksiz rollback duruyor |
| #1016 | D-14 | `rollback.yml` girdileri `env:` üzerinden — shell injection kapandı |
| #1017 | D-24, D-26, D-27, D-28 | Deploy kesintisi **2-3 dk → 2,8 sn**, health failde otomatik geri alma, prune health OKten sonra, rollback runbooku |

Bu terfide deploy yolu ilk kez **iki kez üst üste** koştu (#1029 ve bu tur); ikisinde de `Deploy (Test Server)` yeşil. Otomatik geri alma tetiklenmedi — beklenen davranış.

## 2 · ERP ekran uyumu

| PR | İçerik |
|---|---|
| #1018 | ERP ekran uyumu (19 dosya) |
| #1020 | E2E aktarım testi rotaya taşınan ekrana göre güncellendi — "Ürünlere Aktar" artık modal değil `/erp/aktar` rotası |

## 3 · Karar kaydı

| PR | İçerik |
|---|---|
| #1030 | ADR pratiği kuruldu, 8 mimari karar geriye dönük yazıldı |

`docs/adr/` altında 9 karar: motorun modüllere bölünmesi, LIFO sert kısıtı, denge takası çift yönlü doğrulama, modül bayraklarının kapalı tutulması, üç dallı terfi modeli, docker cache asimetrisi, SHA pinlemenin sürüm yükseltmesinden ayrılması, otomatik geri almanın sessizce başarılı dönmemesi.

## 4 · Bağımlılıklar ve düzeltme

| PR | İçerik |
|---|---|
| #1021 #1023 #1024 #1026 #1028 | npm + NuGet grupları, test kütüphanesi majörleri |
| #1031 | FluentAssertions (Xceed lisansı) ve jsdom (Node ≥22) için majör ignore |
| #1033 | Gecelik algoritma koşusu yapılandırılmamışken kırmızı yanmıyor |
| #1034 | DevOps backlogu tazelendi — 45 → 35 açık bulgu |

## Doğrulama

`test` üzerinde tam deploy zinciri koştu ve beş job da geçti: Image Build, Pending Migration Kontrolü, Deploy (Test), **Deploy (Test Server)**, **E2E Smoke (ERP)**.

## Terfi sonrası beklenen

`release-tag.yml` tetiklenip **v0.16.0** etiketini basacak ve `imagetools` ile backend/frontend imajlarını aynı etiketle GHCRa yazacak. Doğrulanacak: tag, iki imaj ve GitHub Release.