### PR TITLE
Base image hijyeni: imagetools, alpine-slim, cron takvimi (D-31, D-32, D-33)

### DIFF
--- a/.github/workflows/sync-base-images.yml
+++ b/.github/workflows/sync-base-images.yml
@@ -34,17 +34,18 @@ jobs:
         run: echo "tag=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
 
       - name: .NET SDK 8.0 imajını senkronize et
+        # imagetools create manifest list'i doğrudan registry-to-registry kopyalar;
+        # layer'ları runner'a indirmez ve MCR'ın multi-arch manifest'ini korur.
+        # (pull+tag+push yalnızca runner'ın kendi platformunu indirip push ederdi.)
         run: |
-          docker pull mcr.microsoft.com/dotnet/sdk:8.0
-          docker tag mcr.microsoft.com/dotnet/sdk:8.0 ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0
-          docker tag mcr.microsoft.com/dotnet/sdk:8.0 ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0-${{ steps.date.outputs.tag }}
-          docker push ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0
-          docker push ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0-${{ steps.date.outputs.tag }}
+          docker buildx imagetools create \
+            --tag ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0 \
+            --tag ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0-${{ steps.date.outputs.tag }} \
+            mcr.microsoft.com/dotnet/sdk:8.0
 
       - name: .NET ASP.NET 8.0 imajını senkronize et
         run: |
-          docker pull mcr.microsoft.com/dotnet/aspnet:8.0
-          docker tag mcr.microsoft.com/dotnet/aspnet:8.0 ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0
-          docker tag mcr.microsoft.com/dotnet/aspnet:8.0 ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0-${{ steps.date.outputs.tag }}
-          docker push ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0
-          docker push ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0-${{ steps.date.outputs.tag }}
+          docker buildx imagetools create \
+            --tag ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0 \
+            --tag ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0-${{ steps.date.outputs.tag }} \
+            mcr.microsoft.com/dotnet/aspnet:8.0

--- a/.github/workflows/sync-base-images.yml
+++ b/.github/workflows/sync-base-images.yml
@@ -3,10 +3,21 @@ name: Base Image Sync
 # .NET base imagellarını MCR'dan çekip GHCR'a yansıtır.
 # Böylece MCR rate limit veya erişim sorunları build pipeline'ını etkilemez.
 # Tetikleyiciler:
-#   schedule → Her Pazar 02:00 UTC (haftalık yenileme)
+#   schedule (Çarşamba) → Microsoft "Patch Tuesday" (ayın 2. Salı'sı) sonrası ilk gün.
+#     GitHub cron sözdizimi "ayın N. haftaiçi günü"nü doğrudan ifade edemez; ayrıca
+#     day-of-month VE day-of-week aynı anda kısıtlanırsa GitHub bu iki alanı OR'lar
+#     (ör. '9-15 * 3' hem ayın 9-15. günlerinin TAMAMINDA hem de ayın HER Çarşamba'sında
+#     tetiklenir — istenen tek gün değil). Bu yüzden day-of-month '*' bırakılıp her
+#     Çarşamba tetiklenir, gerçek "2. Salı'nın ertesi günü mü" kontrolü job içindeki
+#     "Çalıştırma gerekliliğini belirle" adımında (ayın günü 9-15 aralığında mı) yapılır
+#     — 2. Salı her zaman ayın 8-14. günlerine denk geldiğinden ertesi Çarşamba 9-15
+#     aralığında ve ayda yalnızca bir kez olur.
+#   schedule (Pazar) → Haftalık yedek koşum; patch-günü tetikleyicisi atlanır/gecikirse
+#     bayatlık üst sınırını 7 günde tutar.
 #   workflow_dispatch → Manuel tetikleme (ilk kurulum veya acil güncelleme için)
 on:
   schedule:
+    - cron: '0 3 * * 3'
     - cron: '0 2 * * 0'
   workflow_dispatch:
 
@@ -22,7 +33,28 @@ jobs:
       packages: write
 
     steps:
