### PR TITLE
Özel telif lisansı eklendi

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Telif Hakkı (c) 2026 Divizyon
+
+Tüm hakları saklıdır.
+
+Bu depodaki kaynak kod, dokümantasyon ve tüm ilişkili materyaller Divizyon'a
+aittir ve telif hakkı ile korunmaktadır. Depoya erişebiliyor olmak, içeriği
+kullanma, kopyalama, değiştirme, dağıtma veya ticari amaçla kullanma hakkı
+vermez.
+
+Divizyon'un önceden yazılı izni olmaksızın:
+
+- bu kaynak kodun tamamının veya bir kısmının kopyalanması,
+- türev çalışma oluşturulması,
+- dağıtılması veya üçüncü taraflarla paylaşılması,
+- ticari veya ticari olmayan herhangi bir amaçla kullanılması
+
+yasaktır.
+
+İzin, lisans veya iş birliği talepleri için depo sahibi (Divizyon) ile
+iletişime geçilmelidir.

--- a/README.md
+++ b/README.md
@@ -99,3 +99,5 @@ cargo-pilot/
 ## Katkı Sağlama
 
 Depoya katkı sağlamadan önce [CONTRIBUTING.md](CONTRIBUTING.md) dosyasını okuyun: branch modeli, commit kuralları ve PR süreci orada özetlenir.
+
+Bu depo özel telif hakkına tabidir, tüm hakları saklıdır — bkz. [LICENSE](LICENSE).


### PR DESCRIPTION
## Özet

Depo public ve lisanssızdı. Lisanssız bir depo yasal olarak "tüm hakları saklı" sayılır, ama bunu açıkça yazan bir dosya olmadığı için üçüncü tarafın kullanım hakkı belirsiz kalıyordu. OpenSSF Scorecard'daki iki sıfırdan biri de bu.

Ürün kapalı kaynak bir SaaS olduğu için **özel telif notu (all rights reserved)** seçildi; açık lisans (MIT/Apache-2.0) bilinçli olarak seçilmedi.

- `LICENSE` — Türkçe özel telif notu: erişimin kullanım hakkı vermediği, kopyalama / türev çalışma / dağıtma / ticari kullanımın yazılı izne bağlı olduğu
- `README.md` — "Katkı Sağlama" bölümünün sonuna tek satır lisans notu

Telif sahibi adı `gh api orgs/Divizyon` ile teyit edildi: GitHub'da kayıtlı ad **Divizyon**.

## İlgili User Story / Issue

Faz 0 · F0-02 · OpenSSF Scorecard License = 0

## Değişiklik Tipi

- [x] 📄 Dokümantasyon / lisans

## Test Edildi mi?

- [x] Kanıt doğrulandı: `LICENSE`/`LICENSE.md`/`COPYING` yok, `gh api .license` → null, `.visibility` → public
- [x] README GitBook söz dizimi bozulmadı

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi

## Ek Notlar

**Beklenen sapma:** merge sonrası `gh api repos/Divizyon/cargo-pilot --jq .license` hâlâ `null` dönecek. Özel/proprietary lisanslar GitHub'ın SPDX dedektöründe tanınmaz; bu bir hata değil, açık lisans seçilmediği için doğal sonuç. OpenSSF tarafı `LICENSE` dosyasının varlığıyla kapanır.

Kapsam dışı: bağımlılık lisans taraması, `FluentAssertions` lisans kararı (ayrı iş, ADR konusu).
