### PR TITLE
Servislere bellek tavanı ve MSSQL bellek limiti (D-38, D-39)

### DIFF
--- a/docs/devops/server-requirements.md
+++ b/docs/devops/server-requirements.md
@@ -1,6 +1,6 @@
 # Sunucu Gereksinimleri
 
-**Son güncelleme:** 2026-04-23 · **Durum:** Aktif · **Görev:** US-D01-I
+**Son güncelleme:** 2026-08-18 · **Durum:** Aktif · **Görev:** US-D01-I, F1-02
 
 Bu doküman mevcut sunucunun kapasitesini, bileşen bazlı kaynak gereksinimlerini ve prod + test ortamlarının birlikte çalışabilirliğini özetler.
 
@@ -35,29 +35,51 @@ Bu doküman mevcut sunucunun kapasitesini, bileşen bazlı kaynak gereksinimleri
 | **Minimum (tek ortam)** | **2.5 vCPU** | **3.5 GB** | **80 GB** | |
 | **Önerilen (prod + test)** | **4+ vCPU** | **8+ GB** | **150+ GB** | |
 
-### Tahmini Kaynak Kullanımı (Prod + Test)
+### Kaynak Kullanımı (Prod + Test) — F1-02 ile güncellendi
+
+> **Düzeltme (F1-02 / D-39):** Aşağıdaki "MSSQL × 2 ≈ 4 GB" tahmini **geçersizdi** — bir
+> MSSQL instance'ının kendisi zaten 2–4 GB istiyor (yukarıdaki bileşen tablosu), iki
+> instance için toplamı 4 GB'a sabitlemek bir hesap hatasıydı. Ayrıca hiçbir serviste
+> `mem_limit` tanımlı olmadığından (D-38) SQL Server varsayılan olarak **host RAM'inin
+> %80'ini** hedefliyordu — "4 GB" sadece bir varsayımdı, hiçbir yerde uygulanmıyordu.
+>
+> `infra/compose/*.yml` içine artık her serviste `mem_limit` var (bkz. commit
+> `infra/kaynak-limitleri`); aşağıdaki tablo artık **tahmin değil, compose
+> dosyalarında tanımlı, uygulanan tavan** değerleridir.
 
 ```
-RAM:
-  ├── OS + Docker daemon              ~512 MB
-  ├── Frontend × 2 (prod+test)        ~128 MB
-  ├── Backend × 2                     ~512 MB
-  ├── MSSQL × 2                       ~4 GB
-  ├── MinIO × 2                       ~256 MB
-  └── Monitoring stack                ~1.5 GB
-  ─────────────────────────────────────────────
-  Toplam tahmini     ≈ 6.9 GB / 16 GB  (%43)
+RAM (mem_limit ile sınırlanmış — infra/compose/*.yml, F1-02):
+  ├── Frontend × 2 (prod+test)        512 MB   (256 MB × 2)
+  ├── Backend × 2                     1024 MB  (512 MB × 2)
+  ├── MSSQL × 2 (mem_limit)           6144 MB  (3072 MB × 2)
+  │     └─ MSSQL_MEMORY_LIMIT_MB      2048 MB/instance (SQL Server "max server
+  │                                   memory" hedefi; mem_limit'in altında)
+  ├── MinIO × 2                       1024 MB  (512 MB × 2)
+  └── Monitoring stack × 2 (prod+test) 3456 MB (loki 512 + promtail 128 +
+                                       node-exporter 64 + cadvisor 256 +
+                                       prometheus 512 + grafana 256 = 1728 × 2)
+  ─────────────────────────────────────────────────────────────
+  Yapılandırılmış tavan toplamı   ≈ 12.16 GB / 16 GB  (%74)
+  Kalan pay (OS + Docker daemon + burst) ≈ 4.1 GB / 16 GB  (%26)
+
+  Not: `erp-mssql` / `erp-mssql-init` (docker-compose.test.yml, `--profile e2e`)
+  bu bütçeye dahil değildir — yalnızca GitHub Actions runner'ında (CI) kalkar,
+  bu sunucuda hiç çalışmaz.
 
 Disk:
   ├── OS + Docker images              ~23 GB
   ├── MSSQL data                      ~1–5 GB
   └── MinIO data                      ~1–10 GB
   ─────────────────────────────────────────────
-  Toplam tahmini     < 40 GB / 147 GB  (%16)
+  Toplam tahmini     < 40 GB / 147 GB  (%16)  — VARSAYIM, ölçülmedi
 ```
 
 {% hint style="success" %}