+      - name: Çalıştırma gerekliliğini belirle
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${{ github.event.schedule }}" = "0 2 * * 0" ]; then
+            # Haftalık yedek koşum: her zaman çalışır.
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Çarşamba tetikleyicisi: yalnızca ayın 2. Salı'sının ertesi günü (9-15. gün) çalışır.
+          day=$(date -u +%d)
+          if [ "$day" -ge 9 ] && [ "$day" -le 15 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: GHCR'a giriş yap
+        if: steps.gate.outputs.run == 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -30,10 +62,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tarih etiketi belirle
+        if: steps.gate.outputs.run == 'true'
         id: date
         run: echo "tag=$(date -u +%Y%m%d)" >> $GITHUB_OUTPUT
 
       - name: .NET SDK 8.0 imajını senkronize et
+        if: steps.gate.outputs.run == 'true'
         # imagetools create manifest list'i doğrudan registry-to-registry kopyalar;
         # layer'ları runner'a indirmez ve MCR'ın multi-arch manifest'ini korur.
         # (pull+tag+push yalnızca runner'ın kendi platformunu indirip push ederdi.)
@@ -44,6 +78,7 @@ jobs:
             mcr.microsoft.com/dotnet/sdk:8.0
 
       - name: .NET ASP.NET 8.0 imajını senkronize et
+        if: steps.gate.outputs.run == 'true'
         run: |
           docker buildx imagetools create \
             --tag ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0 \

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
-FROM nginx:1.31-alpine AS final
+FROM nginx:1.31-alpine-slim AS final
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/docs/devops/devops-backlog.md
+++ b/docs/devops/devops-backlog.md
@@ -42,6 +42,7 @@ kayıt orada, plan burada; ikisi arasında tekrar bırakılmaz.
 | 16 | Kaynak limitleri — D-38 (limit yok), D-39 (`MSSQL_MEMORY_LIMIT_MB`) | 🔴 Kritik | ⚠️ Açık |
 | 17 | Prod öncesi zorunlular — D-47 (prod nginx conf), D-50 (port/path uyumsuzluğu) | 🟠 Yüksek | ⚠️ Açık |
 | 18 | Rollback güvenliği — D-24, D-25, D-27 ✅ (#1012, #1017); kalan **D-29 (tatbikat)** | 🟠 Yüksek | ⚠️ Açık |
+| 19 | .NET 8 → .NET 10 LTS geçişi — D-32b, EOL **2026-11-10** | 🔴 Kritik (tarihe bağlı) | ⚠️ Açık — planlama |
 
 Kategori 6, 2026-08-03 taramasının **35 açık** D-bulgusunu D-kodlarıyla birlikte listeler
 (51'den 16'sı kapandı); yukarıdaki matris yalnızca kritik kümeleri özetler.
@@ -434,6 +435,74 @@ Kapananların hiçbiri kritik değildi; altı kritiğin dördü sunucuya SSH eri
 
 **D-38, D-39, D-47, D-50** — bunlar olmadan prod stack kalkarsa ya port çakışır ya OOM olur.
 Madde 2.1 (Production Stack Deploy) bu dördüne bağımlıdır.
+
+---
+
+### 6.9 .NET 8 → .NET 10 LTS geçişi (D-32b)
+
+{% hint style="danger" %}
+**⚠️ Açık — yalnız planlama, geçiş kendisi başka bir görevdedir**
+{% endhint %}
+
+**Bağlam:** D-32'nin stratejik kısmı. .NET 8'in Microsoft desteği **2026-11-10**'da bitiyor;
+bu maddenin yazıldığı tarih (2026-08-18) itibarıyla **~12 hafta** kaldı. .NET 10, Kasım 2025'te
+çıkan bir sonraki LTS'dir (STS olan .NET 9 atlanıyor). F4-03 kapsamında yalnızca bu backlog
+maddesi yazıldı; geçişin kendisi **yapılmadı** (F4-03 kapsam dışı).
+
+**Kapsam (bugünkü kod tabanına göre doğrulandı):**
+
+- 7 `.csproj` dosyası `net8.0` hedefliyor → `net10.0`'a çekilmeli: `CargoPilot.Domain`,
+  `CargoPilot.Application`, `CargoPilot.Infrastructure`, `CargoPilot.WebAPI`,
+  `CargoPilot.Engine.Tests`, `CargoPilot.Infrastructure.Tests`,
+  `tests/CargoPilot.Application.Tests`.
+- `Microsoft.AspNetCore.*` / `Microsoft.EntityFrameworkCore.*` NuGet paketleri (2 proje —
+  muhtemelen `WebAPI` ve `Infrastructure`) 8.x → 10.x major sürüme çekilmeli; ikisi de
+  runtime ile aynı major olmak zorunda.
+- CI: `.github/workflows/ci.yml:170` ve `.github/workflows/test-deploy.yml:50` —
+  `dotnet-version: '8.0.x'` → `'10.0.x'`.
+- `apps/backend/Directory.Build.props` — `LangVersion: latest` zaten ileri sürüme otomatik
+  uyar, ama `TreatWarningsAsErrors` + SonarAnalyzer 10.32 altında yeni SDK'nın getirdiği
+  analyzer kuralları derlemeyi kırabilir (bu dosya F4-04'ün alanı, değişiklik oraya düşer).
+  Backend'de artık aktif olarak kullanılan `EnforceCodeStyleInBuild` bu geçişte ayrıca
+  gözden geçirilmeli.
+- `sync-base-images.yml` (bu PR'da `imagetools create`'e geçirildi, D-33) — `dotnet/sdk:10.0`
+  ve `dotnet/aspnet:10.0` için yeni bir senkron adımı eklenmeli; `apps/backend/Dockerfile`
+  `${DOTNET_SDK_IMAGE}`/`${DOTNET_ASPNET_IMAGE}` build-arg'larını `:10.0` etiketine çekmeli
+  (Dockerfile F4-02'nin alanı).
+- Regresyon: Domain/Application/Infrastructure/WebAPI test projelerinin tamamı yeşile
+  çekilmeli; EF Core major sürüm atlaması migration davranışında (ör. query translation,
+  konvansiyon değişiklikleri) sessiz farklara yol açabilir.
+
+**Riskler:**
+
+- EF Core 8→10 major atlaması, mevcut migration'larda veya LINQ sorgu çevirisinde davranış
+  farkına yol açabilir — mutlaka staging'de gerçek veriyle regresyon gerektirir.
+- ASP.NET Core middleware/minimal API pipeline'ında breaking change olasılığı (her majörde
+  olağan) — auth/CORS/rate-limit gibi hassas orta katmanlar önceliklendirilmeli.
+- Yeni SDK'nın analyzer/SonarAnalyzer seti `TreatWarningsAsErrors` altında derlemeyi
+  kırabilir; bu geçiş F4-04 (`Directory.Build.props`) ile koordine edilmeli.
+- `sync-base-images.yml` → yeni `:10.0` mirror'ı olmadan `apps/backend/Dockerfile` build
+  edilemez; sıralama önemli (önce base image sync, sonra Dockerfile build-arg güncellemesi).
+- Rollback: ADR-0009 (health-check sonrası otomatik geri alma) bu geçişte de geçerli olmalı;
+  major runtime atlaması sonrası ilk deploy için rollback provası (D-29 ile aynı disiplin)
+  önerilir.
+- Downtime riski düşük (aynı deploy pipeline'ı kullanılıyor) ama regresyon riski yüksek —
+  major sürüm atlaması, tek tek patch güncellemesi değil.
+
+**Efor tahmini (tümü tahmin, gerçek efor keşif sonrası netleşir):**
+
+| Adım | Tahmini efor |
+|---|---|
+| NuGet/SDK sürüm bump + derleme hatalarının giderilmesi | ~1–2 gün (tahmin) |
+| Test suite'in (7 proje) yeşile çekilmesi + EF Core regresyon kontrolü | ~1 gün (tahmin) |
+| CI + `sync-base-images.yml` + Dockerfile build-arg zinciri güncellemesi | ~0.5–1 gün (tahmin) |
+| Staging QA + rollback provası | ~1 gün (tahmin) |
+| **Toplam** | **~3.5–5 iş günü (tahmin)** |
+
+**Zamanlama önerisi:** EOL'e (2026-11-10) ~12 hafta var. Planlama ve bağımlılık taraması
+(NuGet paket uyumluluğu, breaking change listesi) şimdi başlamalı; hedef, EOL'den en az
+2-3 hafta önce (Ekim sonu) production'da .NET 10 üzerinde olmak — böylece beklenmedik bir
+regresyon çıkarsa müdahale için tampon süre kalır.
 
 ---
 


### PR DESCRIPTION
## Özet

Üç bulgu, brief'in söylediği sırayla: **D-33** (imagetools) → **D-31** (alpine-slim) → **D-32** (cron takvimi + .NET 8 EOL).

### D-33 — `pull`+`tag`+`push` → `buildx imagetools create`

Eski akış tüm layer'ları runner'a indiriyor **ve multi-arch manifest'i kaybediyordu.** Her iki blok `docker buildx imagetools create --tag ... --tag ... <source>` ile değiştirildi (ikişer `--tag`, sabit `:8.0` ve tarihli etiket korunuyor). `imagetools` layer indirmez ve manifest list'i korur.

**Kanıt — GHCR'a yazmadan mekanizma kanıtlandı:**

| | Sonuç |
|---|---|
| Bugünkü GHCR aynası (`cargo-pilot-dotnet-aspnet:8.0`) | `manifest.v2+json` — **tek manifest, platform listesi yok** (bulgunun kanıtı) |
| Upstream (`mcr.microsoft.com/dotnet/aspnet:8.0`) | `manifest.list.v2+json` — **3 platform**: `linux/amd64`, `linux/arm/v7`, `linux/arm64` |
| `imagetools create` ile kopya (tek kullanımlık yerel `registry:2`) | Sonuç digest'i upstream'in root digest'iyle **bit birebir aynı**, 3 platform korunuyor |

Test registry'si ve konteyneri sonrasında kaldırıldı. Gerçek GHCR'a hiçbir şey push edilmedi, `sync-base-images.yml` çalıştırılmadı.

### D-31 — `nginx:1.31-alpine` → `alpine-slim`

`alpine` varyantı njs getiriyor, njs de `libxml2`/`libxslt` getiriyor — `known-issues.md` #8'deki CVE sınıfı buradan geliyor.

**Önce njs kullanılmadığı doğrulandı:**

```
grep -rniE 'js_import|js_set|js_content|js_preload|njs|ngx_http_js_module' \
  infra/nginx/ apps/frontend/nginx.conf apps/frontend/Dockerfile
→ eşleşme yok (exit 1)
```

`apps/frontend/nginx.conf` yalnız `location`/`proxy_pass`/`try_files` kullanıyor. Yalnız `FROM` satırı değişti.

**Çalışma anı doğrulaması — `docker build` geçmesi kanıt sayılmadı.** `alpine-slim`'de eksik bir modül nginx'i çalışma anında düşürür, build'de değil:

- Eski ve yeni base ile iki image derlendi (`cp-fe-before`, `cp-fe-after`).
- Her biri, adı literal olarak `backend` olan bir konteynerle aynı docker network'ünde çalıştırıldı (nginx'in statik `proxy_pass http://backend:8080` upstream'i başlangıçta çözülebilsin — yoksa base'den bağımsız olarak nginx hiç ayağa kalkmaz).
- `curl -sS -o /dev/null -w '%{http_code}' http://localhost:18081/` → **`200`**; SPA fallback rotası da → **`200`**. Gövde gerçek `index.html`.
- Access log: `"GET / HTTP/1.1" 200 1878`, `"GET /some/deep/route HTTP/1.1" 200 1878`. `docker logs`'ta **sıfır hata** (yalnız normal `[notice]` satırları).

**Boyut (ölçüldü, tahmin değil):**

| | önce | sonra |
|---|---|---|
| base `nginx:1.31-alpine*` | 92,8 MB disk / 26,9 MB içerik | **21,8 MB / 6,61 MB** |
| tam `cp-fe-*` build | 143 MB disk / 49,2 MB içerik | **71,9 MB / 29,3 MB** |

⚠️ **Brief'in ~−36 MB tahmini tam image için tutmuyor:** base katmanda yaklaşık doğru, tam image'da içerik kazancı ~20 MB (disk ~71 MB).

### D-32a — cron takvimi ve GitHub'ın OR tuzağı

Microsoft patch'leri ayın **2. Salı**'sı çıkıyor; workflow haftalık Pazar koşuyordu → 5 güne kadar bayat. Mevcut `0 2 * * 0` (Pazar yedek) korundu, `0 3 * * 3` (her Çarşamba) eklendi ve yeni bir kapı adımı konuldu.

**Neden doğrudan cron ifadesi yazılmadı:** GitHub'ın cron parser'ı day-of-month ve day-of-week alanlarının **ikisi de kısıtlıysa OR'lar** — `9-15 * 3` "her 9–15 arası gün **VE** her Çarşamba" olur, kesişim değil. Bu yüzden day-of-month `*` bırakıldı (her Çarşamba, belirsizlik yok) ve gerçek "Patch Tuesday'den sonraki Çarşamba mı" kontrolü job içinde `date -u +%d` 9–15 arası mı diye yapılıyor; `github.event.schedule` ile iki tetikleyici ayırt ediliyor, Pazar yedeği koşulsuz koşuyor.

2026–2027'nin **24 ayı için** 2. Salı'nın hep 8–14 arasına, dolayısıyla sonraki Çarşamba'nın hep 9–15 arasına **ayda tam bir kez** düştüğü Python ile doğrulandı.

### D-32b — .NET 10 LTS: yapılmadı, backlog'a yazıldı

.NET 8 desteği **2026-11-10**'da bitiyor (~3 ay). Brief bunu bu görevde yapmamayı söylüyor. `docs/devops/devops-backlog.md`'ye eklendi: öncelik matrisine satır **#19** (🔴 Kritik, tarihe bağlı) ve yeni **§6.9** bölümü — kapsam gerçek repoya dayandırıldı (7 `.csproj` `net8.0`'da, `ci.yml:170`/`test-deploy.yml:50` dotnet-version pinleri, `:10.0` için yeni mirror adımı, Dockerfile build-arg zinciri), riskler (EF Core/ASP.NET Core major bump regresyonu, SonarAnalyzer/`TreatWarningsAsErrors` etkileşimi), efor tablosu **baştan sona `(tahmin)`** işaretli, toplam **~3,5–5 iş günü (tahmin)**, ve Kasım EOL'ü nedeniyle Ekim sonundan önce bitirme önerisi.

## İlgili User Story / Issue

Faz 4 · F4-03 · **D-31, D-32, D-33** · `known-issues.md` #8

## Değişiklik Tipi

- [x] 🔧 Altyapı (infra)

## Test Edildi mi?

- [x] njs taraması — eşleşme yok
- [x] `alpine-slim` image **ayağa kalktı ve gerçek istekte 200 döndü** (SPA fallback dahil), loglar temiz
- [x] Image boyutu öncesi/sonrası ölçüldü
- [x] `imagetools create` mekanizması yerel registry'de kanıtlandı (bit birebir digest, 3 platform)
- [x] Cron mantığı 24 ay için doğrulandı

## Ekran Görüntüleri

UI değişikliği yok — sunulan `dist` içeriği aynı, yalnız onu sunan nginx imajının tabanı değişti.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi — `docs/devops/devops-backlog.md` §6.9 + matris #19

## Ek Notlar

1. **D-33 gerçek GHCR'da doğrulanmadı** — kural gereği oraya push yasaktı. Mekanizma eşdeğer bir tek kullanımlık registry'de kanıtlandı; **ilk gerçek koşumda teyit edilmeli.**
2. **Cron kapısı yalnız atlıyor, yüksek sesle başarısız olmuyor.** Gelecek bir runner imajında `date -u` beklenmedik davranırsa sessizce yanlış günde koşabilir/koşmayabilir — bir izleyici veya tek satırlık uyarı eklemeye değer.
3. **`known-issues.md` #8 tam kapanmıyor:** `alpine-slim` `libxml2`/`libxslt` CVE sınıfını ortadan kaldırıyor ama backend .NET image CVE'leri ayrı konu (.NET 10 geçişiyle birlikte ele alınmalı).
4. `apps/frontend/Dockerfile`'da yalnız `FROM` satırına dokunuldu — `npm ci`/`COPY package*.json` satırları paralel giden PR'ın alanı. İki PR birlikte merge testinden geçti ve birleşik image derlenip **200 döndürerek** doğrulandı.
