### PR TITLE
Nginx kurulum scripti doğrulamayı öne aldı, monitoring healthcheck'leri eklendi (D-48, D-49)

### DIFF
--- a/infra/compose/docker-compose.monitoring.prod.yml
+++ b/infra/compose/docker-compose.monitoring.prod.yml
@@ -9,6 +9,14 @@ services:
     volumes:
       - ../docker/loki/loki-config.yml:/etc/loki/config.yml:ro
       - loki_data_prod:/loki
+    # D-49: imajda curl yok, busybox wget var (/usr/bin/wget).
+    # /ready ingester hazir olana kadar 503 döner (ölçümde ~25-30 sn) → start_period 60s.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3100/ready"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
     restart: unless-stopped
     networks:
       - cargo-pilot-prod
@@ -22,6 +30,14 @@ services:
       - ../docker/promtail/promtail.prod.yml:/etc/promtail/config.yml:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    # D-49: promtail imajinda wget/curl/nc yok (debian-slim, minimal). Mevcut olan
+    # bash ile /ready ucuna TCP+HTTP isteği atiliyor.
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/9080 && printf 'GET /ready HTTP/1.0\\r\\n\\r\\n' >&3 && head -n1 <&3 | grep -q '200 OK'"]
+      interval: 20s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
     networks:
       - cargo-pilot-prod
@@ -35,6 +51,15 @@ services:
     volumes:
       - /:/host:ro,rslave
     pid: host
+    # D-49: node-exporter'da ayri bir health ucu yok — /-/healthy dahil TÜM yollar
+    # 200 + landing page donduruyor (olculdu), yani anlamsiz. Gercek isleyisi
+    # dogrulayan tek uc /metrics.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:9100/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 15s
     restart: unless-stopped
     networks:
       - cargo-pilot-prod
@@ -52,6 +77,13 @@ services:
     privileged: true
     devices:
       - /dev/kmsg
+    # D-49: cadvisor'in kendi /healthz ucu var (imajda busybox wget mevcut).
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8080/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
     networks:
       - cargo-pilot-prod
@@ -69,6 +101,13 @@ services:
       - prometheus_data_prod:/prometheus
     ports:
       - "127.0.0.1:9090:9090"
+    # D-49: imajda curl yok, busybox wget var (/bin/wget).
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:9090/-/healthy"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
     restart: unless-stopped
     networks:
       - cargo-pilot-prod
@@ -91,9 +130,18 @@ services:
       - grafana_data_prod:/var/lib/grafana
     ports:
       - "127.0.0.1:3000:3000"
+    # D-49: grafana imajinda hem wget hem curl var; dosya genelinde wget kullaniliyor.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3000/api/health"]
+      interval: 20s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
     depends_on:
-      - prometheus
-      - loki
+      prometheus:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - cargo-pilot-prod

--- a/infra/compose/docker-compose.monitoring.test.yml
+++ b/infra/compose/docker-compose.monitoring.test.yml
@@ -9,6 +9,14 @@ services:
     volumes:
       - ../docker/loki/loki-config.yml:/etc/loki/config.yml:ro
       - loki_data_test:/loki
+    # D-49: imajda curl yok, busybox wget var (/usr/bin/wget).
+    # /ready ingester hazir olana kadar 503 döner (ölçümde ~25-30 sn) → start_period 60s.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3100/ready"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
     restart: unless-stopped
     networks:
       - cargo-pilot-test
@@ -22,6 +30,14 @@ services:
       - ../docker/promtail/promtail.test.yml:/etc/promtail/config.yml:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+    # D-49: promtail imajinda wget/curl/nc yok (debian-slim, minimal). Mevcut olan
+    # bash ile /ready ucuna TCP+HTTP isteği atiliyor.
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/127.0.0.1/9080 && printf 'GET /ready HTTP/1.0\\r\\n\\r\\n' >&3 && head -n1 <&3 | grep -q '200 OK'"]
+      interval: 20s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
     networks:
       - cargo-pilot-test
@@ -35,6 +51,15 @@ services:
     volumes:
       - /:/host:ro,rslave
     pid: host
+    # D-49: node-exporter'da ayri bir health ucu yok — /-/healthy dahil TÜM yollar
+    # 200 + landing page donduruyor (olculdu), yani anlamsiz. Gercek isleyisi
+    # dogrulayan tek uc /metrics.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:9100/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 15s
     restart: unless-stopped
     networks:
       - cargo-pilot-test
@@ -52,6 +77,13 @@ services:
     privileged: true
     devices:
       - /dev/kmsg
