### PR TITLE
docker-build kaldırıldı, concurrency eklendi, npm cache tek yazıcıya indirildi (D-09, Y-05, Y-06)

### DIFF
--- a/.github/workflows/algorithm-suite.yml
+++ b/.github/workflows/algorithm-suite.yml
@@ -60,8 +60,6 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: apps/algorithm-test-ui/package-lock.json
 
       # Kimlik bilgileri tanımlı değilse iş sessizce ve BAŞARILI biter. Zamanlanmış
       # bir iş, yapılandırılmamış olduğu için her gece kırmızı yanmamalı.
@@ -78,6 +76,18 @@ jobs:
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # setup-node'un dahili `cache: 'npm'`i yerine açık restore: yazma YOK.
+      # Bu workflow da `node-cache-*` prefix'ine yazan dördüncü yolduydu; anahtar
+      # ci.yml ve test-deploy.yml ile birebir aynı, tek yazıcı cache-seed.yml.
+      - name: npm cache geri yükle (yazmaz)
+        if: steps.config.outputs.configured == 'true'
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('apps/frontend/package-lock.json', 'apps/algorithm-test-ui/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
 
       - name: Bağımlılıkları yükle
         if: steps.config.outputs.configured == 'true'

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -6,7 +6,8 @@ name: Cache Cleanup
 #      PR cache'leri refs/pull/<number>/merge ve refs/pull/<number>/head ref'leri altında oluşur.
 #      Not: fork PR'larında GITHUB_TOKEN write yetkisi olmadığından sadece aynı repo PR'ları işlenir.
 #   2. Her gün 04:35 UTC (schedule) → önce yaş/orphan kriteriyle, sonra (hâlâ 8 GiB üzerindeyse)
-#      en eski erişilen buildkit-blob'lar test/main/dev korunarak boyut eşiğine inene kadar silinir.
+#      en eski erişilen buildkit-blob ve node-cache girişleri test/main/dev korunarak boyut
+#      eşiğine inene kadar silinir.
 #
 # Amaç: 10 GB limiti dolmadan önce gereksiz cache'leri proaktif olarak temizlemek.
 
@@ -150,13 +151,21 @@ jobs:
           CURRENT_SIZE=$(gh api "/repos/${REPO}/actions/cache/usage" --jq '.active_caches_size_in_bytes')
           echo "==> Toplam cache boyutu: ${CURRENT_SIZE} bayt (eşik: ${SIZE_LIMIT_BYTES})"
           [[ "${CURRENT_SIZE}" -lt "${SIZE_LIMIT_BYTES}" ]] && { echo "==> Eşiğin altında."; exit 0; }
-          # korunan ref'ler: test, main, dev; en eski erişilen buildkit-blob'dan başlanarak silinir
-          SORTED_BLOBS=$(gh api --paginate -H "Accept: application/vnd.github+json" "/repos/${REPO}/actions/caches?per_page=100" --jq '.actions_caches[] | select(.key|startswith("buildkit-blob")) | [(.id|tostring), (.ref // "__NO_REF__"), .last_accessed_at, (.size_in_bytes|tostring)] | join("\t")' 2>/dev/null | awk -F'\t' '$2 !~ /^refs\/heads\/(test|main|dev)$/' | sort -t $'\t' -k3,3)
+          # Kapsam: buildkit-blob + node-cache. node-cache (setup-node ~/.npm) prefix'i
+          # yoktu ve bu adım ona hiç dokunamıyordu; ölçüm 2026-08-18: 60 giriş /
+          # 4,47 GiB = 10 GiB kotanın %45'i. Sonuç, eşik aşıldığında yalnız buildkit
+          # blob'larının tahliye edilmesi — yani soğuk docker build'lerin bedelinin
+          # ödenip asıl yerin geri kazanılmaması oluyordu.
+          # `codeql-*` ve `index-*` prefix'leri BİLEREK kapsam dışı: index girişleri
+          # buildkit manifest'i, silinmesi blob'ları erişilemez bırakır.
+          # Politika buildkit-blob ile birebir aynı: refs/heads/{test,main,dev} korunur,
+          # en eski last_accessed_at'ten başlanarak eşiğin altına inene kadar silinir.
+          SORTED_ENTRIES=$(gh api --paginate -H "Accept: application/vnd.github+json" "/repos/${REPO}/actions/caches?per_page=100" --jq '.actions_caches[] | select(.key|startswith("buildkit-blob") or startswith("node-cache")) | [(.id|tostring), (.ref // "__NO_REF__"), .last_accessed_at, (.size_in_bytes|tostring)] | join("\t")' 2>/dev/null | awk -F'\t' '$2 !~ /^refs\/heads\/(test|main|dev)$/' | sort -t $'\t' -k3,3)
           REMAINING=${CURRENT_SIZE}; DELETED=0
           while IFS=$'\t' read -r CACHE_ID CACHE_REF CACHE_DATE CACHE_SIZE; do
             [[ -z "${CACHE_ID}" ]] && continue
             [[ "${REMAINING}" -lt "${SIZE_LIMIT_BYTES}" ]] && break
             gh api --method DELETE -H "Accept: application/vnd.github+json" "/repos/${REPO}/actions/caches/${CACHE_ID}" > /dev/null 2>&1 \
               && { echo "Silindi: #${CACHE_ID} (${CACHE_REF/__NO_REF__/no-ref}, ${CACHE_SIZE}B)"; REMAINING=$((REMAINING - CACHE_SIZE)); DELETED=$((DELETED + 1)); }
-          done <<< "${SORTED_BLOBS}"
-          echo "==> Boyut temizliği tamamlandı: ${DELETED} blob silindi, kalan tahmini ${REMAINING} bayt."
+          done <<< "${SORTED_ENTRIES}"
+          echo "==> Boyut temizliği tamamlandı: ${DELETED} giriş silindi, kalan tahmini ${REMAINING} bayt."

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -189,9 +189,10 @@ jobs:
             VITE_OAUTH_MICROSOFT_URL=${{ secrets.VITE_OAUTH_MICROSOFT_URL }}
             VITE_APP_ENV=test
           cache-from: type=gha,scope=frontend-test
-          cache-to: |
-            type=gha,mode=max,scope=frontend-test
-            type=gha,mode=max,scope=cargo-pilot-frontend-ci
+          # Tek scope: `cargo-pilot-frontend-ci` yazımı D-09 ile tüketicisiz kaldı
+          # (ci.yml'deki docker-build job'u kaldırıldı). Gerçek tüketiciler
+          # test-deploy.yml'deki build/deploy/e2e job'ları ve hepsi frontend-test okuyor.
+          cache-to: type=gha,mode=max,scope=frontend-test
 
       - name: Kota raporu
         if: always() && steps.quota.outputs.seed == 'true'

--- a/.github/workflows/cache-seed.yml
+++ b/.github/workflows/cache-seed.yml
@@ -30,6 +30,10 @@ name: Cache Seed (nightly)
 #   - `cache-cleanup.yml` 04:35 UTC'de koşuyor; seed 05:10'da, yani temizlikten SONRA.
 #     Nightly olduğu için seed girişleri `MAX_AGE_DAYS=7` yaş kuralına hiç yakalanmaz;
 #     boyut adımı ise `refs/heads/main`'i koruyor.
+#
+# Bu workflow ayrıca npm (`~/.npm`) cache'inin TEK yazıcısıdır; gerekçe aşağıdaki
+# "npm cache seed" bloğunda. Ek kota yükü ~130 MiB (tek giriş), karşılığında
+# `node-cache-*` prefix'inde 60 giriş / 4,47 GiB serbest kalır.
 
 on:
   schedule:
@@ -46,7 +50,7 @@ concurrency:
 
 jobs:
   seed-frontend-cache:
-    name: Frontend Build Cache Seed
+    name: Frontend Build ve npm Cache Seed
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -56,8 +60,9 @@ jobs:
     steps:
       # Önceki generation silinmeden yazılırsa `main` her gece bir generation daha
       # biriktirir ve boyut adımı `main`'i koruduğu için hiç tahliye edilmez.
-      # Yalnız buildkit girişleri silinir; CodeQL ve setup-node cache'lerine
-      # dokunulmaz (farklı key prefix'leri).
+      # Yalnız buildkit girişleri silinir; CodeQL ve npm cache'ine dokunulmaz
+      # (farklı key prefix'leri). npm girişinin burada silinmemesi ÖNEMLİ: main'deki
+      # o giriş artık tüm CI koşumlarının tek npm cache kaynağı.
       - name: Önceki seed generation'ını sil (refs/heads/main)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -108,6 +113,58 @@ jobs:
         with:
           ref: dev
           persist-credentials: false
+
+      # ── npm cache seed ────────────────────────────────────────────────────────
+      # Sorun: `setup-node`un dahili `cache: 'npm'`i, `package-lock.json` hiç
+      # değişmese bile HER ref'e kendi ~/.npm kopyasını yazıyordu. Üç yazıcı vardı
+      # (ci.yml'de frontend-ci ve algorithm-test-ui-ci, test-deploy.yml'de e2e-smoke)
+      # ve hepsi iş branch'i push'larında koşuyor. Ölçüm 2026-08-18: 60 giriş /
+      # 4,47 GiB = 10 GiB kotanın %45'i, ref başına 2-3 giriş.
+      #
+      # Çözüm: o üç yer artık `actions/cache/restore` ile YALNIZ OKUYOR; tek yazıcı
+      # burası. Bu workflow schedule ile koştuğu için ref'i default branch
+      # (refs/heads/main) ve GHA cache okuma kapsamı = kendi ref'i + PR base ref'i +
+      # DEFAULT BRANCH olduğundan giriş tüm branch'lerden ve PR'lardan okunabilir.
+      # Kararlı durum: tek giriş (~130 MiB), 60 giriş / 4,47 GiB yerine.
+      #
+      # `actions/cache` (birleşik) bilerek seçildi: isabet varsa post adımı yazmaz,
+      # yalnızca last_accessed_at tazelenir → main'de generation birikmez ve giriş
+      # cache-cleanup.yml'nin MAX_AGE_DAYS=7 yaş kuralına yakalanmaz.
+      #
+      # Anahtar iki lockfile'ın birleşik hash'i: ~/.npm tek bir paket deposu, iki
+      # uygulamanın paketleri aynı girişte durur. Tüketiciler aynı ifadeyi kullanır;
+      # lockfile'lardan biri iş branch'inde değişirse `npm-<os>-` prefix'i ile
+      # main'in son girişine düşülür ve npm yalnızca farkı indirir.
+      #
+      # Ağaç `dev`'den checkout edildiği için hash de dev'in lockfile'larından
+      # hesaplanır — iş branch'lerinin atası dev olduğu için isabet oranı en yüksek
+      # olan seçim bu.
+      - name: npm cache (apps/frontend + apps/algorithm-test-ui)
+        if: steps.quota.outputs.seed == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('apps/frontend/package-lock.json', 'apps/algorithm-test-ui/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
+
+      - name: Node.js kur
+        if: steps.quota.outputs.seed == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '20'
+
+      # `npm ci` yalnızca ~/.npm'i doldurmak için koşuyor; node_modules çıktısı
+      # kullanılmıyor. Build/test yok, bu yüzden bedeli ~1 dk runner.
+      - name: apps/frontend paketlerini indir
+        if: steps.quota.outputs.seed == 'true'
+        working-directory: apps/frontend
+        run: npm ci
+
+      - name: apps/algorithm-test-ui paketlerini indir
+        if: steps.quota.outputs.seed == 'true'
+        working-directory: apps/algorithm-test-ui
+        run: npm ci
 
       - name: Docker Buildx kur
         if: steps.quota.outputs.seed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,16 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: apps/frontend/package-lock.json
+
+      # setup-node'un dahili `cache: 'npm'`i yerine açık restore: yazma YOK.
+      # Gerekçe ve tek yazıcı için cache-seed.yml'deki "npm cache seed" bloğuna bakın.
+      - name: npm cache geri yükle (yazmaz)
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('apps/frontend/package-lock.json', 'apps/algorithm-test-ui/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
 
       - name: npm versiyonunu güncelle
         run: npm install -g npm@11.6.1
@@ -149,8 +157,16 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: apps/algorithm-test-ui/package-lock.json
+
+      # Anahtar frontend-ci ile birebir aynı: ~/.npm tek bir paket deposu, iki
+      # lockfile'ın paketleri aynı girişte duruyor. Bkz. cache-seed.yml.
+      - name: npm cache geri yükle (yazmaz)
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('apps/frontend/package-lock.json', 'apps/algorithm-test-ui/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
 
       - name: Bağımlılıkları yükle
         run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,13 @@ name: CI — Kod Kalite ve Build Kontrolü
 
 # Tüm iş branch'i push'larında ve dev/test/main PR'larında çalışır.
 # Amaç: hataları bir sonraki dala terfi etmeden yakalamak.
+#
+# D-09: `docker-build` job'u kaldırıldı. Docker imaj kapısı tamamen
+# `test-deploy.yml`'e ait: iş branch'i push'unda `Deploy (Test)` iki imajı da build
+# ediyor VE compose ile ayağa kaldırıp healthcheck'ten geçiriyor; PR → test'te ayrıca
+# `Image Build` koşuyor. Buradaki build'in tek özgün katkısı merge commit'inin imaj
+# build'iydi, o da PR → test kapısında yakalanıyor. Hiçbir ruleset `Docker Image Build`
+# adlı check'i zorunlu tutmuyordu (dev-protection: Frontend CI + Backend CI).
 on:
   push:
     branches:
@@ -187,58 +194,3 @@ jobs:
 
       - name: Testleri çalıştır
         run: dotnet test cargo-pilot.sln --no-build --configuration Release --verbosity normal
-
-  # ─── Docker Image Build (main'e giden PR ve iş branch'i push'ları) ───────────
-  docker-build:
-    name: Docker Image Build
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      packages: read
-    # PR → test/main'de image build test-deploy.yml'deki "Image Build" job'u ile yapılır;
-    # burada yalnızca ilk kapıda (dev PR'ı) koşar; iş branch'i push'ları test-deploy.yml'in
-    # Deploy (Test) job'unda zaten build edildiği için burada tekrar edilmiyor.
-    if: github.event_name == 'pull_request' && github.base_ref == 'dev'
-    # D-12: `needs: [frontend-ci, backend-ci]` kaldırıldı. Docker build bu job'ların
-    # çıktısını (artifact, output, cache) kullanmıyor; kendi context'ini kendi build
-    # ediyor. Zincir yalnızca ~2 dk boş bekleme üretiyordu (ölçüm: 4 dev PR koşumunda
-    # 109–132 sn). Kırık CI'da bu job artık boşa koşar; ölçülen bedel 4/41 PR koşumunda
-    # ~3,5 dk runner (beklenen ~0,4 dk/PR), kazanç her PR'da ~2 dk duvar saati.
-
-    steps:
-      - name: Kodu al
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Docker Buildx kur
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: GHCR'a giriş yap
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Backend Docker image build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: ./apps/backend/
-          push: false
-          tags: cargo-pilot-backend:ci
-          build-args: |
-            DOTNET_SDK_IMAGE=ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0
-            DOTNET_ASPNET_IMAGE=ghcr.io/divizyon/cargo-pilot-dotnet-aspnet:8.0
-          cache-from: type=gha,scope=cargo-pilot-backend-ci
-          cache-to: type=gha,mode=min,scope=cargo-pilot-backend-ci
-
-      - name: Frontend Docker image build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: ./apps/frontend/
-          push: false
-          tags: cargo-pilot-frontend:ci
-          build-args: |
-            VITE_API_BASE_URL=http://localhost:8080/api/v1
-          cache-from: type=gha,scope=cargo-pilot-frontend-ci
-          cache-to: type=gha,mode=max,scope=cargo-pilot-frontend-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,25 @@ on:
 permissions:
   contents: read
 
+# Aynı branch'e hızlı ardışık push'lar tam CI'ı baştan koşuyordu (ölçüm:
+# feat/algoritma-arama-katmani'nda 8 koşum, ikisi saniyeler arayla).
+#
+# `cancel-in-progress` BİLEREK yalnız pull_request'te açık:
+# ci.yml korunan dallarda zorunlu check üretiyor (Frontend CI, Backend CI, Terfi
+# Zinciri Kontrolü). İptal edilen koşumun check'i `cancelled` durumunda kalır ve o
+# commit'te merge'i bloke eder. Push koşumları PR'ın head SHA'sıyla aynı commit'e
+# check yazdığı için push tarafında iptal ETMEK bu riski doğurur; PR tarafında ise
+# iptal edilen koşum her zaman ESKİ head SHA'ya aittir, merge kapısı yalnızca
+# güncel head SHA'ya bakar — güvenli.
+#
+# Grup adı: github.ref push'ta refs/heads/<branch>, pull_request'te
+# refs/pull/<n>/merge → PR ve push koşumları ayrı gruplara düşer, birbirini iptal
+# edemez. concurrency bağlamında `github` context'i kullanılabilir (secrets/matrix
+# kullanılamaz), bu yüzden github.event_name ifadesi burada değerlendirilir.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ─── Terfi zinciri denetimi ──────────────────────────────────────────────────
   # Akış: feat/* → dev → test → main. Sıra atlanırsa dallar ayrışır.

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -362,8 +362,18 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: apps/frontend/package-lock.json
+
+      # setup-node'un dahili `cache: 'npm'`i yerine açık restore: yazma YOK.
+      # Bu job iş branch'i push'larında da koşuyor, yani her branch'e kendi ~/.npm
+      # kopyasını yazan üç yazıcıdan biriydi. Anahtar ci.yml ile birebir aynı;
+      # gerekçe ve tek yazıcı için cache-seed.yml'deki "npm cache seed" bloğuna bakın.
+      - name: npm cache geri yükle (yazmaz)
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('apps/frontend/package-lock.json', 'apps/algorithm-test-ui/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
 
       - name: Bağımlılıkları yükle
         working-directory: apps/frontend


### PR DESCRIPTION
## Özet

Üç onaylanmış CI değişikliği + iki tamamlama. **Private repo bağlamı:** depo private'a taşınacağı için Actions dakikaları ücretli hâle gelecek — bu PR'daki kazançlar hijyen değil **maliyet** kalemi.

| # | İş | Sonuç |
|---|---|---|
| 1 | **D-09** — `ci.yml`'deki `docker-build` job'u | kaldırıldı (55 satır) |
| 2 | **Y-06** — `concurrency` grubu yok | eklendi, `cancel-in-progress` yalnız PR'da |
| 3a | **Y-05** — `cache-cleanup` node-cache'e dokunamıyor | filtre genişletildi |
| 3b | **Y-05** — npm cache her ref'te çoğalıyor | dört yazıcı → **tek yazıcı** |
| + | Ölü cache scope'u | `cargo-pilot-frontend-ci` kaldırıldı |

### 1 · D-09 — `docker-build` kaldırıldı

Kullanıcı kararı. Gerekçe (#1054'te ölçüldü): iş branch'i push'unda `test-deploy.yml`'nin `deploy` job'u iki imajı da build ediyor **ve** compose'la ayağa kaldırıp healthcheck'ten geçiriyor (backend 59 s, frontend 52–54 s) — `ci.yml`'nin yalnız-build job'undan kesin olarak daha güçlü kapı. Dev kapısındaki build'in tek özgün katkısı merge commit'inin imaj build'iydi, o da PR→test'te `build` job'u tarafından yine merge commit üzerinde yakalanıyor.

**Ruleset teyidi — bu adım atlanmadı.** Zorunlu check adları job'larla makineyle eşleştirildi:

| Zorunlu check | Sağlayan | Durum |
|---|---|---|
| Frontend CI | `ci.yml:frontend-ci` | korundu |
| Backend CI | `ci.yml:backend-ci` | korundu |
| Terfi Zinciri Kontrolü | `ci.yml:enforce-promotion` | korundu |
| Pending Migration Kontrolü | `test-deploy.yml:migration-check` | korundu |
| **Image Build** | **`test-deploy.yml:build`** | **dokunulmadı** |
| Deploy (Test) | `test-deploy.yml:deploy` | dokunulmadı |

⚠️ Kaldırılan job'un adı **"Docker Image Build"** — bu ad hiçbir ruleset'te yok. `test-protection`'daki **"Image Build"** farklı bir job (`test-deploy.yml:build`); o kaldırılsaydı `test`'e terfi PR'ları sonsuza kadar merge edilemez hâle gelirdi. Bugün repoda `Docker Image Build` yalnız bir yorum satırında geçiyor (kaldırma gerekçesi).

Beraberinde temizlenen kalıntılar: job-level `permissions`, `if: pull_request && base_ref == 'dev'`, `timeout-minutes: 30`, iki `docker/build-push-action` adımı ve `cargo-pilot-{backend,frontend}-ci` scope okumaları.

**Kabul edilen takas:** yalnızca `apps/*/Dockerfile`'ı bozan bir değişiklik artık `dev`'e girebilir; `test`'e terfide `Image Build` + `Deploy (Test)` yakalar.

### 2 · `concurrency` — `cancel-in-progress` körü körüne açılmadı

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

**Neden push'ta iptal kapalı:** `ci.yml` korunan dallarda zorunlu check üretiyor. Push koşumu PR'ın head SHA'sıyla **aynı commit'e** check yazıyor; iptal edilirse o commit'te `Frontend CI` = `cancelled` kalır ve **merge bloke olur**. PR tarafında iptal edilen koşum her zaman eski head SHA'ya ait, merge kapısı yalnız güncel head'e bakar → güvenli. Bu gerekçe workflow'a yorum olarak da yazıldı.

Grup adı analizi: push'ta `github.ref` = `refs/heads/<branch>`, PR'da `refs/pull/N/merge` → ayrı gruplar, birbirini iptal edemezler. `concurrency` bağlamı `github` context'ini kabul ediyor, ifade gerçekten değerlendiriliyor (YAML parse çıktısıyla doğrulandı).

### 3a · `cache-cleanup` boyut adımı artık node-cache'i de kapsıyor

Eski filtre: `select(.key|startswith("buildkit-blob"))` → kotanın **%45'i erişilemezdi**.
Yeni: `select(.key|startswith("buildkit-blob") or startswith("node-cache"))`. `codeql-*` ve `index-*` bilerek dışarıda — `index-*` buildkit manifest'i, silinmesi blob'ları erişilemez bırakır.

**Dry-run karşılaştırması** (silme yapılmadı, adım mantığı simüle edildi; o an usage 8,82 GB, eşik 8 GiB):

| Filtre | Aday | Seçilen | Byte |
|---|---|---|---|
| Yeni | 174 | 4 node-cache girişi | 310.905.558 |
| Eski | 117 | 10 **buildkit blob** | 226.857.549 |

Yani eski hâliyle soğuk docker build bedeli ödenip 4,47 GiB'lık asıl yer **hiç geri kazanılmıyordu**. Seçilen 4 girişin hiçbiri korunan ref'te değil.

**Sınırı da yazalım:** adım yalnız 8 GiB'a kadar iniyor, yani 3a tek başına 4,47 GiB'ı bir gecede boşaltmaz — node-cache'i tahliyeye **uygun** hâle getirir. Yapısal daralma 3b'den gelir.

### 3b · npm cache: dört yazıcı → tek yazıcı

**Ölçüm:** `node-cache-Linux-x64-npm-*` → **60 giriş / 4,47 GiB** (denetim turundaki 54/4,04 GiB'den büyümüş). Dağılım: 4 lockfile hash'i × ~109 MiB (`apps/frontend`, 32 giriş / 3,41 GiB) + 1 hash × 38 MiB (`apps/algorithm-test-ui`, 28 giriş / 1,05 GiB).

**Kök neden:** `package-lock.json` aynı olsa bile her branch ve her PR ref'i kendi kopyasını yazıyordu.

**Yazıcı sayısı dörttü** (ilk tahmin ikiydi): `ci.yml:78` (frontend), `ci.yml:126` (algorithm-test-ui), `test-deploy.yml:365` (`e2e-smoke`, iş branch'i push'unda koşuyor) ve `algorithm-suite.yml:63`. **Dördü de `actions/cache/restore` ile yalnız okur hâle getirildi.**

Tasarım kararları:
- **`ci.yml`'e `save` adımı EKLENMEDİ, çünkü ölü kod olurdu.** `ci.yml` push tetikleyicileri `main`'i içermiyor ve `main` PR'ının ref'i `refs/pull/N/merge` — yani `github.ref == 'refs/heads/main'` koşulu orada **asla doğru olamaz**. Tek yazıcı `cache-seed.yml`.
- **Tek birleşik giriş.** `~/.npm` tek paket deposu; iki ayrı cache örneği aynı yola bakarsa post adımlarının ikisi de tüm dizini arşivler → aynı byte iki kez. Anahtar iki lockfile'ın birleşik hash'i: `npm-${{ runner.os }}-${{ hashFiles('apps/frontend/package-lock.json', 'apps/algorithm-test-ui/package-lock.json') }}`, `restore-keys: npm-${{ runner.os }}-`, `path: ~/.npm`. **Kararlı durum: 1 giriş / ~130 MiB** (bugün 60 giriş / 4,47 GiB).
- Seed'de `actions/cache/save` yerine **birleşik `actions/cache`**: isabet varsa post adımı yazmaz, yalnız `last_accessed_at` tazelenir → `main`'de generation birikmez ve giriş `MAX_AGE_DAYS=7` yaş kuralına yakalanmaz. `save` olsaydı her gece "key already exists" durumuna girecekti.
- Seed adımları mevcut kota valfine (`steps.quota.outputs.seed`, 9 GiB) bağlandı; valf mantığı değişmedi. Seed'in silme adımı yalnız `buildkit-blob`/`index-` siliyor, `npm-*` hayatta kalıyor; 3a'nın boyut adımı `refs/heads/main`'i koruyor.
- **Yeni pin uydurma değil:** `actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0` — `algorithm-suite.yml:92`'de zaten kullanılan SHA. `path`/`key`/`restore-keys` input adları API'den doğrulandı (`fail-on-cache-miss` default `false`, miss CI'ı düşürmez).

### + Ölü cache scope'u kaldırıldı

`docker-build` gidince `cargo-pilot-frontend-ci` ve `cargo-pilot-backend-ci` scope'larının **tüketicisi kalmadı**; yalnız nightly seed `cargo-pilot-frontend-ci`'ye yazmaya devam ediyordu. O `cache-to` satırı kaldırıldı. Nihai scope haritası:

| Scope | Yazan | Okuyan |
|---|---|---|
| `frontend-test` | 2 (`test-deploy:build` + nightly seed) | 4 |
| `backend-test` | 1 | 3 |

Seed `frontend-test`'e `mode=max` yazıyor, `test-deploy.yml:153` de aynı modla → **ADR-0011 karar #2 ile tutarlı.**

## İlgili User Story / Issue

Faz 6 devamı · **D-09** (kullanıcı kararı: kaldır) · **Y-05**, **Y-06** (#1054'te bulundu, kullanıcı onayladı)

## Değişiklik Tipi

- [x] 🔧 Altyapı (infra)

## Test Edildi mi?

- [x] `python3 -c "import yaml,glob;[yaml.safe_load(open(f)) …]"` → yaml ok
- [x] `grep -rnE 'uses:' .github/workflows/ | grep -vE '@[0-9a-f]{40}'` → **boş** (tümü SHA-pinli)
- [x] Ruleset zorunlu check adları job'larla eşleştirildi → **hepsi mevcut**
- [x] `grep "cache: 'npm'"` → **gerçek eşleşme yok** (kalanlar yorum)
- [x] 3a dry-run: seçilecek girişler listelendi, **hiçbir cache silinmedi**
- [x] `gh workflow run` **koşulmadı**
- [x] Diff yalnız `.github/workflows/` → `docs/**`, `infra/**`, `apps/**` dokunulmadı

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi (gerekçeler workflow yorumlarında; backlog ve ADR ayrı PR'da)

## Ek Notlar — kalan risk

1. **Seed'e bağımlılık (3b'nin ana riski).** `cache-seed.yml` nightly'de düşerse veya kota valfi seed'i atlarsa `npm-*` girişi tazelenmez, 7 gün sonra yaş kuralıyla silinir ve tüm `npm ci` çağrıları **süresiz soğuk** kalır. **Sessiz bir yavaşlama — kimse fark etmez.** 3a valfin tetiklenme olasılığını düşürüyor; izlenmesi gereken tek nokta bu.
2. **Süre etkisi ÖLÇÜLEMEDİ.** İlk koşumlarda `main`'de henüz `npm-*` girişi yok, restore ıskalayacak; ilk gerçek isabet ilk nightly seed'den sonra. İlk 2-3 koşumda `npm ci` süresi izlenmeli. Karşılaştırma tabanı bugünkü davranışın kendisi de her branch'in ilk push'unda soğuk olması, dolayısıyla beklenti nötr-veya-daha-iyi — ama koşmadan iddia edilmiyor. Regresyon çıkarsa geri dönüş tek commit revert.
3. Bir tuzak uygulama sırasında yakalandı ve düzeltildi: `algorithm-suite.yml`'e eklenen restore adımı ilk hâlinde `steps.config.outputs.configured` koşuluna bakıyordu ama `config` adımından **önce** geliyordu. Sonraki adımın çıktısı boş string döner → `if: '' == 'true'` hep false → restore **hiç koşmazdı**. Adım `config`'ten sonraya taşındı (sıra artık `config` → `restore` → `npm ci`).
