### PR TITLE
CI temizliği: needs zinciri, migration-check kapsamı, nightly cache seed, promtail (D-06, D-12, D-13, D-45)

### DIFF
--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -1,0 +1,147 @@
+name: Cache Seed (nightly)
+
+# D-06: Default branch'te (`main`) hiçbir workflow docker build cache'i yazmıyordu.
+# GHA cache okuma kapsamı = kendi ref'i + PR base ref'i + DEFAULT BRANCH. `main`'de
+# cache olmadığı için iş branch'i push'larındaki `cache-from` her seferinde soğuk
+# başlıyordu (ölçüm 2026-08-18: frontend imajı 52–54 sn tam soğuk build).
+#
+# Bu job schedule ile koştuğu için GitHub onu her zaman default branch ref'inde
+# (`refs/heads/main`) çalıştırır; yazılan cache girişleri de o ref'e düşer ve böylece
+# TÜM branch'lerden okunabilir hâle gelir. Ağaç ise `dev`'den checkout edilir: `main`
+# haftada bir terfi ediliyor, `dev` ise iş branch'lerinin gerçek atası.
+#
+# Neden yalnız frontend?
+#   - `apps/frontend/Dockerfile` ayrı bir `deps` stage'inde `npm ci` çalıştırıyor ve
+#     bu katman yalnızca `package*.json` değişince geçersiz oluyor → çapraz-commit
+#     yeniden kullanım değeri yüksek. Frontend scope'ları `mode=max` yazdığı için
+#     (ADR-0007) bu ara katman cache'e gerçekten export ediliyor.
+#   - Backend scope'ları `mode=min` (ADR-0007 kararı). `mode=min` ara stage
+#     katmanlarını export etmez, dolayısıyla backend'i seed etmenin çapraz-commit
+#     değeri ~0 olur — sadece byte ve runner dakikası harcar. Backend'in restore
+#     katmanı #1044 sonrası ayrılabilir hâle geldi; bunu değerlendirmek ADR-0007'nin
+#     revizyonuna bağlı ve bu PR'ın kapsamı dışında.
+#
+# Kota aritmetiği (10 GiB limit, ölçüm 2026-08-18: 278 giriş / 7,78 GiB = %78):
+#   - Tek frontend `mode=max` generation'ı ≈ 250–300 MiB (TAHMİN).
+#   - İlk adım `main` üzerindeki önceki generation'ı siler → kararlı durumda `main`'de
+#     tek generation durur, birikme olmaz. Beklenen kararlı durum ≈ 8,07 GiB (%81).
+#   - Güvenlik valfi: temizlik sonrası kullanım 9 GiB'ı geçiyorsa build atlanır;
+#     seed hiçbir koşulda başka scope'ları tahliye ettirmez.
+#   - `cache-cleanup.yml` 04:35 UTC'de koşuyor; seed 05:10'da, yani temizlikten SONRA.
+#     Nightly olduğu için seed girişleri `MAX_AGE_DAYS=7` yaş kuralına hiç yakalanmaz;
+#     boyut adımı ise `refs/heads/main`'i koruyor.
+
+on:
+  schedule:
+    # cache-cleanup.yml 04:35 UTC'de başlıyor (timeout 10 dk); seed onun ardından.
+    - cron: '10 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cache-seed
+  cancel-in-progress: false
+
+jobs:
+  seed-frontend-cache:
+    name: Frontend Build Cache Seed
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: write
+
+    steps:
+      # Önceki generation silinmeden yazılırsa `main` her gece bir generation daha
+      # biriktirir ve boyut adımı `main`'i koruduğu için hiç tahliye edilmez.
+      # Yalnız buildkit girişleri silinir; CodeQL ve setup-node cache'lerine
+      # dokunulmaz (farklı key prefix'leri).
+      - name: Önceki seed generation'ını sil (refs/heads/main)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          CACHE_IDS=$(gh api \
+            --paginate \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/actions/caches?ref=refs%2Fheads%2Fmain&per_page=100" \
+            --jq '.actions_caches[] | select(.key | startswith("buildkit-blob") or startswith("index-")) | .id' \
+            2>/dev/null || true)
+
+          DELETED=0
+          for ID in ${CACHE_IDS}; do
+            if gh api --method DELETE \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/${REPO}/actions/caches/${ID}" > /dev/null 2>&1; then
+              DELETED=$((DELETED + 1))
+            else
+              echo "Atlandı: cache #${ID} (silinemedi, devam ediliyor)"
+            fi
+          done
+          echo "Önceki generation temizlendi: ${DELETED} giriş silindi."
+
+      - name: Kota güvenlik valfi
+        id: quota
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # 10 GiB kotanın altında 1 GiB manevra payı bırakılır.
+          SEED_ABORT_BYTES: '9663676416' # 9 GiB
+        run: |
+          USAGE=$(gh api "/repos/${REPO}/actions/cache/usage" --jq '.active_caches_size_in_bytes')
+          echo "Temizlik sonrası cache kullanımı: ${USAGE} bayt (eşik: ${SEED_ABORT_BYTES})"
+          if [ "${USAGE}" -ge "${SEED_ABORT_BYTES}" ]; then
+            echo "::warning::Cache kullanımı ${USAGE} bayt — seed atlandı, başka scope'lar tahliye edilmesin."
+            echo "seed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "seed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Cache girişleri workflow'un ref'ine (refs/heads/main) yazılır; checkout
+      # edilen ağaç bunu değiştirmez. `dev` seçilir çünkü iş branch'leri ondan
+      # ayrılıyor, `main` ise haftada bir terfi alıyor.
+      - name: Kodu al (dev ağacı)
+        if: steps.quota.outputs.seed == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: dev
+          persist-credentials: false
+
+      - name: Docker Buildx kur
+        if: steps.quota.outputs.seed == 'true'
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # Tek build, iki `cache-to` hedefi. BuildKit blob'ları içerik adresli olduğu
+      # için aynı ref'e yazılan iki scope aynı blob girişlerini paylaşır; ek maliyet
+      # yalnızca birkaç KiB'lik `index-<scope>` girişidir. Modlar tüketicilerle
+      # birebir aynı (`mode=max`) — ADR-0007 kararına dokunulmuyor.
+      # build-args test-deploy.yml'deki `build` job'u ile hizalı; `deps` stage'i
+      # (asıl kazanç) bu argümanlardan etkilenmiyor.
+      - name: Frontend image build (yalnız cache yaz)
+        if: steps.quota.outputs.seed == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./apps/frontend
+          file: ./apps/frontend/Dockerfile
+          push: false
+          build-args: |
+            VITE_API_BASE_URL=${{ secrets.VITE_API_BASE_URL }}
+            VITE_OAUTH_GOOGLE_URL=${{ secrets.VITE_OAUTH_GOOGLE_URL }}
+            VITE_OAUTH_MICROSOFT_URL=${{ secrets.VITE_OAUTH_MICROSOFT_URL }}
+            VITE_APP_ENV=test
+          cache-from: type=gha,scope=frontend-test
+          cache-to: |
+            type=gha,mode=max,scope=frontend-test
+            type=gha,mode=max,scope=cargo-pilot-frontend-ci
+
+      - name: Kota raporu
+        if: always() && steps.quota.outputs.seed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          USAGE=$(gh api "/repos/${REPO}/actions/cache/usage" --jq '.active_caches_size_in_bytes')
+          COUNT=$(gh api "/repos/${REPO}/actions/cache/usage" --jq '.active_caches_count')
+          echo "Seed sonrası: ${COUNT} giriş / ${USAGE} bayt (10 GiB kotanın $((USAGE * 100 / 10737418240))%'i)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,6 @@ jobs:
     name: Docker Image Build
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [frontend-ci, backend-ci]
     permissions:
       contents: read
       packages: read