+    # D-49: cadvisor'in kendi /healthz ucu var (imajda busybox wget mevcut).
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:8080/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
     networks:
       - cargo-pilot-test
@@ -69,6 +101,13 @@ services:
       - prometheus_data_test:/prometheus
     ports:
       - "127.0.0.1:9091:9090"
+    # D-49: imajda curl yok, busybox wget var (/bin/wget).
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:9090/-/healthy"]
+      interval: 15s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
     restart: unless-stopped
     networks:
       - cargo-pilot-test
@@ -93,9 +132,18 @@ services:
       - grafana_data_test:/var/lib/grafana
     ports:
       - "3002:3000"
+    # D-49: grafana imajinda hem wget hem curl var; dosya genelinde wget kullaniliyor.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3000/api/health"]
+      interval: 20s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
     depends_on:
-      - prometheus
-      - loki
+      prometheus:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - cargo-pilot-test

--- a/infra/compose/docker-compose.prod.yml
+++ b/infra/compose/docker-compose.prod.yml
@@ -82,6 +82,14 @@ services:
       NODE_ENV: production
     ports:
       - "127.0.0.1:${FRONTEND_PORT}:80"
+    # D-49: imaj nginx:1.31-alpine tabanli; busybox wget mevcut. Ayri bir /health
+    # ucu yok, kok yol index.html'i 200 ile donduruyor.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1/"]
+      interval: 20s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
     depends_on:
       backend:
         condition: service_healthy

--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -81,6 +81,14 @@ services:
       NODE_ENV: production
     ports:
       - "127.0.0.1:${FRONTEND_PORT}:80"
+    # D-49: imaj nginx:1.31-alpine tabanli; busybox wget mevcut. Ayri bir /health
+    # ucu yok, kok yol index.html'i 200 ile donduruyor.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1/"]
+      interval: 20s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
     depends_on:
       - backend
     restart: unless-stopped

--- a/infra/scripts/setup-nginx.sh
+++ b/infra/scripts/setup-nginx.sh
@@ -1,26 +1,126 @@
 #!/bin/bash
 # ============================================================
 # Cargo Pilot — Nginx Kurulum Scripti
-# Kullanım: sudo bash infra/scripts/setup-nginx.sh
-# Gereksinim: /opt/cargo-pilot klasöründe çalıştırılmalı
+#
+# Kullanım:
+#   sudo bash infra/scripts/setup-nginx.sh <test|prod> --domain <domain> [--dry-run]
+#
+# Örnek:
+#   sudo bash infra/scripts/setup-nginx.sh test --domain cargopilot.divizyon.org
+#   sudo bash infra/scripts/setup-nginx.sh prod --domain app.musteri.com
+#   sudo bash infra/scripts/setup-nginx.sh prod --domain app.musteri.com --dry-run
+#
+# Akış (D-48): config geçici bir dizine render edilir → izole bir nginx
+# instance'ı ile `nginx -t -c` doğrulanır → YALNIZCA geçerse canlı yola
+# kopyalanır → canlı ağaçta tekrar `nginx -t` → başarısızsa yedekten geri
+# alınır → ancak başarılıysa reload/restart edilir. Bozuk bir config asla
+# /etc/nginx altına yazılmaz.
+#
+# Ortam değişkeni ile geçersiz kılınabilir (varsayılanlar prod sunucu içindir;
+# sandbox/test için bu değişkenler geçici bir dizine yönlendirilebilir):
+#   REPO_DIR, SSL_DIR, NGINX_SITES_AVAILABLE, NGINX_SITES_ENABLED,
+#   NGINX_CONF_DEST, SERVICE_MANAGER, DOMAIN
 # ============================================================
-set -e
+set -euo pipefail
 