-**Sonuç: Yeterli.** Mevcut sunucu kapasitesi prod + test + monitoring stack'i aynı anda çalıştırmaya yeterlidir. Image build CI'da GHCR'a push edildiğinden sunucuda OOM riski yoktur.
+**Sonuç: Yeterli.** Yapılandırılmış bellek tavanlarının toplamı (≈12.16 GB) 16 GB
+sunucu kapasitesinin altında kalıyor ve OS + Docker daemon için ≈4.1 GB (%26) pay
+bırakıyor. `mem_limit` değerleri ölçülmüş gerçek kullanım değil, D-38/D-39 kapsamında
+konulmuş muhafazakâr tavanlardır (bkz. F1-02); ilk prod yükünden sonra gerçek kullanımla
+karşılaştırılıp gerekirse ayarlanmalıdır.
 {% endhint %}
 
 ---

--- a/infra/compose/docker-compose.monitoring.prod.yml
+++ b/infra/compose/docker-compose.monitoring.prod.yml
@@ -4,6 +4,7 @@ services:
   loki:
     image: grafana/loki:2.9.4
     container_name: cargo-pilot-loki-prod
+    mem_limit: 512m
     command: -config.file=/etc/loki/config.yml
     volumes:
       - ../docker/loki/loki-config.yml:/etc/loki/config.yml:ro
@@ -15,6 +16,7 @@ services:
   promtail:
     image: grafana/promtail:2.9.4
     container_name: cargo-pilot-promtail-prod
+    mem_limit: 128m
     command: -config.file=/etc/promtail/config.yml
     volumes:
       - ../docker/promtail/promtail.prod.yml:/etc/promtail/config.yml:ro
@@ -27,6 +29,7 @@ services:
   node-exporter:
     image: prom/node-exporter:v1.7.0
     container_name: cargo-pilot-node-exporter-prod
+    mem_limit: 64m
     command:
       - '--path.rootfs=/host'
     volumes:
@@ -39,6 +42,7 @@ services:
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.49.1
     container_name: cargo-pilot-cadvisor-prod
+    mem_limit: 256m
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro
@@ -55,6 +59,7 @@ services:
   prometheus:
     image: prom/prometheus:v2.50.1
     container_name: cargo-pilot-prometheus-prod
+    mem_limit: 512m
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -71,6 +76,7 @@ services:
   grafana:
     image: grafana/grafana:10.3.3
     container_name: cargo-pilot-grafana-prod
+    mem_limit: 256m
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}

--- a/infra/compose/docker-compose.monitoring.test.yml
+++ b/infra/compose/docker-compose.monitoring.test.yml
@@ -4,6 +4,7 @@ services:
   loki:
     image: grafana/loki:2.9.4
     container_name: cargo-pilot-loki-test
+    mem_limit: 512m
     command: -config.file=/etc/loki/config.yml
     volumes:
       - ../docker/loki/loki-config.yml:/etc/loki/config.yml:ro
@@ -15,6 +16,7 @@ services:
   promtail:
     image: grafana/promtail:2.9.4
     container_name: cargo-pilot-promtail-test
+    mem_limit: 128m
     command: -config.file=/etc/promtail/config.yml
     volumes:
       - ../docker/promtail/promtail.test.yml:/etc/promtail/config.yml:ro
