### PR TITLE
Nginx sertleştirme, prod conf ve env hizalama (D-46, D-47, D-50)

### DIFF
--- a/infra/env/.env.prod.example
+++ b/infra/env/.env.prod.example
@@ -19,7 +19,11 @@
 # ─── Genel ───────────────────────────────────
 ENVIRONMENT=production
 BACKEND_PORT=8080
-FRONTEND_PORT=80
+# Nginx host'ta 80/443 dinliyor; frontend container'ı 80'e bağlanamaz.
+# Yüksek porta alındı; nginx cargopilot-prod.conf içinden 127.0.0.1:3003'e proxy eder.
+# 3000/3002 kullanılamaz (Grafana prod 3000, Grafana test 3002),
+# 3001 test frontend'inde kullanılıyor.
+FRONTEND_PORT=3003
 
 # ─── MSSQL ───────────────────────────────────
 # SQL Server için gerekli yapılandırma
@@ -43,7 +47,10 @@ MINIO_ROOT_PASSWORD=<GENERATE_STRONG_PASSWORD_MIN_16_CHARS>
 MINIO_BUCKET=cargo-pilot
 # Tarayıcının erişebileceği public MinIO adresi (presigned URL üretiminde kullanılır).
 # Boş bırakılırsa dosya bağlantıları container içi adresi gösterir ve dışarıdan açılmaz.
-MINIO_PUBLIC_ENDPOINT=https://<YOUR_DOMAIN>/files
+# Yol, infra/nginx/cargopilot-prod.conf içindeki `location /media/` ile birebir
+# aynı olmak zorunda: MinioStorageService URL'i `{PublicEndpoint}/{objectKey}`
+# olarak kurup bucket adını eklemiyor, bucket'ı nginx route ediyor.
+MINIO_PUBLIC_ENDPOINT=https://<YOUR_DOMAIN>/media
 
 # ─── JWT ─────────────────────────────────────
 # En az 32 karakter, production için güçlü random değer kullan