-DOMAIN="cargopilot.divizyon.org"
-REPO_DIR="/opt/cargo-pilot"
-SSL_DIR="/etc/nginx/ssl"
-NGINX_CONF_SRC="${REPO_DIR}/infra/nginx/cargopilot-test.conf"
-NGINX_CONF_DEST="/etc/nginx/sites-available/cargopilot"
+DOMAIN_PLACEHOLDER="<YOUR_DOMAIN>"
+SITE_NAME="cargopilot"
+
+REPO_DIR="${REPO_DIR:-/opt/cargo-pilot}"
+SSL_DIR="${SSL_DIR:-/etc/nginx/ssl}"
+NGINX_SITES_AVAILABLE="${NGINX_SITES_AVAILABLE:-/etc/nginx/sites-available}"
+NGINX_SITES_ENABLED="${NGINX_SITES_ENABLED:-/etc/nginx/sites-enabled}"
+NGINX_CONF_DEST="${NGINX_CONF_DEST:-${NGINX_SITES_AVAILABLE}/${SITE_NAME}}"
+SERVICE_MANAGER="${SERVICE_MANAGER:-systemctl}"
+
+DOMAIN="${DOMAIN:-}"
+ENVIRONMENT=""
+DRY_RUN=0
+WORK_DIR=""
+
+die() {
+    echo "HATA: $*" >&2
+    exit 1
+}
+
+usage() {
+    cat >&2 <<EOF
+Kullanım: sudo bash infra/scripts/setup-nginx.sh <test|prod> --domain <domain> [--dry-run]
+
+  <test|prod>        Kurulacak ortam. infra/nginx/${SITE_NAME}-<ortam>.conf kullanılır.
+  --domain <domain>  Sertifika CN'i ve conf içindeki ${DOMAIN_PLACEHOLDER} yerine yazılacak domain.
+                     DOMAIN ortam değişkeni ile de verilebilir.
+  --dry-run          Yalnızca render + doğrulama yapar; /etc/nginx altına dokunmaz.
+EOF
+    exit 2
+}
+
+cleanup() {
+    if [ -n "${WORK_DIR}" ] && [ -d "${WORK_DIR}" ]; then
+        rm -rf "${WORK_DIR}"
+    fi
+}
+trap cleanup EXIT
+
+# ── Argümanlar ────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+    case "$1" in
+        test|prod)
+            [ -n "${ENVIRONMENT}" ] && die "Ortam iki kez verildi: ${ENVIRONMENT} / $1"
+            ENVIRONMENT="$1"
+            shift
+            ;;
+        --domain)
+            [ $# -ge 2 ] || die "--domain bir değer bekliyor."
+            DOMAIN="$2"
+            shift 2
+            ;;
+        --domain=*)
+            DOMAIN="${1#--domain=}"
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Bilinmeyen argüman: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+[ -n "${ENVIRONMENT}" ] || { echo "Ortam belirtilmedi (test|prod)." >&2; usage; }
+[ -n "${DOMAIN}" ] || { echo "Domain belirtilmedi (--domain ya da DOMAIN)." >&2; usage; }
+
+case "${DOMAIN}" in
+    *[!a-zA-Z0-9.-]*|-*|.*|"")
+        die "Geçersiz domain: '${DOMAIN}' (yalnız harf, rakam, '.' ve '-')."
+        ;;
+esac
+
+NGINX_CONF_SRC="${NGINX_CONF_SRC:-${REPO_DIR}/infra/nginx/${SITE_NAME}-${ENVIRONMENT}.conf}"
+[ -f "${NGINX_CONF_SRC}" ] || die "Kaynak conf bulunamadı: ${NGINX_CONF_SRC}"
 
 echo "======================================================"
 echo " Cargo Pilot Nginx Kurulumu"
+echo " Ortam  : ${ENVIRONMENT}"
 echo " Domain : ${DOMAIN}"
+echo " Kaynak : ${NGINX_CONF_SRC}"
+echo " Hedef  : ${NGINX_CONF_DEST}"
+[ "${DRY_RUN}" -eq 1 ] && echo " Mod    : DRY-RUN (canlı config değiştirilmez)"
 echo "======================================================"
 
 # ── 1. Nginx kurulumu ─────────────────────────────────────
 echo ""
-echo "==> [1/5] Nginx kontrol ediliyor..."
-if ! command -v nginx &>/dev/null; then
+echo "==> [1/6] Nginx kontrol ediliyor..."
+if ! command -v nginx >/dev/null 2>&1; then
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        die "Nginx kurulu değil; --dry-run modunda kurulum yapılmaz."
+    fi
     echo "    Nginx bulunamadı, kuruluyor..."
     apt-get update -qq && apt-get install -y nginx
     echo "    Nginx kuruldu."
@@ -28,77 +128,199 @@ else
     echo "    Nginx zaten kurulu: $(nginx -v 2>&1)"
 fi
 
-# ── 2. SSL sertifikası ────────────────────────────────────
+# ── 2. Config render + placeholder ikamesi ────────────────
 echo ""
-echo "==> [2/5] SSL sertifikası oluşturuluyor..."
-mkdir -p "${SSL_DIR}"
+echo "==> [2/6] Config render ediliyor (placeholder ikamesi)..."
+WORK_DIR="$(mktemp -d)"
+CANDIDATE="${WORK_DIR}/${SITE_NAME}.conf"
 