@@ -201,6 +200,11 @@ jobs:
     # burada yalnızca ilk kapıda (dev PR'ı) koşar; iş branch'i push'ları test-deploy.yml'in
     # Deploy (Test) job'unda zaten build edildiği için burada tekrar edilmiyor.
     if: github.event_name == 'pull_request' && github.base_ref == 'dev'
+    # D-12: `needs: [frontend-ci, backend-ci]` kaldırıldı. Docker build bu job'ların
+    # çıktısını (artifact, output, cache) kullanmıyor; kendi context'ini kendi build
+    # ediyor. Zincir yalnızca ~2 dk boş bekleme üretiyordu (ölçüm: 4 dev PR koşumunda
+    # 109–132 sn). Kırık CI'da bu job artık boşa koşar; ölçülen bedel 4/41 PR koşumunda
+    # ~3,5 dk runner (beklenen ~0,4 dk/PR), kazanç her PR'da ~2 dk duvar saati.
 
     steps:
       - name: Kodu al

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -53,10 +53,18 @@ jobs:
         run: dotnet tool install --global dotnet-ef
 
       - name: NuGet paketlerini yükle
-        run: dotnet restore cargo-pilot.sln
+        run: dotnet restore apps/backend/CargoPilot.WebAPI/CargoPilot.WebAPI.csproj
 