@@ -27,6 +29,7 @@ services:
   node-exporter:
     image: prom/node-exporter:v1.7.0
     container_name: cargo-pilot-node-exporter-test
+    mem_limit: 64m
     command:
       - '--path.rootfs=/host'
     volumes:
@@ -39,6 +42,7 @@ services:
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.49.1
     container_name: cargo-pilot-cadvisor-test
+    mem_limit: 256m
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro
@@ -55,6 +59,7 @@ services:
   prometheus:
     image: prom/prometheus:v2.50.1
     container_name: cargo-pilot-prometheus-test
+    mem_limit: 512m
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -71,6 +76,7 @@ services:
   grafana:
     image: grafana/grafana:10.3.3
     container_name: cargo-pilot-grafana-test
+    mem_limit: 256m
     environment:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}

--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -9,6 +9,9 @@ services:
       context: ../../apps/backend
       dockerfile: Dockerfile
     container_name: cargo-pilot-backend-prod
+    # F1-02: standalone `docker compose up` ile calisiyoruz (Swarm degil), bu yuzden
+    # deploy.resources.limits yok sayilir; mem_limit standalone'da bagliyicidir.
+    mem_limit: 512m
     environment:
       ASPNETCORE_ENVIRONMENT: Production
       ASPNETCORE_URLS: http://+:8080
@@ -74,6 +77,7 @@ services:
         VITE_OAUTH_GOOGLE_URL: ${VITE_OAUTH_GOOGLE_URL:-}
         VITE_OAUTH_MICROSOFT_URL: ${VITE_OAUTH_MICROSOFT_URL:-}
     container_name: cargo-pilot-frontend-prod
+    mem_limit: 256m
     environment:
       NODE_ENV: production
     ports:
@@ -90,12 +94,19 @@ services:
     platform: linux/amd64
     container_name: cargo-pilot-mssql-prod
     user: root
+    # F1-02 / D-39: mem_limit container tavanı; MSSQL_MEMORY_LIMIT_MB bunun altında
+    # tutulan SQL Server "max server memory" hedefidir (SQL Server olmayan container/
+    # işletim sistemi payı için mem_limit ile aradaki fark bilerek boş bırakılır).
+    mem_limit: 3072m
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_PID: Standard
       # MSSQL_SA_PASSWORD 2022 image'ının beklediği ad; SA_PASSWORD geriye dönük uyumluluk için.
       MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
       SA_PASSWORD: ${MSSQL_SA_PASSWORD}
+      # D-39: tanımsızsa SQL Server host RAM'inin ~%80'ini hedefler; mem_limit'in
+      # (3072m) altında sabit bir tavan veriyoruz.
+      MSSQL_MEMORY_LIMIT_MB: ${MSSQL_MEMORY_LIMIT_MB:-2048}
     ports:
       - "127.0.0.1:${MSSQL_PORT}:1433"
     volumes:
@@ -114,6 +125,7 @@ services:
     image: quay.io/minio/minio:RELEASE.2022-01-08T03-11-54Z
     platform: linux/amd64
     container_name: cargo-pilot-minio-prod
+    mem_limit: 512m
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}

--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -9,6 +9,9 @@ services:
       context: ../../apps/backend
       dockerfile: Dockerfile
     container_name: cargo-pilot-backend-test
+    # F1-02: standalone `docker compose up` ile calisiyoruz (Swarm degil), bu yuzden
+    # deploy.resources.limits yok sayilir; mem_limit standalone'da bagliyicidir.
+    mem_limit: 512m
     environment:
       ASPNETCORE_ENVIRONMENT: Test
       ASPNETCORE_URLS: http://+:8080
@@ -73,6 +76,7 @@ services:
         VITE_OAUTH_GOOGLE_URL: ${VITE_OAUTH_GOOGLE_URL:-}
         VITE_OAUTH_MICROSOFT_URL: ${VITE_OAUTH_MICROSOFT_URL:-}
     container_name: cargo-pilot-frontend-test