-if [ -f "${SSL_DIR}/cargopilot.crt" ]; then
-    echo "    Sertifika zaten mevcut, atlanıyor."
-    echo "    Yenilemek için: rm ${SSL_DIR}/cargopilot.crt ${SSL_DIR}/cargopilot.key"
-else
-    openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
-        -keyout "${SSL_DIR}/cargopilot.key" \
-        -out "${SSL_DIR}/cargopilot.crt" \
-        -subj "/CN=${DOMAIN}" 2>/dev/null
-    chmod 600 "${SSL_DIR}/cargopilot.key"
-    echo "    Self-signed sertifika oluşturuldu (10 yıl geçerli)."
-    echo "    Cloudflare Full SSL modu ile uyumlu."
+# <YOUR_DOMAIN> → gerçek domain. Nginx bu placeholder'ı sözdizimsel olarak
+# geçerli bir server_name kabul ettiği için `nginx -t` yakalamaz; ikame
+# edilmezse 443'teki tek server bloğu olarak trafiği yine karşılar (sessiz
+# yanlış yapılandırma). Bu yüzden ikame sonrası kalan placeholder ölümcül hata.
+sed "s|${DOMAIN_PLACEHOLDER}|${DOMAIN}|g" "${NGINX_CONF_SRC}" >"${CANDIDATE}"
+
+if grep -n '<[A-Za-z0-9_]\+>' "${CANDIDATE}" >"${WORK_DIR}/leftover.txt"; then
+    echo "    İkame edilmemiş placeholder bulundu:" >&2
+    sed 's/^/      /' "${WORK_DIR}/leftover.txt" >&2
+    die "Conf içinde doldurulmamış placeholder var; kurulum durduruldu."
 fi
 
-# ── 3. Nginx config ───────────────────────────────────────
+# server_name gerçekten istenen domain mi? (test conf'unda domain sabit yazılı;
+# yanlış ortam/domain kombinasyonu sessizce geçmesin.)
+CONF_SERVER_NAMES="$(
+    grep -E '^[[:space:]]*server_name[[:space:]]' "${CANDIDATE}" |
+        sed -E 's/^[[:space:]]*server_name[[:space:]]+//; s/;[[:space:]]*$//' |
+        tr -s ' ' '\n' | sort -u
+)"
+[ -n "${CONF_SERVER_NAMES}" ] || die "Conf içinde server_name bulunamadı: ${NGINX_CONF_SRC}"
+
+while IFS= read -r name; do
+    [ -z "${name}" ] && continue
+    [ "${name}" = "${DOMAIN}" ] && continue
+    die "Conf'taki server_name '${name}' verilen domain '${DOMAIN}' ile uyuşmuyor (${NGINX_CONF_SRC})."
+done <<EOF
+${CONF_SERVER_NAMES}
+EOF
+echo "    Placeholder ikamesi tamam; server_name = ${DOMAIN}"
+
+# ── 3. SSL sertifikası ────────────────────────────────────
 echo ""