-      - name: Solution build (migration check için)
-        run: dotnet build cargo-pilot.sln --configuration Release --no-restore
+      # D-13(c): Bu job yalnızca design-time model karşılaştırması yapar; test
+      # projelerinin derlenmesine ihtiyacı yok. Eskiden tüm solution (7 proje)
+      # derleniyordu, `backend-ci` de aynı solution'ı Release'de derliyor.
+      # Artık yalnız `dotnet ef`in gerçekten yüklediği graf derleniyor:
+      # WebAPI (startup) → Infrastructure → Application → Domain.
+      # Configuration bilinçli olarak Release kalıyor: yerel ölçümde Debug hiçbir
+      # şey kazandırmıyor (temiz build 5,97 sn Debug / 6,21 sn Release, aynı 1965
+      # uyarı) — maliyet analyzer'larda, optimizasyonda değil. Bkz. D-35 / #1049.
+      - name: Backend build (migration check için)
+        run: dotnet build apps/backend/CargoPilot.WebAPI/CargoPilot.WebAPI.csproj --configuration Release --no-restore
 
       - name: Pending model değişikliği kontrolü
         # AppDbContextFactory design-time'da connection string gerektirir;

--- a/infra/compose/docker-compose.monitoring.prod.yml
+++ b/infra/compose/docker-compose.monitoring.prod.yml
@@ -30,6 +30,11 @@ services:
       - ../docker/promtail/promtail.prod.yml:/etc/promtail/config.yml:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # D-45: positions.yaml kalıcı olmalı; aksi halde her restart'ta okuma
+      # pozisyonu sıfırlanıp mevcut log dosyaları Loki'ye yeniden gönderiliyor.
+      # Named volume yerine bind mount: üst düzey `volumes:` bloğu monitoring
+      # yığınının diğer servisleriyle paylaşılıyor, burada ona dokunulmuyor.
+      - /var/lib/cargo-pilot/promtail-prod:/var/lib/promtail
     # D-49: promtail imajinda wget/curl/nc yok (debian-slim, minimal). Mevcut olan
     # bash ile /ready ucuna TCP+HTTP isteği atiliyor.
     healthcheck:

--- a/infra/compose/docker-compose.monitoring.test.yml
+++ b/infra/compose/docker-compose.monitoring.test.yml
@@ -30,6 +30,11 @@ services:
       - ../docker/promtail/promtail.test.yml:/etc/promtail/config.yml:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # D-45: positions.yaml kalıcı olmalı; aksi halde her restart'ta okuma
+      # pozisyonu sıfırlanıp mevcut log dosyaları Loki'ye yeniden gönderiliyor.
+      # Named volume yerine bind mount: üst düzey `volumes:` bloğu monitoring
+      # yığınının diğer servisleriyle paylaşılıyor, burada ona dokunulmuyor.
+      - /var/lib/cargo-pilot/promtail-test:/var/lib/promtail
     # D-49: promtail imajinda wget/curl/nc yok (debian-slim, minimal). Mevcut olan
     # bash ile /ready ucuna TCP+HTTP isteği atiliyor.
     healthcheck:

--- a/infra/docker/promtail/promtail.prod.yml
+++ b/infra/docker/promtail/promtail.prod.yml
@@ -2,13 +2,22 @@ server:
   http_listen_port: 9080
   grpc_listen_port: 0
 
+# D-45: positions dosyası kalıcı bir mount altında tutulur. /tmp'te olduğu sürece
+# her promtail restart'ında okuma pozisyonu sıfırlanıyor ve container'ların mevcut
+# log dosyaları baştan gönderiliyordu (Loki'de log tekrarı). Mount tanımı
+# infra/compose/docker-compose.monitoring.prod.yml içindeki promtail servisinde.
 positions:
-  filename: /tmp/positions.yaml
+  filename: /var/lib/promtail/positions.yaml
 
 clients:
   - url: http://cargo-pilot-loki-prod:3100/loki/api/v1/push
 
 scrape_configs:
+  # D-45: Eskiden yalnız backend + frontend toplanıyordu; MSSQL, MinIO ve monitoring
+  # servislerinin logları hiç Loki'ye gitmiyordu. Artık Docker tarafında
+  # `cargo-pilot-` ön ekiyle filtrelenip, relabel aşamasında bu ortamın (`-prod`)
+  # container'ları tutuluyor. Böylece yeni bir servis compose'a eklendiğinde
+  # promtail yapılandırmasını güncellemek gerekmiyor.
   - job_name: docker-containers
     docker_sd_configs:
       - host: unix:///var/run/docker.sock
@@ -16,9 +25,17 @@ scrape_configs:
         filters:
           - name: name
             values:
-              - cargo-pilot-backend-prod
-              - cargo-pilot-frontend-prod
+              - cargo-pilot-
     relabel_configs:
+      # Aynı host'ta test stack'i de koşarsa ortamlar karışmasın.
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/cargo-pilot-.+-prod'
+        action: keep
+      # Promtail kendi loglarını toplamaz: her push için ürettiği satır yeni log
+      # doğurur ve kendi kendini besleyen bir gürültü döngüsü oluşur.
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/cargo-pilot-promtail-prod'
+        action: drop
       - source_labels: ['__meta_docker_container_name']
         regex: '/(.*)'
         target_label: container_name
@@ -27,6 +44,8 @@ scrape_configs:
       - target_label: job
         replacement: cargo-pilot-prod
     pipeline_stages:
+      # Serilog JSON formatı yalnızca backend'de var; eşleşmeyen satırlarda bu
+      # aşama sessizce atlanır ve `level` etiketi oluşmaz.
       - regex:
           expression: '"@l":"(?P<level>[^"]*)"'
       - labels:

--- a/infra/docker/promtail/promtail.test.yml
+++ b/infra/docker/promtail/promtail.test.yml
@@ -2,13 +2,22 @@ server:
   http_listen_port: 9080
   grpc_listen_port: 0
 
+# D-45: positions dosyası kalıcı bir mount altında tutulur. /tmp'te olduğu sürece
+# her promtail restart'ında okuma pozisyonu sıfırlanıyor ve container'ların mevcut
+# log dosyaları baştan gönderiliyordu (Loki'de log tekrarı). Mount tanımı
+# infra/compose/docker-compose.monitoring.test.yml içindeki promtail servisinde.
 positions:
-  filename: /tmp/positions.yaml
+  filename: /var/lib/promtail/positions.yaml
 
 clients:
   - url: http://cargo-pilot-loki-test:3100/loki/api/v1/push
 
 scrape_configs:
+  # D-45: Eskiden yalnız backend + frontend toplanıyordu; MSSQL, ERP MSSQL, MinIO ve
+  # monitoring servislerinin logları hiç Loki'ye gitmiyordu. Artık Docker tarafında
+  # `cargo-pilot-` ön ekiyle filtrelenip, relabel aşamasında bu ortamın (`-test`)
+  # container'ları tutuluyor. Böylece yeni bir servis compose'a eklendiğinde
+  # promtail yapılandırmasını güncellemek gerekmiyor.
   - job_name: docker-containers
     docker_sd_configs:
       - host: unix:///var/run/docker.sock
