### PR TITLE
.dockerignore hijyeni genişletildi, D-35 gerekçeli ertelendi (D-37)

### DIFF
--- a/apps/backend/.dockerignore
+++ b/apps/backend/.dockerignore
@@ -3,3 +3,6 @@
 **/.vs/
 **/appsettings.Development.Local.json
 **/appsettings.*.Local.json
+
+# Yerel test/coverage ciktilari — COPY . . katmanini gereksiz invalidate etmesin (D-37 hijyeni)
+**/TestResults/

--- a/apps/frontend/.dockerignore
+++ b/apps/frontend/.dockerignore
@@ -2,3 +2,16 @@ node_modules
 dist
 .env*.local
 *.log
+
+# Docker build context için gereksiz — COPY . . katmanini bir test/tool
+# dosyasi degistiginde invalidate etmesin diye disarida tutuluyor (D-37).
+.claude
+.serena
+audit
+coverage
+playwright-report
+test-results
+e2e
+playwright.config.ts
+**/*.test.ts
+**/*.test.tsx


### PR DESCRIPTION
## Özet

Brief iki bulgu içeriyordu: **D-37** (`.dockerignore` boşlukları) ve **D-35** (Docker build'de statik analiz).

**D-37 uygulandı. D-35 gerekçeli olarak ERTELENDİ** — brief'in önerdiği iki çözümün **ikisi de çalışmıyor.** `apps/backend/Directory.Build.props` ve `.github/workflows/test-deploy.yml` **değiştirilmedi**, yani kalite kapısında hiçbir regresyon yok.

### D-35 neden ertelendi — brief'in iki seçeneği de uygulanamaz

| Brief'in önerisi | Gerçek |
|---|---|
| **(a)** `test-deploy.yml` build job'una `needs: [backend-ci]` ekle | **Teknik olarak imkânsız.** `backend-ci` `test-deploy.yml` içinde değil, **ayrı bir workflow** olan `ci.yml:158`'de tanımlı (`grep -rn 'backend-ci' .github/workflows/` → yalnız `ci.yml`'de eşleşme). GitHub Actions `needs:` yalnızca **aynı workflow içindeki** job'lar arasında çalışır, cross-workflow referans desteklemez |
| **(b)** Analyzer'ı yalnız `Debug`/CI konfigürasyonunda koştur | **İşe yaramaz** — brief'in kendi uyarısı doğrulandı. CI gerçekten Release derliyor: `ci.yml:176` `dotnet build cargo-pilot.sln --no-restore --configuration Release` ve `apps/backend/Dockerfile:20` `dotnet publish -c Release`. Analyzer'ı Release'te kapatmak onu hem Docker build'inden **hem de `backend-ci`'nin kendisinden** kaldırır → kapı hiçbir yerde koşmaz |

Üçüncü bir yol — `$(GITHUB_ACTIONS)` ortam değişkeninin Docker build container'ına sızmamasından yararlanıp `Directory.Build.props`'u ona koşullamak — incelendi ve **reddedildi:** `Directory.Build.props:26`'daki açık tasarım niyetini ("Quality gate: tüm uyarılar hata olarak işaretlenir — **lokalde de CI'da da**") bozar; yerel geliştirici build'lerinde de `GITHUB_ACTIONS` tanımsız olduğu için analyzer'ı orada da sessizce kapatırdı. Ayrıca "analyzer kurallarını değiştirmek" kapsam dışı maddesine giriyor.

Brief'in kendi talimatı bu durumu öngörüyordu: *"Bunu gösteremezsen analyzer'ı build'den çıkarma — o zaman yalnız D-37'yi yap ve D-35'i gerekçeli olarak ertele."* Bu izlendi.

**Analyzer'ın hâlâ koştuğunun kanıtı:** backend Docker build çıktısında `warning CS1591: Missing XML comment...` doğrudan `dotnet publish` adımında görünüyor.

### D-37 — `.dockerignore` hijyeni

`apps/frontend/.dockerignore` yalnız 4 satırdı (`node_modules`, `dist`, `.env*.local`, `*.log`). Eklenenler:

```
.claude
.serena
audit
coverage
playwright-report
test-results
e2e
playwright.config.ts
**/*.test.ts
**/*.test.tsx
```

`apps/backend/.dockerignore`'a `**/TestResults/` eklendi (`bin`/`obj`/`.vs` zaten vardı; `.claude`/`.serena`/`audit` backend context'inde isabet etmiyor çünkü repo kökünde, context dışında).

Değeri boyut değil — `COPY . .` katmanının bir test dosyası değiştiğinde **invalidate olmaması**.

| Senaryo | `.dockerignore` | `COPY . .` | Süre | CACHED |
|---|---|---|---|---|
| Önce | eski (4 satır) | **DONE (invalidate)** | 14,75 sn | 7 |
| Sonra | yeni | **CACHED** | **0,56 sn** | 9 |

Ölçüm gerçek içerik değişikliğiyle yapıldı — `touch` BuildKit'in içerik-adresli cache'ini tetiklemiyor, bu da ayrıca doğrulandı.

**Build'i kırmadığının kanıtı:** `tsconfig.json` (`include: ["src"]`, `exclude`'unda zaten `*.test.ts(x)` var) ve `tsconfig.node.json` (`include: [vite.config.ts, vitest.config.ts]`) hiçbiri `e2e/` veya `playwright.config.ts`'i referans etmiyor; `src` içinde test dosyasından import eden production kodu yok (grep boş). Docker build gerçekten koşuldu, TS hatası yok, `exporting to image ... DONE`.

## İlgili User Story / Issue

Faz 4 · F4-04 · **D-37** uygulandı · **D-35** ertelendi

## Değişiklik Tipi

- [x] 🔧 Altyapı (infra)

## Test Edildi mi?

- [x] Docker build başarılı, TS hatası yok
- [x] Test dosyası içerik değişikliği artık `COPY . .` katmanını invalidate etmiyor — ölçüldü
- [x] `.dockerignore`'a eklenen hiçbir satırın build'i kırmadığı tsconfig okunarak doğrulandı
- [x] `Directory.Build.props` ve `test-deploy.yml` **dokunulmadı** — kalite kapısında regresyon yok

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekçe commit gövdesinde)

## Ek Notlar — D-35 backlog'da AÇIK kalmalı

**D-35 "kapandı" diye işaretlenmemeli.** Docker build'inde analyzer'ın tekrar koşması build süresini yakmaya devam ediyor. Gerçek çözüm iki seçenekten biri ve ikisi de ayrı bir karar/PR gerektiriyor:

1. `test-deploy.yml` içine `backend-ci`'nin bir kopyasını (aynı workflow'da, `needs:` ile bağlı) eklemek — build'i seri hâle getirir, süre etkisi ölçülmeli.
2. Workflow'ları `workflow_run` ile zincirlemek — daha büyük mimari değişiklik.

Ayrıca: `apps/backend/.gitignore`'da `TestResults/` zaten vardı ama `.dockerignore`'da yoktu; şu an eklendi. Disk üzerinde fiilen `TestResults/` klasörü yok — test edilemeyen ama zararsız, tutarlılık amaçlı ek.

`apps/frontend/Dockerfile` ve `apps/backend/Dockerfile`'a **hiç dokunulmadı** — paralel giden iki PR'ın alanı.