-echo "==> [3/5] Nginx konfigürasyonu kopyalanıyor..."
-cp "${NGINX_CONF_SRC}" "${NGINX_CONF_DEST}"
-ln -sf "${NGINX_CONF_DEST}" /etc/nginx/sites-enabled/cargopilot
+echo "==> [3/6] SSL sertifikası kontrol ediliyor..."
+CERT_PATH="$(grep -E '^[[:space:]]*ssl_certificate[[:space:]]' "${CANDIDATE}" |
+    head -n1 | sed -E 's/^[[:space:]]*ssl_certificate[[:space:]]+//; s/;[[:space:]]*$//')"
+KEY_PATH="$(grep -E '^[[:space:]]*ssl_certificate_key[[:space:]]' "${CANDIDATE}" |
+    head -n1 | sed -E 's/^[[:space:]]*ssl_certificate_key[[:space:]]+//; s/;[[:space:]]*$//')"
+[ -n "${CERT_PATH}" ] && [ -n "${KEY_PATH}" ] || die "Conf içinde ssl_certificate / ssl_certificate_key bulunamadı."
+echo "    Conf'un beklediği sertifika: ${CERT_PATH}"
+
+if [ -f "${CERT_PATH}" ] && [ -f "${KEY_PATH}" ]; then
+    echo "    Sertifika zaten mevcut, atlanıyor."
+    echo "    Yenilemek için: rm ${CERT_PATH} ${KEY_PATH}"
+elif [ "${CERT_PATH#"${SSL_DIR}"/}" != "${CERT_PATH}" ]; then
+    mkdir -p "${SSL_DIR}"
+    openssl req -x509 -nodes -days 3650 -newkey rsa:2048 \
+        -keyout "${KEY_PATH}" \
+        -out "${CERT_PATH}" \
+        -subj "/CN=${DOMAIN}" 2>/dev/null
+    chmod 600 "${KEY_PATH}"
+    echo "    Self-signed sertifika oluşturuldu (10 yıl geçerli)."
+    if [ "${ENVIRONMENT}" = "prod" ]; then
+        echo "    UYARI: prod ortamında self-signed sertifika üretildi."
+        echo "    Gerçek bir CA sertifikası ile değiştirilmeli (${CERT_PATH})."
+    else
+        echo "    Cloudflare Full SSL modu ile uyumlu."
+    fi
+else
+    die "Sertifika yok ve yolu ${SSL_DIR} altında değil: ${CERT_PATH} — elle kurulmalı."
+fi
+
+# ── 4. İzole doğrulama (kopyalamadan ÖNCE) ────────────────
+echo ""
+echo "==> [4/6] Config izole bir nginx instance'ı ile doğrulanıyor..."
+TEST_ROOT="${WORK_DIR}/nginx-test"
+mkdir -p "${TEST_ROOT}/logs"
+cat >"${TEST_ROOT}/nginx.conf" <<EOF
+worker_processes 1;
+error_log stderr warn;
+pid ${TEST_ROOT}/nginx.pid;
+events { worker_connections 64; }
+http {
+    include ${CANDIDATE};
+}
+EOF
+
+if ! nginx -t -p "${TEST_ROOT}" -c "${TEST_ROOT}/nginx.conf"; then
+    die "Config doğrulaması başarısız — canlı config'e DOKUNULMADI (${NGINX_CONF_DEST} değişmedi)."
+fi
+echo "    Config geçerli."
+
+if [ "${DRY_RUN}" -eq 1 ]; then
+    echo ""
+    echo "======================================================"
+    echo " DRY-RUN tamamlandı: config geçerli, hiçbir şey kopyalanmadı."
+    echo "======================================================"
+    exit 0
+fi
+
+# ── 5. Canlı yola kopyalama + canlı ağaçta doğrulama ──────
+echo ""
+echo "==> [5/6] Config canlı yola kopyalanıyor..."
+mkdir -p "${NGINX_SITES_AVAILABLE}" "${NGINX_SITES_ENABLED}"
+
+BACKUP_PATH=""
+if [ -f "${NGINX_CONF_DEST}" ]; then
+    BACKUP_PATH="${NGINX_CONF_DEST}.bak.$(date +%Y%m%d%H%M%S)"
+    cp -p "${NGINX_CONF_DEST}" "${BACKUP_PATH}"
+    echo "    Mevcut config yedeklendi: ${BACKUP_PATH}"
+fi
+
+DEFAULT_SITE_LINK="${NGINX_SITES_ENABLED}/default"
+DEFAULT_SITE_TARGET=""
+if [ -e "${DEFAULT_SITE_LINK}" ]; then
+    DEFAULT_SITE_TARGET="$(readlink "${DEFAULT_SITE_LINK}" || true)"
+fi
+
+rollback() {
+    echo "    Geri alınıyor..." >&2
+    if [ -n "${BACKUP_PATH}" ]; then
+        cp -p "${BACKUP_PATH}" "${NGINX_CONF_DEST}"
+        echo "    Önceki config geri yüklendi: ${NGINX_CONF_DEST}" >&2
+    else
+        rm -f "${NGINX_CONF_DEST}" "${NGINX_SITES_ENABLED}/${SITE_NAME}"
+        echo "    Yeni eklenen config ve symlink kaldırıldı." >&2
+    fi
+    if [ -n "${DEFAULT_SITE_TARGET}" ] && [ ! -e "${DEFAULT_SITE_LINK}" ]; then
+        ln -sf "${DEFAULT_SITE_TARGET}" "${DEFAULT_SITE_LINK}"
+        echo "    Default site symlink'i geri konuldu." >&2
+    fi
+}
+
+cp "${CANDIDATE}" "${NGINX_CONF_DEST}"
+ln -sf "${NGINX_CONF_DEST}" "${NGINX_SITES_ENABLED}/${SITE_NAME}"
+echo "    Config kopyalandı: ${NGINX_CONF_DEST}"
 
 # Default site'ı devre dışı bırak (port 80 çakışması önleme)
-if [ -f /etc/nginx/sites-enabled/default ]; then
-    rm -f /etc/nginx/sites-enabled/default
+if [ -e "${DEFAULT_SITE_LINK}" ]; then
+    rm -f "${DEFAULT_SITE_LINK}"
     echo "    Default site devre dışı bırakıldı."
 fi
 