@@ -16,9 +25,17 @@ scrape_configs:
         filters:
           - name: name
             values:
-              - cargo-pilot-backend-test
-              - cargo-pilot-frontend-test
+              - cargo-pilot-
     relabel_configs:
+      # Aynı host'ta prod stack'i de koşarsa ortamlar karışmasın.
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/cargo-pilot-.+-test'
+        action: keep
+      # Promtail kendi loglarını toplamaz: her push için ürettiği satır yeni log
+      # doğurur ve kendi kendini besleyen bir gürültü döngüsü oluşur.
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/cargo-pilot-promtail-test'
+        action: drop
       - source_labels: ['__meta_docker_container_name']
         regex: '/(.*)'
         target_label: container_name
@@ -27,6 +44,8 @@ scrape_configs:
       - target_label: job
         replacement: cargo-pilot-test
     pipeline_stages:
+      # Serilog JSON formatı yalnızca backend'de var; eşleşmeyen satırlarda bu
+      # aşama sessizce atlanır ve `level` etiketi oluşmaz.
       - regex:
           expression: '"@l":"(?P<level>[^"]*)"'
       - labels:


### PR DESCRIPTION
## Özet

Brief'in yedi kalemi: **D-06, D-09, D-12, D-13(a-d), D-45**. Dördü uygulandı, biri ölçülerek ertelendi, biri dokunulmadı (ADR kararı), biri karar önerisi olarak bırakıldı.

**Private repo bağlamı:** depo private'a taşınacağı için Actions dakikaları ücretli hâle gelecek. Bu PR'daki süre kazançları bu yüzden hijyen değil **maliyet** kalemi.