+    mem_limit: 256m
     environment:
       NODE_ENV: production
     ports:
@@ -88,11 +92,17 @@ services:
     platform: linux/amd64
     container_name: cargo-pilot-mssql-test
     user: root
+    # F1-02 / D-39: mem_limit container tavanı; MSSQL_MEMORY_LIMIT_MB bunun altında
+    # tutulan SQL Server "max server memory" hedefidir.
+    mem_limit: 3072m
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_PID: Developer
       MSSQL_SA_PASSWORD: ${MSSQL_SA_PASSWORD}
       SA_PASSWORD: ${MSSQL_SA_PASSWORD}
+      # D-39: tanımsızsa SQL Server host RAM'inin ~%80'ini hedefler; mem_limit'in
+      # (3072m) altında sabit bir tavan veriyoruz.
+      MSSQL_MEMORY_LIMIT_MB: ${MSSQL_MEMORY_LIMIT_MB:-2048}
     ports:
       - "127.0.0.1:${MSSQL_PORT}:1433"
     volumes:
@@ -116,6 +126,9 @@ services:
     platform: linux/amd64
     container_name: cargo-pilot-erp-mssql-test
     user: root
+    # F1-02: bu servis yalnizca CI (GitHub Actions runner) uzerinde --profile e2e ile
+    # kalkar, prod sunucusunun 16 GB butcesine girmez; yine de tavan konuluyor.
+    mem_limit: 1536m
     environment:
       ACCEPT_EULA: "Y"
       MSSQL_PID: Developer
@@ -145,6 +158,7 @@ services:
     platform: linux/amd64
     container_name: cargo-pilot-erp-mssql-init-test
     user: root
+    mem_limit: 256m
     environment:
       ERP_MSSQL_SA_PASSWORD: ${ERP_MSSQL_SA_PASSWORD:-ErpFake_Pass123!}
     depends_on:
@@ -167,6 +181,7 @@ services:
     image: quay.io/minio/minio:RELEASE.2022-01-08T03-11-54Z
     platform: linux/amd64
     container_name: cargo-pilot-minio-test
+    mem_limit: 512m
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}

--- a/infra/env/.env.prod.example
+++ b/infra/env/.env.prod.example
@@ -27,6 +27,9 @@ FRONTEND_PORT=80
 MSSQL_PORT=1433
 MSSQL_DATABASE=CargoPilot
 MSSQL_SA_PASSWORD=<GENERATE_STRONG_PASSWORD_MIN_16_CHARS>
+# F1-02 / D-39: SQL Server "max server memory" hedefi (MB). Container mem_limit'i
+# (docker-compose.prod.yml'de 3072m) her zaman bu değerin üstünde olmalıdır.
+MSSQL_MEMORY_LIMIT_MB=2048
 
 # NOT: Bağlantı dizesi artık compose içinde yukarıdaki değerlerden kuruluyor.
 # Parolayı ikinci bir yere yazmanız gerekmez. Harici/managed bir veritabanı

--- a/infra/env/.env.test.example
+++ b/infra/env/.env.test.example
@@ -37,6 +37,9 @@ VITE_API_BASE_URL=
 MSSQL_PORT=1434
 MSSQL_DATABASE=CargoPilotTest
 MSSQL_SA_PASSWORD=<CHANGE_ME_TEST_PASSWORD>
+# F1-02 / D-39: SQL Server "max server memory" hedefi (MB). Container mem_limit'i
+# (docker-compose.test.yml'de 3072m) her zaman bu değerin üstünde olmalıdır.
+MSSQL_MEMORY_LIMIT_MB=2048
 
 # ─── Sahte ERP MSSQL (yalnızca e2e) ───────────
 # docker-compose.test.yml'deki `erp-mssql` servisi; `--profile e2e` ile ayağa kalkar.


