### PR TITLE
Secret envanteri 22 ad üzerinden çıkarıldı, geçiş listesi eklendi (D-15)

### DIFF
--- a/docs/devops/secret-management.md
+++ b/docs/devops/secret-management.md
@@ -1,8 +1,17 @@
 # Secret Yönetimi
 
-**Son güncelleme:** 2026-08-13 · **Durum:** Aktif · **Görev:** US-D23-S
+**Son güncelleme:** 2026-08-18 · **Durum:** Aktif · **Görev:** US-D23-S, F8-04
 
 Bu doküman repoya girmemesi gereken secret'ları, ortam dosyalarının konumunu, GHCR/CI-CD secret'larını ve bir secret ihlali durumunda izlenecek adımları açıklar.
+
+{% hint style="danger" %}
+**F8-04 envanteri (2026-08-18):** Workflow'lar **22** benzersiz `secrets.*` adına atıfta
+bulunuyor, repoda **6** tanesi tanımlı. Denetimde (F8 audit) bu oran 19/8'di —
+**makas kapanmadı, açıldı.** Aşağıdaki "Envanter ve Sınıflandırma" bölümü 22 adın tamamını
+kapsar. Bu görev sırasında hiçbir secret DEĞERİ okunmadı veya yazılmadı; yalnızca
+"tanımlı/tanımsız" bilgisiyle çalışıldı (`gh secret list`, `gh api .../environments`,
+workflow kaynak kodu, `gh run view --log` maskeleme durumu).
+{% endhint %}
 
 ---
 
@@ -101,6 +110,46 @@ ASP.NET Core ortam değişkenlerini `appsettings.json` üstüne otomatik uygular
 
 GitHub → Settings → Secrets and variables → Actions
 
