### PR TITLE
Dockerfile cache katmanları: csproj-only restore ve npm ci (D-30, D-34)

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -3,12 +3,21 @@ ARG DOTNET_ASPNET_IMAGE=mcr.microsoft.com/dotnet/aspnet:8.0
 FROM ${DOTNET_SDK_IMAGE} AS build
 WORKDIR /src
 
-# Copy full backend tree so solution/csproj discovery works for monorepo layouts.
-COPY . .
+# --- Restore katmanı -------------------------------------------------------
+# Yalnızca NuGet restore grafiğini etkileyen dosyalar kopyalanır. Kaynak (.cs)
+# değişiklikleri bu katmanı geçersiz kılmaz, dolayısıyla restore cache'den gelir.
+# Directory.Build.props tüm projelere PackageReference eklediği için restore
+# grafiğinin parçasıdır ve kaynaktan ÖNCE kopyalanmak zorundadır.
+COPY global.json Directory.Build.props CargoPilot.slnx ./
+COPY CargoPilot.Domain/CargoPilot.Domain.csproj CargoPilot.Domain/
+COPY CargoPilot.Application/CargoPilot.Application.csproj CargoPilot.Application/
+COPY CargoPilot.Infrastructure/CargoPilot.Infrastructure.csproj CargoPilot.Infrastructure/
+COPY CargoPilot.WebAPI/CargoPilot.WebAPI.csproj CargoPilot.WebAPI/
 
-# ASP.NET Core Web API projesini (Sdk="Microsoft.NET.Sdk.Web") bul ve yayınla.
+# ASP.NET Core Web API projesini (Sdk="Microsoft.NET.Sdk.Web") bul ve restore et.
 # Çoklu proje (Domain/Application/Infrastructure class library'leri) olduğundan
 # "ilk bulunan csproj" yaklaşımı yanlış projeyi (örn. Domain) hedefler.
+# Bulunan yol publish adımında yeniden kullanılmak üzere diske yazılır.
 RUN set -e; \
     project=$(find . -type f -name '*.csproj' -exec grep -l 'Microsoft\.NET\.Sdk\.Web' {} + | head -1); \
     if [ -z "$project" ]; then \
@@ -16,8 +25,18 @@ RUN set -e; \
         exit 1; \
     fi; \
     echo "Web API projesi: $project"; \
-    dotnet restore "$project"; \
-    dotnet publish "$project" -c Release -o /app/publish /p:UseAppHost=false; \
+    echo "$project" > /web-project.path; \
+    dotnet restore "$project"
+
+# --- Publish katmanı -------------------------------------------------------
+# Kaynak ağacı restore'dan sonra kopyalanır; restore yeniden koşmasın diye
+# publish --no-restore ile çalışır (eksik paket varsa build sessizce geçmez,
+# assets file hatası verir).
+COPY . .
+
+RUN set -e; \
+    project=$(cat /web-project.path); \
+    dotnet publish "$project" -c Release -o /app/publish --no-restore /p:UseAppHost=false; \
     basename "$project" .csproj > /app/publish/.entry-dll
 
 FROM ${DOTNET_ASPNET_IMAGE} AS final

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-slim AS deps
 WORKDIR /app
 RUN npm install -g npm@11.6.1
 COPY package*.json ./
-RUN npm install --ignore-scripts --no-audit --no-fund
+RUN npm ci --ignore-scripts --no-audit --no-fund
 
 FROM node:20-slim AS build
 WORKDIR /app


### PR DESCRIPTION
## Özet