--- a/infra/nginx/cargopilot-prod.conf
+++ b/infra/nginx/cargopilot-prod.conf
@@ -1,0 +1,252 @@
+# ============================================================
+# Cargo Pilot — Nginx Reverse Proxy (Production Ortamı)
+#
+# Bu dosya cargopilot-test.conf'tan türetildi. Sertleştirme bloğu
+# (limit_req, gzip, server_tokens, güvenlik başlıkları, timeout'lar,
+# client_max_body_size) iki dosyada BİREBİR aynıdır — birinde değişiklik
+# yapıldığında diğerine de taşınmalıdır.
+#
+# ── TEST ↔ PROD FARKLARI (tek tek buradan izlenir) ──────────
+#   1. Domain      : test = cargopilot.divizyon.org
+#                    prod = <YOUR_DOMAIN>  ← kurulumda değiştirilmeli
+#   2. Backend     : test = 127.0.0.1:8081  → prod = 127.0.0.1:8080
+#                    (.env.prod.example → BACKEND_PORT)
+#   3. Frontend    : test = 127.0.0.1:3001  → prod = 127.0.0.1:3000
+#                    (.env.prod.example → FRONTEND_PORT)
+#   4. MinIO       : test = 127.0.0.1:9002  → prod = 127.0.0.1:9000
+#                    (.env.prod.example → MINIO_API_PORT)
+#   5. Bucket      : test = cargo-pilot-test → prod = cargo-pilot
+#                    (.env.prod.example → MINIO_BUCKET)
+#   6. Sertifika   : test = /etc/nginx/ssl/cargopilot.{crt,key} (self-signed)
+#                    prod = /etc/nginx/ssl/cargopilot-prod.{crt,key}
+#                    Prod'da gerçek bir CA sertifikası kullanılmalı; Let's
+#                    Encrypt ile kurulursa yol
+#                    /etc/letsencrypt/live/<YOUR_DOMAIN>/fullchain.pem ve
+#                    .../privkey.pem olarak güncellenir. (Sertifika değişimi
+#                    bu görevin kapsamı dışında.)
+#   7. limit_req zone adı: cargopilot_auth_test → cargopilot_auth_prod
+#                    (aynı ad iki dosyada çakışır)
+#
+# NOT: infra/scripts/setup-nginx.sh şu an sabit olarak test conf'unu
+# kopyalıyor; ortam parametresi alması F1-03'ün işi. Bu dosya oraya
+# bağlanana kadar elle kurulur.
+# ============================================================
+
+# ── Rate limit zone (http context) ──────────────────────────
+# Kimlik doğrulama uçları için. Zone adı ortama göre benzersiz olmak zorunda:
+# test ve prod conf'ları aynı conf.d dizininde yüklenirse aynı ad çakışır.
+#
+# rate=60r/m (1r/s) + burst=20 nodelay seçildi:
+#   - Gerçek kullanıcı yükü çok düşük: access token 60 dk ömürlü
+#     (appsettings.json → Jwt:AccessTokenExpiryMinutes=60), yani /auth/refresh
+#     kullanıcı başına saatte ~1 kez çağrılıyor. Login/register/şifre sıfırlama
+#     oturum başına 1-2 istek.
+#   - Anahtar $binary_remote_addr ve Cloudflare CF-Connecting-IP ile gerçek IP
+#     alınıyor; ancak NAT arkasındaki bir müşteri ofisi tek IP'den gelir.
+#     60r/m + 20 burst, vardiya başında eşzamanlı giriş yapan ~20 kişilik bir
+#     ofisi 429'a düşürmez.
+#   - Credential stuffing tarafında dakikada binlerce denemeyi 60'a indirir;
+#     backend'in kendi kilitleme mantığıyla birlikte yeterli.
+limit_req_zone $binary_remote_addr zone=cargopilot_auth_prod:10m rate=60r/m;
+
+# HTTP → HTTPS yönlendirme
+server {
+    listen 80;
+    server_name <YOUR_DOMAIN>;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name <YOUR_DOMAIN>;
+
+    # Nginx sürüm bilgisini yanıt başlığından ve hata sayfalarından kaldır
+    server_tokens off;
+
+    # limit_req aşımında 503 değil 429 dön (istemci için doğru semantik)
+    limit_req_status 429;
+
+    # SSL — prod sertifikası (FARK: test self-signed kullanıyor)
+    ssl_certificate     /etc/nginx/ssl/cargopilot-prod.crt;
+    ssl_certificate_key /etc/nginx/ssl/cargopilot-prod.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    # ── gzip (yalnız metin tipleri) ──────────────────────────
+    # Görsel/font/zip zaten sıkıştırılmış; tekrar sıkıştırmak CPU harcar.
+    # NOT: gzip + HTTPS, yanıt gövdesinde saldırganın kısmen kontrol ettiği
+    # bir gizli değer varsa BREACH'e açıktır. Cargo Pilot API'si CSRF token'ı
+    # gövdede döndürmüyor (refresh token httpOnly cookie'de), bu yüzden
+    # application/json sıkıştırması kabul edilebilir risk.
+    gzip              on;
+    gzip_vary         on;
+    gzip_min_length   1024;
+    gzip_comp_level   5;
+    gzip_proxied      any;
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        text/xml
+        application/json
+        application/javascript
+        application/xml
+        application/xml+rss
+        image/svg+xml;
+
+    # ── Güvenlik başlıkları ─────────────────────────────────
+    # DİKKAT: add_header alt bloklarda MİRAS ALINMAZ. Bir location kendi
+    # add_header'ını tanımlarsa buradaki tüm başlıklar o location için düşer.
+    # Bu yüzden add_header kullanan /media/ bloğu aynı listeyi tekrarlıyor.
+    add_header X-Frame-Options SAMEORIGIN always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+
+    # HSTS — 1 yıl. `preload` BİLEREK eklenmedi: preload listesine girmek
+    # pratikte geri alınamaz ve alan adı Cloudflare arkasında; sertifika
+    # zinciri doğrulanana kadar preload açılmamalı.
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    # CSP — BİLEREK Report-Only. Enforce edilirse frontend'i kırma riski
+    # yüksek ve doğrulanmamış noktalar var:
+    #   - src/index.css satır 1'de `@import url(https://fonts.googleapis.com/...)`
+    #     → style-src ve font-src harici host gerektiriyor (doğrulandı).
+    #   - Three.js/@react-three/drei sahnesi + @react-pdf/renderer + xlsx:
+    #     blob:, data: ve worker-src blob: gerekebilir; @react-pdf'in yoga
+    #     layout motoru WASM kullanıyorsa 'wasm-unsafe-eval' şart olur.
+    #     Bu kalem YEREL OLARAK DOĞRULANAMADI (node_modules kurulu değil).
+    #   - Radix/shadcn inline style attribute yazdığı için style-src
+    #     'unsafe-inline' gerekiyor.
+    # Aşağıdaki politika "hedeflenen enforce politikası"dır; Report-Only olarak
+    # yayına alıp tarayıcı konsolundaki ihlalleri topladıktan sonra
+    # `-Report-Only` soneki kaldırılarak enforce'a çevrilmelidir.
+    # Rapor toplayıcı (report-uri/report-to) henüz yok; ihlaller yalnız
+    # tarayıcı konsolunda görünür.
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; frame-src 'self' blob:; connect-src 'self'; upgrade-insecure-requests" always;
+
+    # Cloudflare'den gelen gerçek IP'yi al
+    set_real_ip_from 103.21.244.0/22;
+    set_real_ip_from 103.22.200.0/22;
+    set_real_ip_from 103.31.4.0/22;
+    set_real_ip_from 104.16.0.0/13;
+    set_real_ip_from 104.24.0.0/14;
+    set_real_ip_from 108.162.192.0/18;
+    set_real_ip_from 131.0.72.0/22;
+    set_real_ip_from 141.101.64.0/18;
+    set_real_ip_from 162.158.0.0/15;
+    set_real_ip_from 172.64.0.0/13;
+    set_real_ip_from 173.245.48.0/20;
+    set_real_ip_from 188.114.96.0/20;
+    set_real_ip_from 190.93.240.0/20;
+    set_real_ip_from 197.234.240.0/22;
+    set_real_ip_from 198.41.128.0/17;
+    real_ip_header CF-Connecting-IP;
+
+    # ── Kimlik doğrulama uçları (rate limitli) ───────────────
+    # `^~` ile /api/ prefix'inden önce eşleşir. AuthController rotası:
+    # api/v1/auth → login, register, refresh, logout, google, google/callback,
+    # request-password-reset, reset-password, secure-account,
+    # force-change-password.
+    location ^~ /api/v1/auth/ {
+        limit_req zone=cargopilot_auth_prod burst=20 nodelay;
+
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_buffering    off;
+    }
+
+    # ── Backend API (/api/* → backend:8080) ─────────────────
+    location /api/ {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+
+        # proxy_read_timeout 60s → 180s.
+        # Ölçüm (2026-08-18): 500 kutuluk plan, WeightBalance kriteri
+        # Release'te ~18 sn, Debug'ta ~29 sn. Prod Release koşuyor.
+        # 180s seçildi çünkü:
+        #   - 500 kutuda 18 sn olan bir çözücünün kutu sayısı arttıkça
+        #     doğrusaldan hızlı büyümesi beklenir; ~2000 kutuda 90 sn'lik
+        #     kötü senaryo makul bir üst tahmin. 180s bunun 2 katı pay bırakır.
+        #   - Debug ölçümünün (29 sn) 6 katından fazla.
+        #   - Sınırsız değil: takılan bir backend isteği worker bağlantısını
+        #     süresiz tutmasın.
+        # UYARI: Cloudflare'in origin yanıt zaman aşımı (Free/Pro planlarda
+        # 100 sn) bu değerden küçük. 100 sn'yi aşan koşular nginx'e değil
+        # Cloudflare 524'e takılır; gerçek çözüm uzun optimizasyonu
+        # asenkron (job + polling) hâle getirmektir.
+        proxy_connect_timeout 10s;
+        proxy_send_timeout    180s;
+        proxy_read_timeout    180s;
+
+        # Excel/ERP içe aktarma bugün 413 alıyor: import satırları istemcide
+        # (SheetJS) ayrıştırılıp toplu JSON olarak POST ediliyor.
+        # 25m seçildi — Kestrel'in 30 MB varsayılan gövde sınırının altında
+        # kalıyor, böylece sınırı nginx uyguluyor ve backend'in kendi limiti
+        # sürpriz bir ikinci duvar olmuyor.
+        client_max_body_size 25m;
+
+        proxy_buffering    off;
+    }
+
+    # ── Backend health endpoint ──────────────────────────────
+    location /health {
+        proxy_pass         http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+
+    # ── MinIO Media (/media/* → minio:9000/cargo-pilot/) ──
+    # Bu yol MINIO_PUBLIC_ENDPOINT ile BİREBİR aynı olmak zorunda:
+    # MinioStorageService dosya URL'ini `{PublicEndpoint}/{objectKey}` olarak
+    # kuruyor ve bucket adını eklemiyor — bucket'ı nginx route ediyor.
+    location /media/ {
+        proxy_pass         http://127.0.0.1:9000/cargo-pilot/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              127.0.0.1:9000;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_buffering    off;
+
+        # Resim/dosya cache — tarayıcıda 7 gün tut
+        add_header Cache-Control "public, max-age=604800, immutable";
+
+        # add_header mirası kırıldığı için server seviyesindeki güvenlik
+        # başlıkları burada tekrar ediliyor (yukarıdaki DİKKAT notu).
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; frame-src 'self' blob:; connect-src 'self'; upgrade-insecure-requests" always;
+
+        # Büyük dosyalar için timeout artır
+        proxy_read_timeout 120s;
+        client_max_body_size 50m;
+    }
+
+    # ── Frontend (catch-all → frontend:3000) ────────────────
+    location / {
+        proxy_pass         http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+    }
+}

--- a/infra/nginx/cargopilot-prod.conf
+++ b/infra/nginx/cargopilot-prod.conf
@@ -11,8 +11,9 @@
 #                    prod = <YOUR_DOMAIN>  ← kurulumda değiştirilmeli
 #   2. Backend     : test = 127.0.0.1:8081  → prod = 127.0.0.1:8080
 #                    (.env.prod.example → BACKEND_PORT)
-#   3. Frontend    : test = 127.0.0.1:3001  → prod = 127.0.0.1:3000
-#                    (.env.prod.example → FRONTEND_PORT)
+#   3. Frontend    : test = 127.0.0.1:3001  → prod = 127.0.0.1:3003
+#                    (.env.prod.example → FRONTEND_PORT). 80 nginx'in kendisi,
+#                    3000 Grafana prod, 3002 Grafana test, 3001 test frontend.
 #   4. MinIO       : test = 127.0.0.1:9002  → prod = 127.0.0.1:9000
 #                    (.env.prod.example → MINIO_API_PORT)
 #   5. Bucket      : test = cargo-pilot-test → prod = cargo-pilot
@@ -240,9 +241,9 @@ server {
         client_max_body_size 50m;
     }
 
-    # ── Frontend (catch-all → frontend:3000) ────────────────
+    # ── Frontend (catch-all → frontend:3003) ────────────────
     location / {
-        proxy_pass         http://127.0.0.1:3000;
+        proxy_pass         http://127.0.0.1:3003;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
         proxy_set_header   X-Real-IP         $remote_addr;

--- a/infra/nginx/cargopilot-test.conf
+++ b/infra/nginx/cargopilot-test.conf
@@ -4,7 +4,25 @@
 # SSL     : Self-signed (Cloudflare Full SSL ile uyumlu)
 # Frontend: localhost:3001 (cargo-pilot-frontend-test)
 # Backend : localhost:8081 (cargo-pilot-backend-test)
+# MinIO   : localhost:9002, bucket cargo-pilot-test
 # ============================================================
+
+# ── Rate limit zone (http context) ──────────────────────────
+# Kimlik doğrulama uçları için. Zone adı ortama göre benzersiz olmak zorunda:
+# test ve prod conf'ları aynı conf.d dizininde yüklenirse aynı ad çakışır.
+#
+# rate=60r/m (1r/s) + burst=20 nodelay seçildi:
+#   - Gerçek kullanıcı yükü çok düşük: access token 60 dk ömürlü
+#     (appsettings.json → Jwt:AccessTokenExpiryMinutes=60), yani /auth/refresh
+#     kullanıcı başına saatte ~1 kez çağrılıyor. Login/register/şifre sıfırlama
+#     oturum başına 1-2 istek.
+#   - Anahtar $binary_remote_addr ve Cloudflare CF-Connecting-IP ile gerçek IP
+#     alınıyor; ancak NAT arkasındaki bir müşteri ofisi tek IP'den gelir.
+#     60r/m + 20 burst, vardiya başında eşzamanlı giriş yapan ~20 kişilik bir
+#     ofisi 429'a düşürmez.
+#   - Credential stuffing tarafında dakikada binlerce denemeyi 60'a indirir;
+#     backend'in kendi kilitleme mantığıyla birlikte yeterli.
+limit_req_zone $binary_remote_addr zone=cargopilot_auth_test:10m rate=60r/m;
 
 # HTTP → HTTPS yönlendirme
 server {
@@ -17,6 +35,12 @@ server {
     listen 443 ssl http2;
     server_name cargopilot.divizyon.org;
 
+    # Nginx sürüm bilgisini yanıt başlığından ve hata sayfalarından kaldır
+    server_tokens off;
+
+    # limit_req aşımında 503 değil 429 dön (istemci için doğru semantik)
+    limit_req_status 429;
+
     # SSL — self-signed (Cloudflare Full mode için yeterli)
     ssl_certificate     /etc/nginx/ssl/cargopilot.crt;
     ssl_certificate_key /etc/nginx/ssl/cargopilot.key;
@@ -25,6 +49,59 @@ server {
     ssl_prefer_server_ciphers off;
     ssl_session_cache   shared:SSL:10m;
     ssl_session_timeout 10m;
+
+    # ── gzip (yalnız metin tipleri) ──────────────────────────
+    # Görsel/font/zip zaten sıkıştırılmış; tekrar sıkıştırmak CPU harcar.
+    # NOT: gzip + HTTPS, yanıt gövdesinde saldırganın kısmen kontrol ettiği
+    # bir gizli değer varsa BREACH'e açıktır. Cargo Pilot API'si CSRF token'ı
+    # gövdede döndürmüyor (refresh token httpOnly cookie'de), bu yüzden
+    # application/json sıkıştırması kabul edilebilir risk.
+    gzip              on;
+    gzip_vary         on;
+    gzip_min_length   1024;
+    gzip_comp_level   5;
+    gzip_proxied      any;
+    gzip_types
+        text/plain
+        text/css
+        text/javascript
+        text/xml
+        application/json
+        application/javascript
+        application/xml
+        application/xml+rss
+        image/svg+xml;
+
+    # ── Güvenlik başlıkları ─────────────────────────────────
+    # DİKKAT: add_header alt bloklarda MİRAS ALINMAZ. Bir location kendi
+    # add_header'ını tanımlarsa buradaki tüm başlıklar o location için düşer.
+    # Bu yüzden add_header kullanan /media/ bloğu aynı listeyi tekrarlıyor.
+    add_header X-Frame-Options SAMEORIGIN always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+
+    # HSTS — 1 yıl. `preload` BİLEREK eklenmedi: preload listesine girmek
+    # pratikte geri alınamaz ve alan adı hâlâ self-signed sertifika +
+    # Cloudflare Full (strict değil) modunda.
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    # CSP — BİLEREK Report-Only. Enforce edilirse frontend'i kırma riski
+    # yüksek ve doğrulanmamış noktalar var:
+    #   - src/index.css satır 1'de `@import url(https://fonts.googleapis.com/...)`
+    #     → style-src ve font-src harici host gerektiriyor (doğrulandı).
+    #   - Three.js/@react-three/drei sahnesi + @react-pdf/renderer + xlsx:
+    #     blob:, data: ve worker-src blob: gerekebilir; @react-pdf'in yoga
+    #     layout motoru WASM kullanıyorsa 'wasm-unsafe-eval' şart olur.
+    #     Bu kalem YEREL OLARAK DOĞRULANAMADI (node_modules kurulu değil).
+    #   - Radix/shadcn inline style attribute yazdığı için style-src
+    #     'unsafe-inline' gerekiyor.
+    # Aşağıdaki politika "hedeflenen enforce politikası"dır; Report-Only olarak
+    # yayına alıp tarayıcı konsolundaki ihlalleri topladıktan sonra
+    # `-Report-Only` soneki kaldırılarak enforce'a çevrilmelidir.
+    # Rapor toplayıcı (report-uri/report-to) henüz yok; ihlaller yalnız
+    # tarayıcı konsolunda görünür.
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; frame-src 'self' blob:; connect-src 'self'; upgrade-insecure-requests" always;
 
     # Cloudflare'den gelen gerçek IP'yi al
     set_real_ip_from 103.21.244.0/22;
@@ -44,9 +121,22 @@ server {
     set_real_ip_from 198.41.128.0/17;
     real_ip_header CF-Connecting-IP;
 
-    # Temel güvenlik başlıkları
-    add_header X-Frame-Options SAMEORIGIN always;
-    add_header X-Content-Type-Options nosniff always;
+    # ── Kimlik doğrulama uçları (rate limitli) ───────────────
+    # `^~` ile /api/ prefix'inden önce eşleşir. AuthController rotası:
+    # api/v1/auth → login, register, refresh, logout, google, google/callback,
+    # request-password-reset, reset-password, secure-account,
+    # force-change-password.
+    location ^~ /api/v1/auth/ {
+        limit_req zone=cargopilot_auth_test burst=20 nodelay;
+
+        proxy_pass         http://127.0.0.1:8081;
+        proxy_http_version 1.1;
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_buffering    off;
+    }
 
     # ── Backend API (/api/* → backend:8081) ─────────────────
     location /api/ {
@@ -56,7 +146,32 @@ server {
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto $scheme;
-        proxy_read_timeout 60s;
+
+        # proxy_read_timeout 60s → 180s.
+        # Ölçüm (2026-08-18): 500 kutuluk plan, WeightBalance kriteri
+        # Release'te ~18 sn, Debug'ta ~29 sn. Prod Release koşuyor.
+        # 180s seçildi çünkü:
+        #   - 500 kutuda 18 sn olan bir çözücünün kutu sayısı arttıkça
+        #     doğrusaldan hızlı büyümesi beklenir; ~2000 kutuda 90 sn'lik
+        #     kötü senaryo makul bir üst tahmin. 180s bunun 2 katı pay bırakır.
+        #   - Debug ölçümünün (29 sn) 6 katından fazla.
+        #   - Sınırsız değil: takılan bir backend isteği worker bağlantısını
+        #     süresiz tutmasın.
+        # UYARI: Cloudflare'in origin yanıt zaman aşımı (Free/Pro planlarda
+        # 100 sn) bu değerden küçük. 100 sn'yi aşan koşular nginx'e değil
+        # Cloudflare 524'e takılır; gerçek çözüm uzun optimizasyonu
+        # asenkron (job + polling) hâle getirmektir.
+        proxy_connect_timeout 10s;
+        proxy_send_timeout    180s;
+        proxy_read_timeout    180s;
+
+        # Excel/ERP içe aktarma bugün 413 alıyor: import satırları istemcide
+        # (SheetJS) ayrıştırılıp toplu JSON olarak POST ediliyor.
+        # 25m seçildi — Kestrel'in 30 MB varsayılan gövde sınırının altında
+        # kalıyor, böylece sınırı nginx uyguluyor ve backend'in kendi limiti
+        # sürpriz bir ikinci duvar olmuyor.
+        client_max_body_size 25m;
+
         proxy_buffering    off;
     }
 
@@ -71,6 +186,9 @@ server {
     }
 
     # ── MinIO Media (/media/* → minio:9002/cargo-pilot-test/) ──
+    # Bu yol MINIO_PUBLIC_ENDPOINT ile BİREBİR aynı olmak zorunda:
+    # MinioStorageService dosya URL'ini `{PublicEndpoint}/{objectKey}` olarak
+    # kuruyor ve bucket adını eklemiyor — bucket'ı nginx route ediyor.
     location /media/ {
         proxy_pass         http://127.0.0.1:9002/cargo-pilot-test/;
         proxy_http_version 1.1;
@@ -82,7 +200,15 @@ server {
 
         # Resim/dosya cache — tarayıcıda 7 gün tut
         add_header Cache-Control "public, max-age=604800, immutable";
+
+        # add_header mirası kırıldığı için server seviyesindeki güvenlik
+        # başlıkları burada tekrar ediliyor (yukarıdaki DİKKAT notu).
+        add_header X-Frame-Options SAMEORIGIN always;
         add_header X-Content-Type-Options nosniff always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; form-action 'self'; script-src 'self' 'wasm-unsafe-eval'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; frame-src 'self' blob:; connect-src 'self'; upgrade-insecure-requests" always;
 
         # Büyük dosyalar için timeout artır
         proxy_read_timeout 120s;


### PR DESCRIPTION
## Özet

Üç bulgu tek PR'da ve **bağlayıcı sırayla**: D-46 (sertleştirme) → D-47 (prod conf) → D-50 (env hizalama). Sıra kritik — önce sertleştirme yapılmasa D-47 eksik conf'u ikinci bir dosyaya kopyalar ve dokuz eksiği iki yerde düzeltmek gerekirdi.

Bugüne kadar `infra/nginx/` içinde tek dosya vardı (`cargopilot-test.conf`). Prod sunucusu kurulsa `setup-nginx.sh` bu test conf'unu kopyalayacak ve **prod domain'ini test container'larına proxy edecekti.**

### D-46 — `cargopilot-test.conf` sertleştirme

| Direktif | Değer | Dayanak |
|---|---|---|
| `client_max_body_size` (`/api/`) | `25m` | Kestrel'in 30 MB varsayılan gövde sınırının altında (`RequestSizeLimit`/`MaxRequestBodySize` override'ı yok) — limiti nginx uygular, backend sürpriz ikinci duvar olmaz. Bugün Excel/ERP import 413 alıyordu (nginx default 1 MB) |
| `proxy_read_timeout` | `60s` → `180s` | Ölçüm: 500 kutu / WeightBalance, Release ~18 sn, Debug ~29 sn (2026-08-18). ~2000 kutuda ~90 sn kötü senaryo varsayımı × 2 pay. Sınırsız değil — takılan istek worker bağlantısını süresiz tutmasın |
| `limit_req` | `60r/m`, `burst=20 nodelay`, `limit_req_status 429` | `Jwt:AccessTokenExpiryMinutes=60` → `/auth/refresh` kullanıcı başına saatte ~1. Cloudflare `CF-Connecting-IP` ile gerçek IP alındığı için NAT arkası ofis tek IP'den gelir; 60r/m + 20 burst vardiya başında eşzamanlı giren ~20 kişiyi 429'a düşürmez, credential stuffing'i dakikada binlerden 60'a indirir |
| HSTS | `max-age=31536000; includeSubDomains` | `preload` **bilerek yok** — geri alınamaz ve alan adı hâlâ self-signed + Cloudflare Full (Strict değil) |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | — |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=(), usb=()` | — |
| `server_tokens` | `off` | — |
| `gzip` | `on`, yalnız metin tipleri | Görsel/font/zip listeye alınmadı |

### CSP kararı: **Report-Only** — gerekçesi doğrulanmış bir kırıcı bulgu

`Content-Security-Policy-Report-Only` olarak konuldu, enforce edilmedi. Sebep:

- **Doğrulandı:** `apps/frontend/src/index.css:1` harici bir `@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans...')` içeriyor. `default-src 'self'` enforce edilse **tüm tipografi anında düşerdi.** Politikaya `style-src ... https://fonts.googleapis.com` ve `font-src ... https://fonts.gstatic.com` eklendi.
- **Doğrulandı:** `blob:` kullanımı (`exportPlanToPdf.ts`, `useReports.ts`, `export-utils.ts` → `URL.createObjectURL`) → `worker-src`/`media-src`/`frame-src`/`img-src`'a eklendi. Vite `assetsInlineLimit` küçük varlıkları data: URI yaptığı için `img-src data:` de var.
- **Doğrulandı:** Radix/shadcn inline `style` attribute yazıyor → `style-src 'unsafe-inline'` zorunlu.
- **Doğrulanamadı:** `@react-pdf/renderer` v4'ün yoga layout motorunun WASM için `'wasm-unsafe-eval'` gerektirip gerektirmediği (`node_modules` kurulu değil). İhtiyaten eklendi — **bu bir varsayım, ölçüm değil.**
- Google OAuth kontrol edildi: `handleOAuth(OAUTH_GOOGLE_URL)` üst düzey navigasyon, CSP fetch direktiflerine tabi değil.

Yazılan politika **hedeflenen enforce politikasıdır**; Report-Only olarak yayına alınıp ihlaller toplandıktan sonra sonek kaldırılarak enforce'a çevrilmelidir. Bu adım conf yorumunda yazılı.

### Yakalanan iki sessiz tuzak

1. **`add_header` mirası:** nginx'te bir `location` kendi `add_header`'ını tanımlarsa server seviyesindeki **tüm** başlıklar o location için düşer. `/media/` bloğu `Cache-Control` için `add_header` kullanıyor → HSTS/CSP/Referrer-Policy/Permissions-Policy medya yanıtlarında **sessizce kaybolacaktı.** Liste `/media/` içinde tekrarlandı ve nedeni yorumla işaretlendi.
2. **`limit_req_zone` adı:** test ve prod aynı zone adını taşısa, ikisi aynı `conf.d` dizininde yüklendiğinde nginx duplicate zone hatası verir. `cargopilot_auth_test` / `cargopilot_auth_prod` diye ayrıldı; iki conf birlikte mount edilerek `nginx -t` ile doğrulandı.

### D-47 — prod conf

`infra/nginx/cargopilot-prod.conf` sertleştirilmiş test conf'undan **`sed` ile türetildi** (elle yazılmadı) — sertleştirme bloğu byte düzeyinde aynı kalsın diye. Farklar dosyanın başında numaralı listede:

| # | Test | Prod |
|---|---|---|
| 1 | `cargopilot.divizyon.org` | `<YOUR_DOMAIN>` |
| 2 | backend `127.0.0.1:8081` | `127.0.0.1:8080` |
| 3 | frontend `127.0.0.1:3001` | `127.0.0.1:3003` |
| 4 | minio `127.0.0.1:9002` | `127.0.0.1:9000` |
| 5 | bucket `cargo-pilot-test` | `cargo-pilot` |
| 6 | `cargopilot.{crt,key}` self-signed | `cargopilot-prod.{crt,key}` (Let's Encrypt yolu yorumda; sertifika değişimi kapsam dışı) |
| 7 | zone `cargopilot_auth_test` | `cargopilot_auth_prod` |

`setup-nginx.sh`'ye **dokunulmadı** — F1-03'ün işi.

### D-50 — `/media` seçildi, `FRONTEND_PORT` 3003

- **Path:** `/media/` seçildi, `/files` değil. `/media/` test ortamında **fiilen kullanılan** yol; kalıcı medya URL'lerinde geçiyor ve cache-header bloğu ona bağlı. `/files` env dosyasındaki, hiçbir conf'ta karşılığı olmayan bir placeholder'dı — conf'u ona çevirmek kayıtlı URL'leri geçersiz kılardı.
- Trailing slash bilinçli: `MinioStorageService.UploadAsync` URL'i `{PublicEndpoint}/{objectKey}` olarak kuruyor ve `_hasCustomPublicEndpoint` true iken bucket adını eklemiyor (bucket'ı nginx route ediyor) → env'de `/media`, conf'ta `location /media/`.
- **`FRONTEND_PORT=80` → `3003`.** İlk 3000 seçildi, sonra tüm compose host port binding'leri tarandı ve çakışma bulundu: `docker-compose.monitoring.prod.yml` Grafana'yı `127.0.0.1:3000:3000`'e bağlıyor. 3002 Grafana test, 3001 test frontend. 3003 hiçbir yerde kullanılmıyor. Prod host'ta dolu portlar: 80/443, 1433, 3000, 8080, 9000, 9001, 9090.

## İlgili User Story / Issue

Faz 1 · F1-01 · **D-46 → D-47 → D-50** · madde 2.1 Production Stack Deploy'un ön koşulu

## Değişiklik Tipi

- [x] 🔧 Altyapı (infra)

## Test Edildi mi?

- [x] `nginx -t` her iki conf **tek tek ve birlikte** başarılı (`nginx:1.31-alpine`, gerçek sertifika dosyaları mount edilerek)
- [x] Sertleştirme diff'i **boş** — iki conf birebir aynı sertleştirmeyi taşıyor:

```
diff <(grep -oE '^\s*(limit_req|add_header|gzip|server_tokens)' cargopilot-test.conf | sort) \
     <(grep -oE '^\s*(limit_req|add_header|gzip|server_tokens)' cargopilot-prod.conf | sort)
→ BOŞ (23/23 satır)
```
- [x] `infra/compose/*.yml` ve `infra/scripts/setup-nginx.sh` **değişmedi** — diff tam olarak 3 dosya

Kalan uyarı: `listen ... http2` deprecation uyarısı **mevcut satırdan** geliyor, bu PR'ın eklediği bir şey değil. `http2 on;` sözdizimi nginx ≥1.25.1 gerektiriyor ve sunucudaki nginx sürümü bilinmediği için bilinçli olarak dokunulmadı.

## Ekran Görüntüleri

UI değişikliği yok. CSP Report-Only olduğu için frontend davranışı değişmiyor.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok (`nginx -t`)
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekçeler conf yorumlarında)

## Ek Notlar — merge öncesi bilinmesi gerekenler

1. **Cloudflare 524, `proxy_read_timeout 180s`'i etkisiz kılıyor.** Cloudflare'in origin yanıt zaman aşımı Free/Pro planlarda 100 sn. 100 sn'yi aşan optimizasyon koşuları artık nginx 504 yerine **Cloudflare 524** alacak. nginx tarafı darboğazdan çıktı ama gerçek çözüm uzun optimizasyonu asenkron (job + polling) hâle getirmek — ayrı iş, backlog'a girmeli.
2. **`<YOUR_DOMAIN>` prod conf'ta canlı bir placeholder.** `nginx -t` bunu kabul ediyor (sözdizimsel olarak geçerli `server_name`), yani yerine gerçek domain yazılmazsa **hata vermez** — 443'teki tek server bloğu olduğu için trafiği yine karşılar. Sessiz yanlış yapılandırma ihtimali: **F1-03 substitution'ı eklemeden prod'a alınmamalı.**
3. **`limit_req` NAT riski.** 60r/m tahmini access token ömrüne dayanıyor. Prod'a çıkınca `limit_req` 429 loglarını izlemek gerekir.
4. **CSP enforce'a çevrilirken** 3D sahne + PDF export + Excel export akışları tarayıcıda elle gezilmeli. **Rapor toplayıcı (`report-uri`/`report-to`) yok** — ihlaller yalnız tarayıcı konsolunda görünür; bu bilinen bir eksik.
5. **`gzip` + HTTPS = teorik BREACH.** API CSRF token'ı gövdede döndürmüyor (refresh token httpOnly cookie'de), bu yüzden `application/json` sıkıştırması kabul edilebilir risk sayıldı ve conf'a not düşüldü.