+### Envanter ve Sınıflandırma (22 ad — 2026-08-18)
+
+Sınıflar: **tanımlı** (repo seviyesinde `gh secret list`'te görünüyor) · **tanımsız-fallback'li**
+(secret yok ama workflow'da `secrets.X || 'literal'` deseni var, iş yeşil geçer ama fallback
+değeri fiilen kullanılır) · **tanımsız-boş** (fallback yok, değer boş string olarak enjekte
+edilir, iş kırılmaz ama özellik sessizce bozulur) · **tanımsız-iş atlanıyor** (workflow kendi
+kontrolüyle adımı atlar, iş yeşil kalır) · **tanımsız-iş kırılıyor** (fallback yok, iş kırmızı
+biter) · **otomatik** (GitHub tarafından sağlanır, repo secret olarak tanımlanmaz) ·
+**variable olmalı** (gizli değil, secret olarak tutmak yanlış).
+
+| # | Ad | Kullanıldığı yer | Tanımlı mı | Tanımsızsa sonuç | Sınıf |
+|---|----|--------------------|:----------:|-------------------|-------|
+| 1 | `JWT_SECRET` | `test-deploy.yml:181,300` | ✅ | — | tanımlı |
+| 2 | `PROMOTION_PAT` | `promote.yml:71,142` | ✅ | — | tanımlı |
+| 3 | `TEST_SSH_HOST` | `test-deploy.yml:435`, `rollback.yml:68` | ✅ | — | tanımlı |
+| 4 | `TEST_SSH_PRIVATE_KEY` | `test-deploy.yml:437`, `rollback.yml:70` | ✅ | — | tanımlı |
+| 5 | `VITE_API_BASE_URL` | `test-deploy.yml:139,232` (frontend build-arg) | ✅ | — | tanımlı → **variable olmalı** |
+| 6 | `VITE_OAUTH_GOOGLE_URL` | `test-deploy.yml:140,233` (frontend build-arg) | ✅ | — | tanımlı → **variable olmalı** |
+| 7 | `VITE_OAUTH_MICROSOFT_URL` | `test-deploy.yml:141,234` (frontend build-arg) | ❌ | `--build-arg VITE_OAUTH_MICROSOFT_URL=` boş enjekte edilir (log'da doğrulandı); Microsoft OAuth butonu sessizce boş URL'e gider | tanımsız-boş → **variable olmalı** |
+| 8 | `TEST_MSSQL_SA_PASSWORD` | `test-deploy.yml:172,293` | ❌ | hardcoded fallback kullanılır (D-15) | tanımsız-fallback'li |
+| 9 | `TEST_MINIO_ROOT_USER` | `test-deploy.yml:175,296` | ❌ | hardcoded fallback kullanılır (D-15) | tanımsız-fallback'li |
+| 10 | `TEST_MINIO_ROOT_PASSWORD` | `test-deploy.yml:176,297` | ❌ | hardcoded fallback kullanılır (D-15) | tanımsız-fallback'li |
+| 11 | `SEED_DEFAULT_ADMIN_PASSWORD` | `test-deploy.yml:179,299,388` (ayrıca E2E admin login) | ❌ | hardcoded fallback kullanılır (D-15) | tanımsız-fallback'li |
+| 12 | `RESEND_API_KEY` | `test-deploy.yml:183` (`deploy` job; `e2e-smoke` job'da zaten literal, secret'a hiç bakmıyor) | ❌ | hardcoded fallback kullanılır (D-15) | tanımsız-fallback'li |
+| 13 | `RESEND_FROM_EMAIL` | `test-deploy.yml:184` | ❌ | hardcoded fallback kullanılır | tanımsız-fallback'li (gizli değil, variable adayı) |
+| 14 | `RESEND_FROM_NAME` | `test-deploy.yml:185` | ❌ | hardcoded fallback kullanılır | tanımsız-fallback'li (gizli değil, variable adayı) |
+| 15 | `PASSWORD_RESET_FRONTEND_URL` | `test-deploy.yml:186` | ❌ | hardcoded fallback kullanılır | tanımsız-fallback'li (gizli değil, variable adayı) |
+| 16 | `EMAIL_CHANGE_FRONTEND_CONFIRM_URL` | `test-deploy.yml:187` | ❌ | hardcoded fallback kullanılır | tanımsız-fallback'li (gizli değil, variable adayı) |
+| 17 | `GITHUB_TOKEN` | `test-deploy.yml`, `ci.yml`, `promote.yml`, `release-tag.yml`, `cache-cleanup.yml`, `sync-base-images.yml` | n/a | — | **otomatik** — GitHub her run'da otomatik sağlar, `gh secret list` göstermez, repo secret olarak eklenmez |
+| 18 | `PROD_SSH_HOST` | `rollback.yml:91` | ❌ | fallback yok → `prod` hedefiyle manuel dispatch edilirse ssh-action adımı kırmızı biter | tanımsız-iş kırılıyor → **environment'a taşınmalı (`prod`)** |
+| 19 | `PROD_SSH_PRIVATE_KEY` | `rollback.yml:93` | ❌ | aynı — iş kırılıyor | tanımsız-iş kırılıyor → **environment'a taşınmalı (`prod`)** |
+| 20 | `ALGO_SUITE_API_URL` | `algorithm-suite.yml:71,104` | ❌ | `if [ -z ... ]` kontrolü `configured=false` üretir, adım atlanır, iş **yeşil** kalır (satır 66-67 yorumu: "zamanlanmış iş yapılandırılmamış diye kırmızı yanmamalı") | tanımsız-iş atlanıyor (tanımlanması **F8-03** kapsamında, kapsam dışı) |
+| 21 | `ALGO_SUITE_EMAIL` | `algorithm-suite.yml:72,105` | ❌ | aynı — atlanıyor | tanımsız-iş atlanıyor (F8-03) |
+| 22 | `ALGO_SUITE_PASSWORD` | `algorithm-suite.yml:73,106` | ❌ | aynı — atlanıyor | tanımsız-iş atlanıyor (F8-03) |
+
+**Ölü ad:** Bu 22'nin içinde yok. `TEST_GHCR_PAT`/`TEST_GHCR_USER` zaten workflow'lardan
+çıkarılmış ve repodan silinmiş durumda (aşağıdaki "Kaldırılan secret'lar" bölümü zaten
+güncel) — bu envanterde ayrıca listelenmiyor çünkü artık hiçbir `.github/workflows/*.yml`
+onlara atıfta bulunmuyor.
+
 ### Sunucu erişimi
 
 | Secret | Nerede kullanılıyor | Ne işe yarar |
@@ -110,11 +159,47 @@ GitHub → Settings → Secrets and variables → Actions
 | `PROD_SSH_HOST` | `rollback.yml` | Prod sunucusu IP'si — **henüz tanımlı değil**, prod stack kurulmadı |
 | `PROD_SSH_PRIVATE_KEY` | `rollback.yml` | Prod SSH deploy key'i — **henüz tanımlı değil** |
 
-### Geçici stack (runner içi doğrulama)
+{% hint style="warning" %}
+**Environment'a taşıma önerisi:** `PROD_SSH_HOST` / `PROD_SSH_PRIVATE_KEY` repo seviyesi
+yerine `prod` GitHub environment'ına tanımlanmalı. Bugün `prod` environment'ı
+`required_reviewers` korumasıyla var ama içinde **hiç secret yok** — yani koruma şu an
+yalnızca boş bir onay diyaloğu, korunan bir kaynak yok. Bu iki secret `prod`'a taşınınca
+required-reviewer onayı gerçek bir kapıya dönüşür: prod sunucusuna SSH erişimi, onaysız
+tetiklenemez hâle gelir. (`test`, `prod`, `copilot` — üç environment de bugün 0 secret
+içeriyor; bu öneri yalnızca `PROD_SSH_*` içindir.)
+{% endhint %}
 
-Bu değerler `test-deploy.yml`'in `deploy` job'unda runner üzerinde ayağa kaldırılan geçici
-stack'e verilir. Hepsinin workflow'da CI fallback'i vardır; secret tanımlı değilse doğrulama
-yine de koşar.
+### Geçici stack (runner içi doğrulama) — D-15
+
+Bu değerler `test-deploy.yml`'in `deploy` ve `e2e-smoke` job'larında **runner üzerinde
+ayağa kaldırılan geçici stack'e** verilir; bu stack her run'ın sonunda `docker compose down -v`
+ile yok edilir (satır 273) — **gerçek test sunucusunu etkilemez**, sunucudaki değerler
+`/opt/cargo-pilot/infra/env/.env.test`'ten gelir (bkz. aşağıdaki bilgi kutusu).
+
+{% hint style="danger" %}
+**D-15'in gerçek kapsamı (2026-08-18 doğrulandı):** Aşağıdaki 7 secret'ın hiçbiri repoda
+tanımlı değil (`gh secret list`) ve hepsinin workflow'da `secrets.X || 'literal'` fallback'i
+var (`test-deploy.yml:172,175,176,179,183-187,293,296,297,299`). Bu, teoride bir olasılık
+değil — `gh run view --log` ile alınan gerçek bir run'da (2026-08-18, `test` dalı push'u)
+bu fallback literal'lerin **maskelenmeden** log'a düştüğü doğrulandı: değerler `secrets.*`
+context'inden gelmediği için GitHub bunları secret olarak tanımıyor ve maskelemiyor. Yani:
+
+- `MSSQL_SA_PASSWORD`, `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`,
+  `Seed__DefaultAdminPassword`, `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `RESEND_FROM_NAME`
+  **her koşuda** workflow kaynağındaki hardcoded fallback değerleriyle çalışıyor — secret
+  hiç tanımlanmamış olsa da iş yeşil geçiyor, bu da eksikliğin fark edilmesini engelliyor.
+- Etkilenen job'lar: `deploy` (satır 165-187) ve `e2e-smoke` (satır 287-310); ikisi de
+  yalnızca GitHub Actions runner'ı üzerinde yaşayan, işten sonra silinen geçici bir
+  container stack'i besliyor. **Gerçek test sunucusuna deploy** (`deploy-test-server` job'u,
+  satır 414-538) bu secret'lara hiç bakmıyor; SSH ile bağlanıp sunucudaki
+  `infra/env/.env.test` dosyasını kullanıyor.
+- Sonuç: fallback parolalar "prod'a sızmış bir sır" değil, ama **repoda açık, tahmin
+  edilebilir, sabit parolalarla çalışan bir CI deseni** — secret mekanizmasının amacını
+  fiilen boşaltıyor. Repo private olsa da bu davranış aynen kalır (D-15, kapsam dışı
+  değişiklik: fallback'leri koddan kaldırmak bu envanterden SONRAKİ ayrı bir iştir).
+- `JWT_SECRET` bu 7'nin dışında: o **tanımlı** (yukarıdaki envanter tablosuna bakın), yani
+  gerçek değeri kullanılıyor, fallback'e düşmüyor.
+{% endhint %}
 
 | Secret | Nerede kullanılıyor | Ne işe yarar |
 |--------|---------------------|--------------|
@@ -147,6 +232,14 @@ doğrulama stack'ini besler.
 `VITE_*` değerleri **secret sınıfı değildir.** Vite bunları build sırasında bundle'a gömer;
 değerler hem tarayıcıya inen JS'te hem de public GHCR imajının içinde görünür. Bunları repo
 **variable**'ına taşımak önerilir — secret olarak tutmak yanlış bir gizlilik beklentisi yaratır.
+
+**Durum (2026-08-18):** `VITE_API_BASE_URL` ve `VITE_OAUTH_GOOGLE_URL` bugün tanımlı ama
+secret olarak; `VITE_OAUTH_MICROSOFT_URL` hiç tanımlı değil ve `test-deploy.yml`'de fallback'i
+de yok, bu yüzden frontend build-arg'ına **boş string** olarak geçiyor (Microsoft OAuth
+butonu sessizce boş URL'e gider). Üçü de repo **variable**'ına taşınmalı: (1) gizlilik
+sağlamıyorlar, (2) variable'a taşınınca PR'lardan/fork'lardan da okunabilir hâle gelir ki
+zaten public bilgi, (3) Actions log'unda `***` ile maskelenmedikleri için debug daha kolay
+olur.
 {% endhint %}
 
 ### Otomasyon
@@ -164,9 +257,13 @@ değerler hem tarayıcıya inen JS'te hem de public GHCR imajının içinde gör
 | `TEST_GHCR_USER` | ❌ Kaldırıldı — aynı gerekçe, 2026-08-13'te repodan silindi |
 
 {% hint style="info" %}
-**GitHub Environment'ları (2026-08-13):** Repoda `test` ve `prod` environment'ları oluşturuldu;
-`prod` required-reviewer onayı ile korunuyor. SSH secret'larının repo seviyesinden ilgili
-environment seviyesine taşınması önerilir — **henüz yapılmadı**, secret'lar hâlâ repo seviyesinde.
+**GitHub Environment'ları (2026-08-18 doğrulandı):** Repoda üç environment var — `test`,
+`prod`, `copilot`. `prod` `required_reviewers` korumasıyla tanımlı (tek reviewer). **Üçünde
+de 0 secret var** (`gh api repos/.../environments/{env}/secrets --jq .total_count` → hepsi
+`0`) — bugün her şey repo seviyesinde duruyor. Bu yüzden `prod` üzerindeki required-reviewer
+koruması şu an korunan hiçbir kaynağı yok; yalnızca boş bir onay diyaloğu. SSH secret'larının
+repo seviyesinden ilgili environment seviyesine taşınması önerilir (bkz. yukarıdaki
+"Environment'a taşıma önerisi" kutusu) — **henüz yapılmadı**.
 {% endhint %}
 
 ---
@@ -193,6 +290,49 @@ environment seviyesine taşınması önerilir — **henüz yapılmadı**, secret
 {% hint style="warning" %}
 Domain doğrulanana kadar `RESEND_FROM_EMAIL` olarak yalnızca `onboarding@resend.dev` kullanılabilir ve yalnızca hesap sahibinin adresine gönderilebilir.
 {% endhint %}
+
+---
+
+## Yeni Repoya Geçiş — Minimum Secret Kümesi
+
+Bu repo private bir repoya, **git geçmişi taşınmadan, sıfırdan ilk commit** olarak
+aktarılacak. Yeni repoda **hiçbir secret olmayacak** — bugünkü 6 tanımlı secret dahil hepsi
+elle yeniden girilmeli. Aşağıdaki liste, `ci.yml` + `test-deploy.yml` + `promote.yml`'in
+ilk günden çalışması için gereken minimumu, öncelik sırasına göre verir.
+
+### Zorunlu — bunlar olmadan ilgili workflow amacını yerine getiremez
+
+| Secret/Ayar | Neden zorunlu |
+|---|---|
+| `PROMOTION_PAT` | `promote.yml` bunu `-z` kontrolüyle ister; tanımsızsa iş `exit 1` ile kırmızı biter (fallback yok, `GITHUB_TOKEN` ile merge test/main push-tetiklemeli workflow'ları tetiklemediği için bilinçli tasarım) |
+| `TEST_SSH_HOST`, `TEST_SSH_PRIVATE_KEY` | `test-deploy.yml`'in `deploy-test-server` job'u ve `rollback.yml` bunları fallback'siz kullanır; tanımsızsa gerçek sunucuya deploy/rollback kırılır |
+| GHCR Actions izinleri (secret değil, repo ayarı) | `ci.yml`/`test-deploy.yml` GHCR login'i `secrets.GITHUB_TOKEN` ile yapar (otomatik) — yeni repoda Settings → Actions → Workflow permissions → "Read and write" işaretli olmalı, aksi hâlde `packages: write` gerektiren push adımları 403 ile kırılır |
+
+### Güçlü öneri — tanımsız olsa da iş yeşil kalır ama gerçek işlev bozulur
+
+| Secret | Tanımsızsa ne olur (bugünkü davranış) |
+|---|---|
+| `JWT_SECRET` | Fallback var (`ci-test-secret-key-...`); yeni repoda "sıfırdan temiz başlangıç" fırsatını kaçırmamak için gerçek bir değerle tanımlanmalı |
+| `VITE_API_BASE_URL` | Fallback yok, boş build-arg → deploy edilen frontend gerçek API'ye bağlanamaz |
+| `VITE_OAUTH_GOOGLE_URL` | Aynı — Google login butonu boş URL'e gider |
+| `TEST_MSSQL_SA_PASSWORD`, `TEST_MINIO_ROOT_USER`, `TEST_MINIO_ROOT_PASSWORD`, `SEED_DEFAULT_ADMIN_PASSWORD` | Fallback var (D-15) — yeni repoda bu hardcoded fallback'lerle başlamak yerine gerçek değer tanımlamak, deseni ilk günden kırar |
+| `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `RESEND_FROM_NAME`, `PASSWORD_RESET_FRONTEND_URL`, `EMAIL_CHANGE_FRONTEND_CONFIRM_URL` | Fallback var; e-posta gönderimi gerçek test edilmek isteniyorsa tanımlanmalı, aksi hâlde placeholder ile devam edilebilir |
+
+### İlk günden gerekmez
+
+| Secret | Neden erteleniyor |
+|---|---|
+| `PROD_SSH_HOST`, `PROD_SSH_PRIVATE_KEY` | Yalnızca `rollback.yml`'in manuel `prod` dispatch'i kullanır; prod sunucusu kurulana kadar anlamsız — kurulduğunda repo secret'ı olarak değil, doğrudan `prod` environment secret'ı olarak tanımlanmalı |
+| `ALGO_SUITE_API_URL`, `ALGO_SUITE_EMAIL`, `ALGO_SUITE_PASSWORD` | Tanımlanması **F8-03** kapsamında; workflow zaten tanımsızlığı zarifçe atlıyor |
+| `VITE_OAUTH_MICROSOFT_URL` | Bugün de tanımlı değil, Microsoft OAuth henüz devrede değilse ertelenebilir — ama **variable** olarak eklenmeli, secret olarak değil |
+
+### Variable olarak (secret olarak DEĞİL) taşınmalı
+
+`VITE_API_BASE_URL`, `VITE_OAUTH_GOOGLE_URL`, `VITE_OAUTH_MICROSOFT_URL` — bkz. yukarıdaki
+"Frontend build-time (VITE)" bölümü. Bu üçü yeni repoda hiç secret olarak girilmemeli,
+doğrudan repo/environment **variable**'ı olarak eklenmeli; bu hem yanlış gizlilik beklentisini
+önler hem de geçiş sırasında "bunu secret mi variable mı gireyim" belirsizliğini ortadan
+kaldırır.
 
 ---
 


### PR DESCRIPTION
## Özet

Workflow'lar **22** benzersiz secret adına atıfta bulunuyor; tanımlı olan **6**. Denetimde bu oran 19/8'di — **makas kapanmadı, açıldı.** Bu PR envanteri çıkarıp `secret-management.md`'yi gerçek durumla hizalıyor.

**Private repo bağlamı — bu görevin değerini değiştiren şey:** depo private bir repoya, geçmiş olmadan, sıfırdan ilk commit olarak taşınacak. Yani **yeni repoda hiçbir secret olmayacak; 22 referansın gerekli olanları elle yeniden tanımlanacak.** Bu envanter bu yüzden yalnız temizlik değil, **geçiş kontrol listesi**. Dokümana bunun için ayrı bir bölüm eklendi.

### 22 adın sınıflandırması

| Sınıf | Sayı | Not |
|---|---|---|
| Tanımlı | 6 | 3'ü `VITE_*` → **variable olmalı** |
| Tanımsız, fallback'li | 9 | D-15'in gerçek kapsamı |
| Tanımsız, boş bake ediliyor | 1 | `VITE_OAUTH_MICROSOFT_URL` |
| Tanımsız, iş atlanıyor | 3 | `ALGO_SUITE_*` (graceful skip, F8-03 kapsamı) |
| Tanımsız, iş kırılıyor | 2 | `PROD_SSH_*` |
| Otomatik | 1 | `GITHUB_TOKEN` |
| **Toplam** | **22** | 22 içinde ölü ad yok |

Tanımlı 6: `JWT_SECRET`, `PROMOTION_PAT`, `TEST_SSH_HOST`, `TEST_SSH_PRIVATE_KEY`, `VITE_API_BASE_URL`, `VITE_OAUTH_GOOGLE_URL`.

### D-15'in gerçek kapsamı — ampirik olarak daraltıldı

2026-08-18 tarihli bir `test` branch koşumunun log'u incelendi (`gh run view --log`):

- Tanımlı 6 secret log'da doğru şekilde **`***` maskeli** görünüyor.
- `TEST_MSSQL_SA_PASSWORD`, `TEST_MINIO_ROOT_USER/PASSWORD`, `SEED_DEFAULT_ADMIN_PASSWORD`, `RESEND_API_KEY/FROM_EMAIL/FROM_NAME` fallback literalleri **maskesiz** görünüyor — yani GitHub secret'ı değil, workflow'daki düz metin.

**Ama maruziyet sanıldığından küçük:** bu değişkenler yalnız `test-deploy.yml`'nin `deploy` ve `e2e-smoke` job'larındaki **runner-içi geçici Docker stack**'ini besliyor ve job sonunda `docker compose down -v` ile yok ediliyor. Gerçek test sunucusuna deploy eden `deploy-test-server` job'u bu değişkenlere **hiç dokunmuyor** — SSH ile girip sunucunun kendi `.env.test`'ini kullanıyor.

**Asıl zarar parola sızması değil, gapı gizlemesi:** secret hiç tanımlanmadığı hâlde CI yeşil kalıyor, bu yüzden eksiklik fark edilmiyor. **Ve bu geçişte tuzağa dönüşüyor** — yeni repoda "CI yeşil, demek ki secret'lar tamam" sanılabilir.

### "API'nin göstermediği tanım var mı?" bulmacası çözüldü

Denetim, `test-deploy.yml`'nin `RESEND_*` ve `TEST_MSSQL_SA_PASSWORD` kullanmasına rağmen %97 yeşil koşmasını bir bilinmeyen olarak bırakmıştı. **Gizli tanım yok:** `||` fallback deseni yeşil oranının tamamını açıklıyor. Hem `gh secret list` hem maskelenmemiş log çıktısı bunu doğruluyor.

### Environment'lar

Üç environment tanımlı: `test`, `prod` (required_reviewers, 1 kişi), `copilot` — **üçünde de 0 secret** (`environments/{env}/secrets --jq .total_count` → 0/0/0).

Yani `prod`'un onay koruması bugün **hiçbir şeyi korumuyor**. Öneri: `PROD_SSH_HOST` / `PROD_SSH_PRIVATE_KEY` `prod` environment'ına taşınsın — orada durursa required-reviewer kuralı **gerçek** bir koruma olur.

### `VITE_*` → variable, secret değil

`VITE_API_BASE_URL`, `VITE_OAUTH_GOOGLE_URL`, `VITE_OAUTH_MICROSOFT_URL` build sırasında bundle'a giriyor ve istemcide **zaten görünür**. Secret olarak tutulmaları yanlış sinyal veriyor; repo/environment **variable**'ına taşınmalı.

### Yeni repoya geçiş — minimum secret kümesi

Dokümana eklenen yeni bölüm:

| Sınıf | Secret'lar |
|---|---|
| **Zorunlu** — olmadan ilgili workflow amacını yerine getiremez | `PROMOTION_PAT`, `TEST_SSH_HOST`, `TEST_SSH_PRIVATE_KEY` + GHCR için Actions write izni |
| **Güçlü öneri** — tanımsız olsa iş yeşil kalır ama gerçek işlev bozulur | `JWT_SECRET`, `VITE_*` çifti, D-15 fallback grubu |
| **İlk günden gerekmez** | `PROD_SSH_*`, `ALGO_SUITE_*` |
| **Variable olarak taşınmalı** | üç `VITE_*` |

## İlgili User Story / Issue

Faz 8 · F8-04 · **D-15** ile bağlantılı

## Değişiklik Tipi

- [x] 📄 Dokümantasyon

## Test Edildi mi?

- [x] `grep -rhoE 'secrets\.[A-Z_]+' .github/workflows/ | sort -u | wc -l` → 22
- [x] `gh secret list` → 6
- [x] Üç environment'ın secret sayısı → 0/0/0
- [x] D-15 kapsamı gerçek koşum log'u ile doğrulandı
- [x] **Değer sızıntısı taraması:** `test-deploy.yml`'deki 10 fallback literalinin **hiçbiri** dokümanda geçmiyor (birebir `grep -F` ile tek tek kontrol edildi)

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi

## Ek Notlar

- **Hiçbir secret değeri hiçbir yere yazılmadı** — ne dokümana, ne commit mesajına. Yalnız adlar ve tanımlı/tanımsız bilgisi kullanıldı. Dokümandaki parola benzeri satırlar (`<REPLACE_WITH_LOCAL_SA_PASSWORD>`, `PAROLA`) **önceden vardı**, bu commit eklemedi.
- Brief `secret-management.md`'nin `TEST_GHCR_*`'ı hâlâ aktif listelediğini söylüyordu — o kayıt zaten "❌ Kaldırıldı, 2026-08-13'te silindi" diye işaretliymiş. Uydurma düzeltme yapılmadı.
- **Kapsam dışı:** secret değerlerini değiştirmek / rotasyon (F8-01), `ALGO_SUITE_*` tanımlamak (F8-03), fallback'leri workflow'dan kaldırmak — envanter çıktığı için bu artık planlanabilir ayrı bir iş.