| Kalem | Sonuç |
|---|---|
| **D-12** gereksiz `needs:` zinciri | ✅ uygulandı — `ci.yml` PR→dev duvar saati **363 → 238 sn (−%34)** |
| **D-13(c)** çifte Release derleme | ✅ uygulandı — `migration-check` yalnız WebAPI grafını derliyor |
| **D-06** default branch'te cache yok | ✅ uygulandı — nightly `cache-seed.yml` |
| **D-45** promtail 2 container topluyor | ✅ uygulandı — tüm `cargo-pilot-*`, positions kalıcı |
| **D-13(b)** NuGet cache | ⏸️ **ölçülerek ertelendi** |
| **D-13(a)** sürüm ayrışması | ✅ **zaten kapalı** (#1032) — doğrulandı, 48/48 SHA-pinli |
| **D-13(d)** frontend `mode=max` | 🚫 **dokunulmadı** — ADR-0007 kararı |
| **D-09** dev kapısındaki docker-build | ❓ **karar önerisi** — aşağıda |

### D-12 — ölçülmüş kazanç

`docker-build`'in `needs: [frontend-ci, backend-ci]` zinciri kaldırıldı. Docker build bu job'ların **çıktısına** bağımlı değildi. Dört gerçek dev PR koşumunun job start/complete zamanlarından:

| run | kapılar biter | docker süre | duvar (önce) | duvar (sonra) | kazanç |
|---|---|---|---|---|---|
| 32144306584 | 130 s | 206 s | 338 s | 206 s | −132 s |
| 32143048100 | 125 s | 201 s | 329 s | 201 s | −128 s |
| 32142894659 | 129 s | 259 s | 391 s | 259 s | −132 s |
| 32139107568 | 106 s | 287 s | 396 s | 287 s | −109 s |

**Ortalama 363 → 238 sn = −125 sn (−%34).**

**Bedeli ölçüldü:** `needs:` kalkınca kırık CI'da docker-build boşa koşar. `ci.yml` PR koşumlarının **4/41'i (%9,8)** fail → beklenen ek maliyet **~0,4 dk runner/PR** (private repoda ≈ $0,003/PR), karşılığı her PR'da ~2 dk duvar saati. Net pozitif.

### D-13(c) — analyzer'ı sessizce kapatmadan tekilleştirme

`migration-check` + `backend-ci` aynı solution'ı Release'de iki kez derliyordu. Konfigürasyon düşürmek yerine **kapsam daraltıldı**: `migration-check` artık `cargo-pilot.sln` (7 proje) yerine `dotnet ef`in gerçekten yüklediği grafı derliyor — `CargoPilot.WebAPI.csproj` → Infrastructure → Application → Domain. Üç test projesi migration kontrolü için gereksizdi.

**Analyzer güvenliği ölçüldü** (yerel, .NET 8.0.424, temiz `bin`/`obj`, `-m:1`):

| Konfigürasyon | Süre | Uyarı sayısı |
|---|---|---|
| Release, tüm solution | 6,21 s | 1965 |
| Debug, tüm solution | 5,97 s | **1965** |
| Release, WebAPI grafı | 5,24 s | — |

Aynı uyarı sayısı → `TreatWarningsAsErrors` + NetAnalyzers + SonarAnalyzer **konfigürasyondan bağımsız** (`Directory.Build.props`'ta `Condition` yok). Yani Debug'a inmek kaliteyi sessizce kapatmazdı **ama hiçbir şey de kazandırmazdı** (%4, gürültü içi) — maliyet analyzer'larda, optimizasyonda değil. Release korundu, **D-35 / #1049 kaydıyla çatışma yok.**

Uçtan uca doğrulandı: daraltılmış restore+build ardından `dotnet ef migrations has-pending-model-changes --configuration Release` → *"No changes have been made to the model since the last migration."*

Tam tekilleştirme (tek Release build) **açık kaldı**: iki job farklı workflow'da, `needs:` çapraz-workflow çalışmıyor (#1049'da kayıtlı). `migration-check`'i `backend-ci` içine taşımak `push test` kapsamını kaybettirir ve deploy kapısının `needs:` telini söker.

### D-13(b) — NuGet cache ölçülerek ertelendi

| Ölçüm | Değer |
|---|---|
| `dotnet restore` gerçek süresi | **8 s** (backend-ci) / 9 s (migration-check) — kazanılacak tavan |
| NuGet ayak izi | 157 paket / 551,4 MiB açılmış |
| Tahmini cache girişi (zstd) | ~180–220 MiB **(tahmin)** |
| ~27 aktif ref × ~200 MiB | ≈ **5,4 GiB (tahmin)** → 7,78 + 5,4 = **13,2 GiB, kotayı %32 aşar** |
| Cache indirme+açma maliyeti | 8–12 s → kazanılan 8 s'ye karşı **net ≈ 0 veya negatif** |

**Sert engel:** `setup-dotnet`'in `cache: true` girdisi `**/packages.lock.json` ister; repoda **hiç yok** (`find` boş). Etkinleştirmek `RestorePackagesWithLockFile` + 7 lock dosyası demek — bu PR'ın kapsamı dışı.

Ayrıca `cache-cleanup.yml`'nin boyut adımı yalnız `buildkit-blob` prefix'ini siliyor → NuGet girişleri **hiç geri kazanılamaz**. DEVIR notundaki "YAPMA" kaydı ve ADR-0007'nin reddedilen alternatifler listesi **hâlâ geçerli**.

**Yeniden açma koşulu:** repo `packages.lock.json`'a geçerse **ve** kota ~5 GiB altına inerse.

### D-06 — nightly cache seed

Yeni `.github/workflows/cache-seed.yml`. Ölçülen sorun: `refs/heads/dev` üzerinde **0 cache girişi** var, yani `cache-from` iş branch'lerinde hep soğuk başlıyor.

Tasarım kararları:
- `schedule: '10 5 * * *'` — `cache-cleanup.yml` 04:35'te koşuyor (timeout 10 dk), seed **sonra** yazıyor
- Schedule her zaman default branch ref'inde koşar → girişler `refs/heads/main`'e düşer; GHA okuma kapsamı default branch'i içerdiği için **her branch'ten okunur**. Ağaç `dev`'den checkout ediliyor (`main` haftada bir terfi ediyor, iş branch'lerinin gerçek atası `dev`)
- **Yalnız frontend.** Frontend `deps` stage'i (`npm ci`) `package-lock.json` değişmedikçe geçersiz olmaz ve `mode=max` onu export ediyor → çapraz-commit değeri var. Backend scope'ları `mode=min`; `mode=min` ara stage katmanlarını export etmediği için backend seed'inin değeri ~0 olur
- **Tek build, iki `cache-to`** (`frontend-test` + `cargo-pilot-frontend-ci`) — buildkit blob'ları içerik adresli, aynı ref'e yazıldığı için iki scope aynı blob'ları paylaşır; ek maliyet birkaç KiB `index-<scope>`. Modlar tüketicilerle birebir aynı → **ADR-0007'ye dokunulmuyor**