-echo "    Config kopyalandı: ${NGINX_CONF_DEST}"
+echo "    Canlı ağaçta nginx -t..."
+if ! nginx -t; then
+    rollback
+    die "Canlı ağaçta nginx -t başarısız oldu; değişiklikler geri alındı ve reload yapılmadı."
+fi
+echo "    Canlı config geçerli."
 
+# ── 6. UFW + nginx reload ─────────────────────────────────
 echo ""
-echo "==> [3.5] Nginx config test ediliyor..."
-nginx -t
-
-# ── 4. UFW ───────────────────────────────────────────────
-echo ""
-echo "==> [4/5] UFW port 443 açılıyor..."
-if command -v ufw &>/dev/null; then
-    ufw allow 443/tcp
-    ufw status | grep 443
+echo "==> [6/6] UFW ve nginx..."
+if command -v ufw >/dev/null 2>&1; then
+    # UFW pasif olabilir; bu bir hata değil, script `set -e` altında ölmemeli.
+    if ufw allow 443/tcp; then
+        echo "    UFW 443/tcp kuralı uygulandı."
+    else
+        echo "    UYARI: 'ufw allow 443/tcp' başarısız oldu, atlanıyor."
+    fi
+    UFW_STATUS="$(ufw status 2>/dev/null || true)"
+    if printf '%s\n' "${UFW_STATUS}" | grep -q '443'; then
+        printf '%s\n' "${UFW_STATUS}" | grep '443' | sed 's/^/    /'
+    else
+        echo "    UFW çıktısında 443 kaydı görünmüyor (UFW pasif olabilir)."
+    fi
 else
     echo "    UFW bulunamadı, atlanıyor."
 fi
 
-# ── 5. Nginx başlatma ────────────────────────────────────
-echo ""
-echo "==> [5/5] Nginx yeniden başlatılıyor..."
-systemctl restart nginx
-systemctl enable nginx
+if "${SERVICE_MANAGER}" is-active --quiet nginx; then
+    echo "    Nginx çalışıyor, reload ediliyor..."
+    "${SERVICE_MANAGER}" reload nginx
+else
+    echo "    Nginx çalışmıyor, başlatılıyor..."
+    "${SERVICE_MANAGER}" restart nginx
+fi
+"${SERVICE_MANAGER}" enable nginx
 
 echo ""
 echo "======================================================"
-echo " ✅ Nginx kurulumu tamamlandı!"
+echo " Nginx kurulumu tamamlandı! (${ENVIRONMENT} / ${DOMAIN})"
 echo "======================================================"
 echo ""
 echo " Sonraki adım — Frontend'i yeniden build et:"
 echo ""
 echo "   cd ${REPO_DIR}"
-echo "   # .env.test dosyasına şu satırı ekle/güncelle:"
+echo "   # infra/env/.env.${ENVIRONMENT} dosyasına şu satırı ekle/güncelle:"
 echo "   #   VITE_API_BASE_URL=https://${DOMAIN}"
 echo ""
 echo "   docker compose \\"
-echo "     -f infra/compose/docker-compose.test.yml \\"
-echo "     --env-file infra/env/.env.test \\"
+echo "     -f infra/compose/docker-compose.${ENVIRONMENT}.yml \\"
+echo "     --env-file infra/env/.env.${ENVIRONMENT} \\"
 echo "     build --no-cache frontend"
 echo ""
 echo "   docker compose \\"
-echo "     -f infra/compose/docker-compose.test.yml \\"
-echo "     --env-file infra/env/.env.test \\"
+echo "     -f infra/compose/docker-compose.${ENVIRONMENT}.yml \\"
+echo "     --env-file infra/env/.env.${ENVIRONMENT} \\"
 echo "     up -d --no-build frontend"
 echo ""
 echo " Test:"


### PR DESCRIPTION
## Özet