### PR DESCRIPTION
## Özet

İki **kritik** bulgu (D-38, D-39) ve ikisi de `madde 2.1 Production Stack Deploy`'u bloke ediyordu.

Dört compose dosyası, 557 satır ve **tek bir kaynak limiti yoktu** — tek kaçak servis 16 GB'lık sunucuyu götürürdü. Ayrıca SQL Server varsayılan olarak host RAM'inin ~%80'ini hedefler; ana MSSQL servislerinde bellek tavanı tanımlı değildi (yalnız ERP servisinde vardı).

### Bellek bütçesi — aritmetik

Prod ve test **aynı host'ta** (8 vCPU / 16 GB / 147 GB SSD, Ubuntu 24.04).

| Servis | `mem_limit` | Adet | Toplam |
|---|---|---|---|
| backend | 512 MB | ×2 (prod+test) | 1.024 MB |
| frontend | 256 MB | ×2 | 512 MB |
| mssql (ana) | 3.072 MB | ×2 | 6.144 MB |
| minio | 512 MB | ×2 | 1.024 MB |
| loki | 512 MB | ×2 (monitoring) | 1.024 MB |
| prometheus | 512 MB | ×2 | 1.024 MB |
| grafana | 256 MB | ×2 | 512 MB |
| cadvisor | 256 MB | ×2 | 512 MB |
| promtail | 128 MB | ×2 | 256 MB |
| node-exporter | 64 MB | ×2 | 128 MB |
| **Yapılandırılmış toplam tavan** | | | **12.160 MB ≈ 11,9 GB** |
| OS + Docker daemon + burst payı | | | **4.224 MB ≈ 4,1 GB (%26)** |
| **Sunucu RAM'i** | | | **16.384 MB** |

Dosya bazında alt toplamlar: `prod.yml` 4.352 · `test.yml` (e2e hariç) 4.352 · `monitoring.prod.yml` 1.728 · `monitoring.test.yml` 1.728.

### MSSQL: iki katmanlı tavan

- Container `mem_limit`: **3.072 MB** — kernel cgroup tavanı, aşılırsa container OOM-kill olur.
- `MSSQL_MEMORY_LIMIT_MB`: **2.048 MB** (`${MSSQL_MEMORY_LIMIT_MB:-2048}`) — SQL Server'ın kendi "max server memory" hedefi.

Arada **1 GB pay bilerek var:** `max server memory` yalnız buffer pool'u sınırlar; thread stack'leri, bağlantı overhead'i, backup/restore tamponları o hesaba **girmez**. Pay bırakılmazsa engine kendi hedefine ulaşmadan container cgroup tavanına çarpıp OOM-kill olur — tam olarak kaçınmak istediğimiz senaryo.

### `mem_limit` mi `deploy.resources.limits` mi

**`mem_limit` seçildi.** Dört dosyada da `version:` yok (Compose Specification formatı, top-level `name:`) ve stack `docker compose -f ... up -d` ile **standalone** çalışıyor — `docker stack deploy` yok, Swarm yok. `deploy.resources.limits` yalnız Swarm modunda bağlayıcıdır; standalone `docker compose up`'ta parse edilir ama **enforce edilmez**. `mem_limit` standalone'da doğrudan cgroup limiti olarak uygulanır.

## Brief'te düzeltilen üç şey