İki bulgu: **D-30** (backend restore katmanı hiç cache'lenmiyor) ve **D-34** (`npm install` → `npm ci`).

### D-30 — csproj-only restore katmanı

Eskiden `apps/backend/Dockerfile:7` `COPY . .` restore'dan önce geliyordu; tek bir `.cs` değişikliği `dotnet restore`'u **her build'de sıfırdan** koşturuyordu.

Yeni katman sırası: `COPY global.json Directory.Build.props CargoPilot.slnx ./` → 4 csproj COPY → `dotnet restore` (bulunan proje yolu `/web-project.path`'e yazılır) → `COPY . .` → `dotnet publish --no-restore`.

**Hangi csproj'lar kopyalanıyor ve neden:** `CargoPilot.slnx` 7 proje bildiriyor. Publish yalnız `CargoPilot.WebAPI`'yi hedefliyor (tek `Microsoft.NET.Sdk.Web` projesi); transitif grafiği WebAPI → Application, Infrastructure → Domain. Bu 4 csproj dizin yapısı korunarak kopyalanıyor.

3 test projesi (`Engine.Tests`, `Infrastructure.Tests`, `tests/Application.Tests`) **bilinçli olarak kopyalanmıyor** — Dockerfile onları hiç derlemiyor, dışarıda tutmak restore katmanının cache-invalidation yüzeyini küçültüyor. `tests/Directory.Build.props` de bu yüzden gerekmiyor.

**`Directory.Build.props` kopyalanmak ZORUNDA** — yalnız stil dosyası değil, her projeye `PackageReference` enjekte ediyor (`Microsoft.Bcl.Memory` 9.0.19 + NetAnalyzers/SonarAnalyzer paketleri), yani restore grafiğinin parçası. Yalnız kaynakla birlikte kopyalansaydı `dotnet publish --no-restore` assets-file uyuşmazlığına düşerdi. Aynı sebeple `global.json` (SDK 8.0.419 pinli) ve `CargoPilot.slnx` (proje eklenip çıkarıldığında cache'i patlatır) da kopyalanıyor. **İçerikleri değiştirilmedi.**

### D-34 — `npm ci`

`apps/frontend/Dockerfile` tek satır: `npm install --ignore-scripts --no-audit --no-fund` → `npm ci --ignore-scripts --no-audit --no-fund`. `npm install` lock dosyasını **yazabiliyordu**, yani image içi bağımlılıklar CI'daki `npm ci` sonucundan sapabilirdi.

`COPY package*.json ./` zaten `package-lock.json`'ı (311 KB) kapsıyor ve `.dockerignore` onu dışlamıyor — `deps` aşamasında `/app/package-lock.json` varlığı teyit edildi, `npm ci` `added 610 packages in 11s` raporladı.

## Ölçüm

| Senaryo | Süre | CACHED | restore koştu? |
|---|---|---|---|
| Eski Dockerfile, 1 `.cs` değişti | 38,36 sn | 3 | **evet (2×)** |
| **Yeni Dockerfile, 1 `.cs` değişti** | **15,67 sn** | **9** | **hayır (0×)** |
| Yeni Dockerfile, soğuk | 49,03 sn | 0 | evet (~30 sn) |
| Yeni Dockerfile, değişiklik yok | 0,72 sn | 13 | hayır |

Gerçekçi kod-değişikliği yolunda **~%59 hızlanma (22,7 sn tasarruf)**.

### ⚠️ Brief'in doğrulama komutu geçersizdi — düzeltildi

Brief `touch` ile ölçmeyi söylüyor. **`touch` hiçbir şey kanıtlamıyor:** BuildKit içerik-adresli hash kullanıyor, mtime'a bakmıyor. O koşum 13 CACHED / 0,72 sn veriyor ama restore katmanı hakkında bilgi vermiyor.

Gerçek kanıt için `VolumeScoring.cs`'e gerçek içerik eklendi (sonra geri alındı):

```
#14 [build  8/10] RUN ... dotnet restore "$project"     → CACHED
#15 [build  9/10] COPY . .                              → re-ran
#16 [build 10/10] RUN ... dotnet publish --no-restore    → re-ran
```

`grep -c 'Determining projects to restore'` = **0** — restore gerçekten koşmadı.

### Sessiz eksik paket riski elendi

Brief "build sessizce eksik paketle geçebilir" diye uyarıyordu. Eski Dockerfile ayrı tag'le derlenip publish çıktıları karşılaştırıldı: **her ikisi de tam 130 dosya, `diff` boş.** Entrypoint doğru çözülüyor (`dotnet /app/CargoPilot.WebAPI.dll`). Kalan uyarılar zaten var olan CS1591 (`WarningsNotAsErrors` içinde).

## İlgili User Story / Issue

Faz 4 · F4-02 · **D-30, D-34**

## Değişiklik Tipi

- [x] 🔧 Altyapı (infra)

## Test Edildi mi?

- [x] Her iki image derleniyor (`cp-be-test`, `cp-fe-test` exit 0)
- [x] Restore katmanı kod değişikliğinde `CACHED` — log kanıtı yukarıda
- [x] Publish çıktısı eski Dockerfile ile birebir aynı (130 dosya, `diff` boş)
- [x] Frontend `dist` nginx aşamasında doğrulandı (hash'li asset bundle'ları mevcut)
- [x] CI context'leri (`ci.yml:222/234` → `./apps/backend/`, `./apps/frontend/`) yerel çağrılarla birebir aynı, context-relative COPY yolları CI'da da tutuyor

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekçeler Dockerfile yorumlarında)

## Ek Notlar

- **Kalan bakım yükü:** yeni bir **üretim** projesi eklenirse Dockerfile'a bir COPY satırı gerekiyor. Bu hata **gürültülü** (restore/assets hatası), sessiz değil — cache'lenebilir katmanın bedeli. Dockerfile ileride test koşturacak şekilde genişletilirse 3 test csproj'u + `tests/Directory.Build.props` restore katmanına eklenmeli.
- **Kapsam dışı:** base image değişimi (D-31/D-32 → ayrı PR), analyzer'ın build'den çıkarılması (D-35 → ayrı PR). Analyzer paketleri hâlâ restore edilip build sırasında koşuyor.
- `apps/frontend/Dockerfile`'daki **`FROM` satırlarına dokunulmadı** — paralel giden base image PR'ının alanı. İki PR birlikte merge testinden geçti.