**Kota koruması iki katmanlı:**
1. Her koşumda `refs/heads/main` üzerindeki `buildkit-blob*`/`index-*` girişleri **önce silinir** → kararlı durumda tek generation, birikme yok (codeql ve node-cache prefix'leri filtre dışı, jq yerel test edildi)
2. Temizlik sonrası kullanım **9 GiB'ı geçerse build atlanır** ve warning basar — seed hiçbir koşulda başka scope'ları tahliye ettirmez

Kota aritmetiği: tek frontend `mode=max` generation'ı ≈ **250–300 MiB (tahmin)**; kararlı durum ≈ **8,07 GiB / 10 GiB ≈ %81 (tahmin)**. Runner maliyeti ~2 dk/gece ≈ 60 dk/ay **(tahmin)**; karşılığı ölçülen 52–54 sn'lik soğuk frontend build'in ~25–30 sn'ye inmesi × ~15 push/gün ≈ 200 dk/ay → net ≈ **3:1**.

### D-45 — promtail, canlı Loki ile doğrulandı

Docker filtresi `cargo-pilot-` ön ekine açıldı, ortam ayrımı relabel `keep` ile (`/cargo-pilot-.+-test|prod`), promtail kendi loglarını `drop` ediyor. `positions.filename` `/tmp/positions.yaml` → `/var/lib/promtail/positions.yaml`, compose'da **bind mount** (`/var/lib/cargo-pilot/promtail-{test,prod}`).

Named volume yerine bind mount seçildi: üst düzey `volumes:` bloğu #1053'ün (F5-03) servisleriyle paylaşılıyor, oraya dokunulmadı.

Gerçek promtail 2.9.4 + Loki 2.9.4 ile doğrulama (sonra temizlendi):
- `promtail -check-syntax` her iki dosyada: *"Valid config file! No syntax issues found"*
- Loki'ye ingest edilen `container_name`: `cargo-pilot-dummy-test`, **`cargo-pilot-loki-test`**, `cargo-pilot-serilog-test` → **monitoring container'ı artık toplanıyor**, yeni servis config değişikliği olmadan otomatik keşfediliyor
- `cargo-pilot-dummy-prod` **ingest edilmedi** (ortam `keep` çalışıyor)
- `cargo-pilot-promtail-test` **ingest edilmedi** (self-drop çalışıyor)
- Serilog satırından `level="Error"` çıkarıldı, düz metin satırlar hatasız geçti
- `positions.yaml` mount altında yazıldı (363 B)

## İlgili User Story / Issue

Faz 6 · F6-01 · **D-06, D-09, D-12, D-13, D-45**

## Değişiklik Tipi

- [x] 🔧 Altyapı (infra)

## Test Edildi mi?

- [x] `python3 -c "import yaml,glob;[yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"` → yaml ok (10 workflow)
- [x] `docker compose config` her iki monitoring dosyasında → exit 0
- [x] `grep -rnE 'uses:' .github/workflows/ | grep -vE '@[0-9a-f]{40}'` → **boş, 48/48 SHA-pinli**
- [x] `git diff origin/dev..HEAD | grep 'mode='` → **boş** (ADR-0007'ye dokunulmadı)
- [x] promtail canlı Loki ile doğrulandı (yukarıda)
- [x] `dotnet ef migrations has-pending-model-changes` daraltılmış graf ile geçti
- [x] Cache kotası ölçüldü: 278 giriş / 7,78 GiB / 10 GiB = %77,8

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekçeler workflow ve config yorumlarında)

## Ek Notlar — üç şey karar bekliyor

### 1 · D-09: dev kapısındaki `docker-build` kaldırılsın mı? (öneri: **kaldırılsın**)

Kanıt: iş branch'i push'unda `test-deploy.yml`'nin `deploy` job'u **iki imajı da build ediyor** (`load: true`) **ve compose'la ayağa kaldırıp healthcheck'ten geçiriyor** (ölçüm: backend 59 s, frontend 52–54 s). Bu, `ci.yml`'nin yalnız-build job'undan **kesin olarak daha güçlü** bir kapı. Kaynak seviyesi kırıklıkları da zaten yakalanıyor (frontend `npm run build` → frontend-ci, backend derleme → backend-ci).

Dev kapısındaki build'in **tek özgün katkısı merge commit'inin imaj build'i** — o da PR→test'te `build` job'u tarafından yine merge commit üzerinde yakalanıyor. Katkı "bir kapı erken tespit"ten fazlası değil.

Kazanç: dev PR başına **238 s runner + 238 s duvar saati**. Risk: imaj katmanı regresyonu dev yerine test kapısında görünür.

*Ara yol:* job'u bir `changed-files` adımıyla `if:`'e bağlayıp yalnız imaj-katmanı girdileri değişince koşturmak. Uyarı: `pull_request` üstündeki `paths:` **workflow'un tamamını** filtreler, tek job'u filtrelemez — yeni bir action bağımlılığı gerekir.

### 2 · ⚠️ ADR-0007 kendi yeniden-değerlendirme koşulunu tetikledi

ADR-0007 satır 61-62 aynen şunu yazıyor:

> *"Backend Dockerfile'ı ileride `restore` ve `publish`'i ayrı `RUN` katmanlarına bölerse bu madde yeniden değerlendirilmelidir — o zaman `mode=max`'ın gerçek bir karşılığı olur."*

**#1047 tam bunu yaptı.** `apps/backend/Dockerfile` artık `:21 RUN … dotnet restore` ve `:37 RUN … dotnet publish --no-restore` ayrı katmanları içeriyor. Yani ADR-0007'nin **karar #1'inin (backend `mode=min`) gerekçesi düştü**; karar #2 (frontend `mode=max`) tam geçerli.

Bu PR'da **değiştirilmedi** — kabul edilmiş ADR gövdesi düzenlenmez, yeni ADR yazılır. Bu ayrıca backend cache seed'inin de ön koşulu.

### 3 · İki yeni bulgu (backlog'a girmeli)

- **Kotanın en büyük kalemi buildkit değil:** `node-cache-Linux-x64-npm-*` → **54 giriş / 4,04 GiB = kotanın %52'si**. Ve `cache-cleanup.yml`'nin boyut adımı yalnız `select(.key|startswith("buildkit-blob"))` filtresiyle çalıştığı için **bunlara hiç dokunamıyor**. Kotanın yarısı temizlik kör noktasında.
- **`ci.yml`'de `concurrency` grubu yok.** Aynı branch'e hızlı ardışık push'lar tam CI'ı baştan koşuyor (`feat/algoritma-arama-katmani`'nda 8 koşum, ikisi saniyeler arayla). Private repoda bu doğrudan fatura: `concurrency: {group: ci-${{ github.ref }}, cancel-in-progress: true}`. Bu PR'ın kapsamı dışı.

Ayrıca: **promtail `mem_limit: 128m`** artık 2 yerine ~8 container scrape edecek — #1044'ün alanı olduğu için dokunulmadı, gözden geçirilmeli.