1. **"16 servis" iddiası tutmuyor.** `docker compose config --services` ile ölçüldü: `prod.yml` 4 · `test.yml` 4 (+2 `--profile e2e`) · `monitoring.prod.yml` 6 · `monitoring.test.yml` 6. Sunucuda prod deploy edildiğinde aynı anda çalışacak gerçek toplam **20**, e2e dahil tüm YAML blokları **22**. "16" rakamı `docs/archive/devops-iyilestirme-analizi-2026-08.md`'den geliyor ve `erp-mssql`/`erp-mssql-init`'in #938 ile eklenmesinden önceki bir sayım. **Hepsine limit uygulandı, dışarıda bırakılan servis yok.**
2. **Satır numaraları kaymış:** ana `mssql` gerçekte `test.yml:86` / `prod.yml:88` (brief 90/92 diyor). İçerik iddiası doğru.
3. `erp-mssql` (1.536 MB) ve `erp-mssql-init` (256 MB) bütçeye dahil **değil** — `.github/workflows/test-deploy.yml` okunarak doğrulandı: bu servisler yalnız GitHub Actions `ubuntu-latest` runner'ında kalkıyor, sunucuda çalışmıyor. Limitleri yine de tanımlandı.

## İlgili User Story / Issue

Faz 1 · F1-02 · **D-38, D-39** (ikisi de 🔴 Kritik) · Kategori 6.8 · madde 2.1'in ön koşulu

## Değişiklik Tipi

- [x] 🔧 Altyapı (infra)

## Test Edildi mi?

- [x] `docker compose config` **dört dosyada da geçerli** (RC=0; yalnız beklenen "değişken tanımsız" uyarıları)
- [x] `.env.*.example` ile interpolasyon doğrulandı: mssql `mem_limit` → `3221225472` (3072m), `MSSQL_MEMORY_LIMIT_MB` → `2048`
- [x] Toplam tavan bağımsız olarak yeniden toplandı: 12.160 MB
- [x] `infra/nginx/*` ve `infra/scripts/*` **değişmedi**; `.env.prod.example`'da `FRONTEND_PORT`/`MINIO_PUBLIC_ENDPOINT` satırlarına dokunulmadı (paralel giden #1043'ün alanı — test-merge temiz)

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi — `docs/devops/server-requirements.md`

`server-requirements.md` düzeltmesi: satır 43'teki "MSSQL × 2 ≈ 4 GB" geçersiz varsayımı kaldırıldı; "Tahmini Kaynak Kullanımı" bloğu artık ölçülmemiş tahmin değil, compose'daki gerçek `mem_limit` değerlerine dayanan servis-servis tablo.

## Ek Notlar — merge öncesi bilinmesi gerekenler

1. **Bütün sayılar VARSAYIM.** Sunucuya SSH erişimi yok; kapasite `docs/devops/server-requirements.md` + `docs/context/project-snapshot.md`'ye dayanıyor ve hiçbir gerçek kullanım telemetrisi yok. `mem_limit` değerleri muhafazakâr tavanlar. **İlk prod yükünde gözden geçirilmeli.**
   - ÖLÇÜM olanlar: servis sayıları ve adları, dört dosyanın `docker compose config` geçerliliği, interpolasyon değerleri, `erp-mssql`'in CI runner'ında çalıştığı.
2. **`--profile e2e` sunucuda verilirse bütçe daralıyor:** +1.792 MB → 13.952 MB, OS+Docker'a yalnız 2,4 GB kalır. Bugün bu profil sunucuda kalkmıyor, ama koruma bir varsayım — **D-02 (F5-01)** tam olarak bu profilin ERP portunu dışarı açabildiğini söylüyor. İki iş birlikte düşünülmeli.
3. **D-38 bu PR ile TAM kapanmıyor.** Bulgu metni `mem_limit` **+ `cpus` + `pids_limit`** yokluğundan bahsediyor; bu PR yalnız **belleği** kapatıyor. CPU/pids için ölçüm yok ve kapsam bilinçli olarak genişletilmedi. **Backlog'da D-38 "kapandı" diye işaretlenmemeli** — "bellek kapandı, CPU/pids açık" olarak kaydedilmeli.
4. **Risk simetrik:** limit çok düşükse servis OOM-kill olur ve bugünkü limitsiz durumdan **daha görünür** bir kesinti üretir; MSSQL'e dar tavan sorgu performansını çökertir. Bu yüzden değerler muhafazakâr tutuldu.