İki bulgu: **D-48** (`setup-nginx.sh` canlı config'i test etmeden üzerine yazıyor) ve **D-49** (healthcheck kapsamı eksik).

### D-48 — doğrulama artık kopyalamadan ÖNCE

Eski akış: `:52` `cp` → `:65` `nginx -t`. Yani bozuk bir config **yerinde kalıyor** ve sonraki reload nginx'i düşürüyordu. Ayrıca `:72` `ufw status | grep 443`, UFW pasifse `set -e` altında exit 1 veriyor ve restart adımına hiç gelinmiyordu.

Yeni akış:

1. nginx var mı (dry-run'da kurulum yapmaz)
2. **Render:** kaynak conf `mktemp -d` altına kopyalanır, `<YOUR_DOMAIN>` → verilen domain ikame edilir; sonra (a) kalıntı placeholder taraması, (b) conf'taki her `server_name` verilen domain'e eşit mi kontrolü. Canlı yola hâlâ dokunulmadı
3. **Sertifika:** cert/key yolları **rendered conf'tan** okunur (`ssl_certificate`), böylece test (`cargopilot.crt`) / prod (`cargopilot-prod.crt`) farkı conf'tan gelir. Yoksa ve yol `SSL_DIR` altındaysa self-signed üretilir (prod'da yüksek sesli uyarı); dışındaysa (ör. Let's Encrypt) durur
4. **İzole doğrulama:** geçici kökte sarmalayıcı `nginx.conf` yazılır, `nginx -t -p <tmp> -c <tmp>/nginx.conf` koşar. **Başarısızsa burada durur; `/etc/nginx` hiç açılmaz.** `--dry-run` burada exit 0
5. **Kopyalama:** mevcut hedef `*.bak.<timestamp>` olarak yedeklenir → `cp` → `ln -sf` → default site devre dışı → canlı ağaçta tekrar `nginx -t`. Başarısızsa **rollback** ve **reload yapılmaz**
6. **UFW + reload:** UFW `if`/`|| true` ile sarıldı; pasifse bilgi mesajı, ölüm yok

`set -e` → `set -euo pipefail`.

### Yeni arayüz — ortam ve domain zorunlu

```bash
sudo bash infra/scripts/setup-nginx.sh <test|prod> --domain <domain> [--dry-run]
```

Sabit varsayılan bırakılmadı (eskiden `DOMAIN="cargopilot.divizyon.org"` ve conf yolu sabit test conf'uydu). Conf yolu `infra/nginx/cargopilot-<ortam>.conf` olarak türetiliyor; argüman eksikse usage + exit 2.

### F1-01'in bıraktığı açık kapatıldı

PR #1043 `cargopilot-prod.conf`'u eklerken `server_name` olarak canlı bir `<YOUR_DOMAIN>` placeholder'ı bıraktı ve raporunda "sessiz yanlış yapılandırma" diye uyardı. **Bu uyarı doğrulandı** — sandbox'ta placeholder'lı conf ile `nginx -t` **exit 0** dönüyor:

```
56:    server_name <YOUR_DOMAIN>;
nginx: configuration file /tmp/ph/nginx.conf test is successful
==> nginx -t cikis kodu: 0   (placeholder'i nginx yakalamiyor)
```

Script artık ikame ediyor ve doldurulmamış placeholder kalırsa **durup canlı hedefe dokunmuyor**:

```
==> [2/6] Config render ediliyor (placeholder ikamesi)...
    İkame edilmemiş placeholder bulundu:
      158:        proxy_pass         http://<BACKEND_HOST>:8080;
HATA: Conf içinde doldurulmamış placeholder var; kurulum durduruldu.
==> KANIT: canli hedef DEGISMEDI
```

### D-49 — healthcheck: 4·3·0·0 → 5·4·6·6

| Servis | Komut | Neden bu komut |
|---|---|---|
| prometheus | `wget .../-/healthy` | `curl` MISSING, `wget=/bin/wget`; canlı: `Prometheus Server is Healthy.` |
| loki | `wget .../ready`, `start_period: 60s` | `/ready` 10-20s'de 503, ~30s'de hazır → start_period şart |
| grafana | `wget .../api/health` | canlı: `{"database":"ok",...}` |
| **promtail** | `bash -c` + `/dev/tcp` ile HTTP isteği | **`wget`, `curl`, `nc`, `busybox` HEPSİ MISSING**; yalnız `bash` var |
| cadvisor | `wget .../healthz` | gerçek health ucu, `ok` döndürüyor |
| **node-exporter** | `wget .../metrics` — `/-/healthy` **DEĞİL** | `/-/healthy` **her yola** 200 döndürüyor, `/bogus` dahil → sahte pozitif |
| frontend (test+prod) | `wget http://127.0.0.1/` | `nginx.conf`'ta `/health` yok; kök `index.html`'i 200 veriyor |

**İki yerde brief'ten bilinçli sapıldı ve ikisi de ölçümle gerekçelendirildi:**

1. **promtail:** brief `/ready` diyor ama imajda o isteği atacak hiçbir araç yok. Brief körü körüne uygulansa "healthcheck var" görünen ama **daima başarısız** bir yapılandırma çıkardı.
2. **node-exporter:** brief `/-/healthy` öneriyor. Ölçüm: v1.7.0 `/-/healthy` dahil her yol için 200 + landing page HTML döndürüyor — `/tamamen-uydurma-yol` bile exit 0. Gerçek işleyişi kanıtlayan `/metrics` seçildi; gerekçe compose dosyalarında yorum olarak da duruyor.

Grafana `depends_on` artık koşullu:

```yaml
    depends_on:
      prometheus:
        condition: service_healthy
      loki:
        condition: service_healthy
```

## İlgili User Story / Issue

Faz 1 · F1-03 · **D-48, D-49** · #1043'ün placeholder açığının kapatılması

## Değişiklik Tipi

- [x] 🔧 Altyapı (infra)

## Test Edildi mi?

- [x] **Bozuk conf testi:** test conf'una `;` eksik bir `server {` bloğu enjekte edildi; script `[4/6]`'da durdu ve canlı hedefin **sha256'sı öncesi/sonrası birebir aynı** kaldı
- [x] `--dry-run` hedefi değiştirmiyor (sha256 aynı)
- [x] UFW pasif/hatalı senaryosunda script sonuna kadar koşuyor (exit 0)
- [x] Başarılı prod kurulumunda yedek oluşuyor (`cargopilot.bak.20260818131229`), symlink doğru
- [x] Placeholder ikamesi + ikame edilmemişte durma — kanıt yukarıda
- [x] Domain uyuşmazlığı guard'ı: conf `server_name` ≠ verilen domain → exit 1
- [x] **Gerçek stack ile healthcheck doğrulaması:** healthcheck blokları birebir kopyalanmış geçici stack `docker compose up -d --wait` ile kalktı → **7/7 healthy** (cadvisor, frontend, grafana, loki, node-exporter, prometheus, promtail)
- [x] `bash -n` → ok · `shellcheck` (docker `koalaman/shellcheck-alpine`) → **çıktı yok, exit 0**
- [x] Dört compose dosyasında `docker compose config` → exit 0
- [x] promtail healthcheck'inin YAML kaçışı `cat -v` ile doğrulandı (`\r\n` iki karakterli dizi, gerçek CR değil)
- [x] `mem_limit` satırlarına dokunulmadı (#1044'ün alanı), conf içerikleri değişmedi (#1043'ün alanı)

Sunucuda hiçbir şey çalıştırılmadı — sandbox `nginx:1.31` konteynerinde, sahte `systemctl`/`ufw` ile test edildi.

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok (`bash -n`, `shellcheck`)
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekçeler script ve compose yorumlarında)

## Ek Notlar — sunucuda elle yapılması gerekenler

1. **Script imzası değişti:** artık argümansız çağrılamaz. Sunucudaki alışkanlık/runbook `sudo bash infra/scripts/setup-nginx.sh` ise güncellenmeli. Repoda çağıran başka script/CI **yok** (grep ile teyit edildi).
2. **Doğrulanamadı:** gerçek sunucuda `systemctl reload/restart/enable nginx` ve gerçek `ufw` davranışı. Sandbox'ta sahte komutlarla test edildi.
3. **Prod sertifikası:** ilk prod çalıştırmasında cert yoksa script `/etc/nginx/ssl/cargopilot-prod.{crt,key}` için self-signed üretip yüksek sesle uyarır. Gerçek CA / Let's Encrypt sertifikası elle konulmalı; Let's Encrypt yoluna geçilirse `ssl_certificate` yolu `SSL_DIR` dışına çıkacağı için script "elle kurulmalı" diye **kasıtlı olarak** durur.
4. **`node-exporter`/`cadvisor`** healthcheck'leri macOS Docker Desktop'ta doğrulandı; gerçek Linux host mount'larıyla (`/host`, `/dev/disk`, `--path.rootfs`) ilk deploy'da bir kez `docker ps` üzerinden teyit edilmeli.
5. **Test ortamı domain'i:** `cargopilot-test.conf` içinde `server_name` hâlâ sabit `cargopilot.divizyon.org`. Script farklı bir domain verilirse sessizce geçmiyor, açıkça hata veriyor — ama test domain'i değişecekse conf da güncellenmeli (conf içeriği #1043 kapsamı, dokunulmadı).
6. **Bilgi:** nginx 1.31 conf'lardaki `listen 443 ssl http2` için deprecation uyarısı veriyor. Sadece warning, `nginx -t` geçiyor; conf içeriği kapsam dışı olduğu için dokunulmadı — #1043 takibine değer.
