### PR TITLE
ADR-0011: backend cache modu yeniden değerlendirildi; backlog Faz 5/6/8 ve geçiş bölümüyle tazelendi

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -29,6 +29,7 @@
 * [ADR-0007 — Docker Build Cache Asimetrisi](docs/adr/ADR-0007-docker-build-cache-asimetrisi.md)
 * [ADR-0008 — SHA Pinleme Sürüm Yükseltmesinden Ayrılır](docs/adr/ADR-0008-sha-pinleme-surum-yukseltmeden-ayri.md)
 * [ADR-0009 — Otomatik Geri Alma Sessizce Başarılı Dönmez](docs/adr/ADR-0009-otomatik-geri-alma-sessizce-basarili-donmez.md)
+* [ADR-0011 — Docker Build Cache Modu: Backend Restore Katmanı Ayrıldıktan Sonra](docs/adr/ADR-0011-docker-build-cache-modu-backend-restore-sonrasi.md)
 
 ## 🛠️ DevOps
 

--- a/docs/adr/ADR-0007-docker-build-cache-asimetrisi.md
+++ b/docs/adr/ADR-0007-docker-build-cache-asimetrisi.md
@@ -1,6 +1,6 @@
 # ADR-0007 — Docker build cache asimetrisi: backend `mode=min`, frontend `mode=max`
 
-- **Durum:** Kabul edildi
+- **Durum:** Yerini aldı: ADR-0011
 - **Tarih:** 2026-08-15 (K3 panel kararı ve PR #992)
 - **Kapsam:** `.github/workflows/ci.yml`, `.github/workflows/test-deploy.yml`,
   `apps/backend/Dockerfile`, `apps/frontend/Dockerfile`

--- a/docs/adr/ADR-0011-docker-build-cache-modu-backend-restore-sonrasi.md
+++ b/docs/adr/ADR-0011-docker-build-cache-modu-backend-restore-sonrasi.md
@@ -1,0 +1,194 @@
+# ADR-0011 — Docker build cache modu: backend restore katmanı ayrıldıktan sonra yeniden değerlendirme
+
+- **Durum:** Kabul edildi
+- **Tarih:** 2026-08-18 (bu ADR'nin ölçümleri ve kararı aynı gün alındı)
+- **Kapsam:** `.github/workflows/ci.yml`, `.github/workflows/test-deploy.yml`,
+  `apps/backend/Dockerfile`, `apps/frontend/Dockerfile` · Tetikleyen: PR #1047 (D-30) ·
+  **ADR-0007'nin tamamının yerini alır**
+
+## Bağlam
+
+ADR-0007 karar #1 (backend `cache-to` `mode=min`) şu öncüle dayanıyordu: `apps/backend/Dockerfile`
+tek bir `RUN` içinde hem `dotnet restore` hem `dotnet publish` çalıştırıyordu, dolayısıyla
+ayrılabilir, çapraz-commit yeniden kullanılabilir bir restore katmanı **yoktu**
+(ADR-0007 `## Karar` madde 1, satır 47-49). ADR-0007 kendi yeniden değerlendirme koşulunu
+açıkça yazmıştı (satır 61-62):
+
+> "Backend Dockerfile'ı ileride `restore` ve `publish`'i ayrı `RUN` katmanlarına bölerse bu
+> madde yeniden değerlendirilmelidir — o zaman `mode=max`'ın gerçek bir karşılığı olur."
+
+**Bu koşul gerçekleşti.** PR #1047 (D-30, "Backend Dockerfile csproj-only restore katmanı +
+`--no-restore`") tam bunu yaptı. Bugün doğrulandı (`apps/backend/Dockerfile`):
+
+- `:11-15` yalnızca restore grafiğini etkileyen dosyalar kopyalanıyor: `global.json`,
+  `Directory.Build.props`, `CargoPilot.slnx` ve dört `.csproj` (Domain/Application/
+  Infrastructure/WebAPI).
+- `:21-29` **ayrı bir `RUN`** bloğu; `:29` `dotnet restore "$project"` ile bitiyor.
+- `:35` `COPY . .` — kaynak ağacı restore'dan **sonra** kopyalanıyor.
+- `:37-40` **ikinci, ayrı bir `RUN`** bloğu; `:39` `dotnet publish ... --no-restore` çalıştırıyor.
+
+Yani karar #1'in "ayrılabilir restore katmanı yok" öncülü artık **yanlış**. Karar #1'in
+gerekçesi düştü; kararın kendisinin de düşüp düşmediği ölçülerek test edilmesi gerekiyordu —
+bu ADR'nin konusu budur.
+
+Karar #2 (frontend `mode=max`) bu değişiklikten etkilenmedi: `apps/frontend/Dockerfile` hâlâ
+ayrı bir `deps` stage kullanıyor, yapısı değişmedi.
+
+**Neden ADR-0007'nin tamamı yerini alıyor, yalnız `Durum` satırı değil:** Konvansiyon
+(`docs/adr/README.md:66-73`) kabul edilmiş bir ADR'nin gövdesinin düzenlenemeyeceğini, yalnız
+`Durum` satırının `Yerini aldı: ADR-XXXX` olarak güncellenebileceğini söylüyor. Ama ADR-0007
+**iki bağımsız karar** içeriyor ve yalnızca biri (karar #1) yeniden değerlendirmeyi
+gerektiriyordu; dört durum değeri (`Önerildi` / `Kabul edildi` / `Reddedildi` /
+`Yerini aldı: ADR-XXXX`) kısmi devralmayı ifade edemiyor — "ADR-0007 sadece karar #1 için
+yerini aldı" diye bir ara durum yok. En temiz çözüm: bu ADR, ADR-0007'nin **tamamının**
+yerini alır; karar #2'yi (frontend `mode=max`) ve karar #3/#4'ün hâlâ geçerli olan
+sonuçlarını kendi içinde yeniden ifade edip yürürlükte tutar. Böylece güncel cache
+politikasını anlatan **tek bir yürürlükteki ADR** kalır; ADR-0007'nin `Durum` satırı
+`Yerini aldı: ADR-0011` olur, gövdesi değiştirilmez.
+
+## Karar
+
+### 1. Backend `cache-to` `mode=min`'de kalır — gerekçe değişti, sonuç değişmedi
+
+Kod: `.github/workflows/ci.yml:233` (`type=gha,mode=min,scope=cargo-pilot-backend-ci`),
+`.github/workflows/test-deploy.yml:135` (`type=gha,mode=min,scope=backend-test`).
+
+Gerekçe:
+
+- **Değer artık var (ölçüldü).** Restore katmanı ayrıldığı için `mode=max`'ın artık gerçek
+  bir çapraz-commit karşılığı var — bu, ADR-0007 karar #1'in öncülünü geçersiz kılan doğrudan
+  kanıt: local `docker buildx build ./apps/backend/` üzerinde yalnız bir `.cs` dosyası
+  (`CargoPilot.WebAPI/Program.cs`, restore grafiğinin parçası değil — geçici olarak
+  değiştirilip ölçüm sonrası geri alındı) değiştirilip yeniden build edildiğinde:
+  `--cache-from type=local,src=<mode=min export>` ile restore `RUN` katmanı
+  (`Dockerfile:21-29`) **CACHE MISS** verdi (11,6 sn yeniden çalıştı, adım `DONE 11.6s`);
+  aynı build `--cache-from type=local,src=<mode=max export>` ile aynı adımda **CACHE HIT**
+  verdi (`#16 ... CACHED`, 0 sn). İki `docker buildx build` komutunun ham çıktısı bu ölçümün
+  kaynağıdır (2026-08-18, Docker 29.7.2, buildx v0.36.1, `docker-container` sürücüsü).
+- **Ama byte maliyeti orantısız.** Aynı local ortamda tek bir backend imajı için
+  `--cache-to type=local,dest=...` export boyutu: `mode=min` → **97,4 MiB** (12 blob, `du -sk`
+  99.784 KB), `mode=max` → **684,7 MiB** (25 blob, `du -sk` 701.180 KB). Fark
+  **~587,3 MiB / generation**. Bu, `type=gha` export'unun byte maliyeti için iyi bir vekildir
+  (aynı buildkit cache mekanizması, aynı ara katmanlar; GHA'nın kendi ağ/sıkıştırma
+  davranışıyla birebir aynı olmayabilir — bkz. Açık konular).
+- **Kota bugün doluluğa çok yakın.** `gh api /repos/Divizyon/cargo-pilot/actions/cache/usage`
+  (2026-08-18): 284 giriş / **8,210 GiB / 10 GiB bütçe = %82,1**. Sayfalanmış
+  `actions/caches` dökümünde `node-cache-*` 60 giriş / **4,468 GiB** (kotanın **%44,7**'si,
+  aktif kullanımın **%54,4**'ü); `buildkit-blob-*` 192 giriş / 3,667 GiB.
+- **Aktif ref/generation sayısı.** `gh api .../actions/caches -q '.actions_caches[].ref' | sort -u | wc -l`
+  ile bugün **37** farklı ref (branch/PR) aktif cache tutuyor. Bunlardan yalnızca backend
+  scope'ları (`cargo-pilot-backend-ci` + `backend-test`) için gerçek "index" girişi taşıyanlar
+  **13** — yani bugün fiilen 13 farklı ref/PR için canlı bir backend cache generation'ı var.
+- **Extrapolasyon iki senaryoyla:** 587,3 MiB × 13 (bugün canlı backend generation sayısı)
+  ≈ **7,46 GiB** ek yük; bugünkü 8,21 GiB toplam kullanıma eklenirse **~15,67 GiB**, 10 GiB
+  bütçenin **%157'si**. Daha geniş 37 aktif ref varsayımıyla (her ref'in er ya da geç backend
+  cache'i tetikleyeceği kötü senaryosu) 587,3 MiB × 37 ≈ **21,2 GiB** — bütçenin **>2 katı**.
+  Her iki senaryoda da mode=max'a geçiş kotayı kesin olarak patlatır; ara bir orta yol yok.
+- Node-cache'in tek başına kotanın %44,7'sini tuttuğu (Y-05, ayrı ve henüz kapanmamış bir
+  borç — bkz. `docs/devops/devops-backlog.md` §6.9) bir ortamda backend'e 7,5–21 GiB ek yük
+  eklemek bugün kabul edilemez.
+
+Sonuçları:
+
+- ADR-0007'nin karar #1'i **yeniden değerlendirildi ve korundu**; gerekçesi "ayrılabilir
+  restore katmanı yok" (artık yanlış) yerine **"değer var, ama kota buna izin vermiyor"**
+  oldu. Bu meşru bir ADR sonucudur — koşul gerçekleşti, karar aynı kaldı, gerekçe değişti.
+  Kod tarafında hiçbir satır değişmiyor: `mode=min` zaten yürürlükte.
+- Bu karar, node-cache borcu (Y-05) kapanıp kota belirgin biçimde düşmedikçe ve/veya aktif
+  ref sayısı önemli ölçüde azalmadıkça geçerlidir (bkz. Açık konular — yeniden açma koşulu).
+- Backend'de yalnız kaynak (`.cs`) değişen build'lerde restore adımı her seferinde ~11,6 sn
+  maliyetli çalışmaya devam eder; bu, kota tasarrufunun kabul edilen bedelidir.
+
+### 2. Frontend `cache-to` `mode=max`'ta kalır — ADR-0007 karar #2'nin devamı
+
+Kod: `.github/workflows/ci.yml:244` (`type=gha,mode=max,scope=cargo-pilot-frontend-ci`),
+`.github/workflows/test-deploy.yml:153` (`type=gha,mode=max,scope=frontend-test`).
+
+Gerekçe (ADR-0007'den değişmeden devralındı, bugün yeniden doğrulandı):
+
+- `apps/frontend/Dockerfile` ayrı bir `deps` stage tanımlar (`COPY package*.json ./` ardından
+  `npm ci`, D-34 ile `npm install`'dan değişti); bu, `package-lock.json` değişmedikçe
+  çapraz-commit yeniden kullanılabilen tek gerçek ara katmandır ve nihai imajda yer almaz.
+- `mode=min` bu katmanı dışa aktarmaz; sonuç her build'de sıfırdan `npm ci` olur.
+- Frontend blob'ları backend'inkilerden küçüktür (D-06/`cache-seed.yml` yorumu: tek
+  generation ≈ 250–300 MiB, **tahmin**); `mode=max`'ın byte maliyeti burada karşılanabilir —
+  nitekim `cache-seed.yml` (D-06) zaten yalnızca frontend'i nightly besliyor.
+
+Sonuçları: Frontend'de `mode=max` bir israf değil, tek anlamlı cache kazancının ön koşulu
+— değişmedi.
+
+### 3. Asimetri korunuyor; gerekçesi "yapı farkı"ndan "yapı farkı + kota"ya genişledi
+
+Backend'de artık `mode=max`'ın ölçülmüş bir değeri var (karar #1), ama byte maliyeti kotanın
+kaldıramayacağı büyüklükte. Frontend'de değer var **ve** byte maliyeti karşılanabilir (küçük
+`deps` katmanı, tek generation ~250-300 MiB tahmini backend'in 684,7 MiB ölçülen mode=max
+export'undan belirgin biçimde küçük).
+
+Sonuçları:
+
+- D-13(d)'nin "asimetri = borç" iddiası ADR-0007'de bir kez, bu ADR'de ikinci kez ve daha
+  güçlü (byte + kota ölçümüyle) gerekçeyle reddedildi.
+- Asimetriyi "hizalamak" (dördünü `mode=max` ya da dördünü `mode=min` yapmak) hâlâ bir
+  gerileme olur — ADR-0007'nin bu konudaki sonucu değişmedi.
+
+### 4. Deploy job'u cache okur, yazmaz — ADR-0007 karar #4'ün devamı
+
+Kod: `test-deploy.yml:229,245` (`cache-from`, deploy job) ve `:345,359` (e2e job) — bu
+job'larda `cache-to` yok.
+
+Gerekçe (ADR-0007'den değişmeden devralındı): Deploy job'u zaten build job'un yazdığı
+katmanları tüketir; ikinci kez yazması aynı içeriği farklı ref altında çoğaltır. Bu ADR'nin
+kota ölçümleri (bugün %82,1 dolu) bu kararı daha da güçlendiriyor — ikinci bir yazım noktası
+bugünkü koşullarda çok daha maliyetli olurdu.
+
+Sonuçları: Değişmedi — cache yazımı tek noktada (build job) toplu.
+
+## Ölçüm — kararın dayandığı sayılar
+
+| Ölçüm | Değer | Kaynak |
+|---|---|---|
+| Backend `mode=min` local cache export boyutu | 97,4 MiB (12 blob) | `docker buildx build ./apps/backend/ --cache-to type=local,dest=...,mode=min` + `du -sk`, 2026-08-18 |
+| Backend `mode=max` local cache export boyutu | 684,7 MiB (25 blob) | Aynı komut, `mode=max`, 2026-08-18 |
+| Fark (mode=max ek maliyeti / generation) | ~587,3 MiB | Yukarıdaki iki ölçümün farkı |
+| Restore katmanı CACHE durumu, `mode=min` cache-from | **MISS** — 11,6 sn yeniden çalıştı | `docker buildx build --cache-from type=local,src=<cmin>` sonrası `.cs` değişikliğiyle, ham build log |
+| Restore katmanı CACHE durumu, `mode=max` cache-from | **HIT** — `CACHED`, 0 sn | Aynı senaryo, `--cache-from type=local,src=<cmax>` |
+| GHA cache toplam kullanım (2026-08-18) | 284 giriş / 8,210 GiB / 10 GiB = **%82,1** | `gh api /repos/Divizyon/cargo-pilot/actions/cache/usage` |
+| `node-cache-*` payı | 60 giriş / 4,468 GiB (kotanın %44,7'si, aktif kullanımın %54,4'ü) | `gh api .../actions/caches` (paginate), prefix toplamı |
+| `buildkit-blob-*` payı | 192 giriş / 3,667 GiB | Aynı döküm |
+| Aktif ref sayısı (tüm scope'lar) | 37 | `gh api .../actions/caches -q '.actions_caches[].ref' \| sort -u \| wc -l` |
+| Bugün canlı backend cache generation sayısı | 13 (`cargo-pilot-backend-ci` + `backend-test` index girişleri) | Aynı döküm, `grep -c` |
+| Extrapolasyon — 13 generation senaryosu | 587,3 MiB × 13 ≈ 7,46 GiB ek → toplam ~15,67 GiB (**%157** bütçe) | Yukarıdaki ölçümlerden türetildi |
+| Extrapolasyon — 37 ref senaryosu | 587,3 MiB × 37 ≈ 21,2 GiB ek → bütçenin **>2 katı** | Yukarıdaki ölçümlerden türetildi |
+| Frontend tek generation boyutu | ≈250–300 MiB (**tahmin**) | `cache-seed.yml` yorum satırı; bu ADR'de yeniden ölçülmedi |
+
+## Alternatifler
+
+| Alternatif | Neden seçilmedi |
+|---|---|
+| Backend `cache-to`'yu da `mode=max`'a çevirmek | **Ölçümle elendi.** Restore katmanının artık gerçek değeri var (CACHED vs 11,6 sn MISS), ama 587,3 MiB/generation × 13 canlı generation ≈ 7,46 GiB ek yük, kota zaten %82,1 dolu — toplam bütçenin %157'sine çıkar |
+| Backend cache'ini tamamen kapatmak (`cache-to` satırını silmek, yalnız `cache-from` bırakmak — deploy job'undaki gibi) | Restore katmanının artık ölçülmüş bir cross-commit değeri var; kapatmak bu kazancı da siler ve net bir gerileme olurdu, mevcut `mode=min` bu değerin bir kısmını (final image katmanları) zaten koruyor |
+| Dört cache satırının hepsini `mode=min`'e "hizalamak" | ADR-0007'den değişmeden devralındı: frontend `deps` stage'i dışa aktarılmaz, her build'de sıfırdan `npm ci` — frontend'de gerçek gerileme |
+| Node-cache temizliğiyle (Y-05) eşzamanlı olarak backend'i mode=max'a geçirmek | Y-05 paralel bir ajanın kapsamında ve henüz kapanmadı; ayrıca node-cache temizliği (~4,47 GiB kazanç) tek başına backend'in 7,5+ GiB'lik ek yükünü karşılamaya yetmiyor — iki değişikliği birleştirmek bu ADR'nin ölçüm tarihindeki kota durumuyla hâlâ negatif sonuç verir |
+
+*Dört elenen alternatif listelendi (şablonun istediği en az iki alternatifin üzerinde).*
+
+## Açık konular
+
+- Bu ADR'nin byte ölçümü **local `type=local` cache export**'a dayanır; gerçek GHA
+  `type=gha` export'u ağ sıkıştırması ve chunk boyutu farklarıyla sistematik olarak sapabilir.
+  Bir GHA ortamında `mode=max` ile gerçek bir backend build koşup `actions/caches` üzerinden
+  doğrulamak yapılmadı — bu ADR'nin sayısı bir **vekil ölçümdür**, birebir GHA doğrulaması
+  değildir.
+- "13 canlı backend generation" ve "37 aktif ref" rakamları 2026-08-18 anlık ölçümleridir;
+  branch/PR trafiğiyle günden güne değişir. Karar bu ölçümün büyüklük mertebesine
+  (kotanın kesin olarak aşılacağı) dayanır, tam sayıya değil.
+- **Yeniden açma koşulu:** node-cache borcu (Y-05, `docs/devops/devops-backlog.md` §6.9)
+  kapanıp kota kalıcı biçimde ~%50'nin altına inerse **ve** aktif backend generation sayısı
+  bugünkünün belirgin altındaysa, backend `mode=max` sorusu gerçek bir GHA ölçümüyle
+  yeniden açılabilir.
+- Frontend tek generation boyutu (~250-300 MiB) bu ADR'de yeniden ölçülmedi; `cache-seed.yml`
+  yorumundan alınan bir tahmindir.
+- Repo yakında private + geçmişsiz bir depoya taşınacak (bkz. `docs/devops/devops-backlog.md`
+  "Private repo geçişi" bölümü); taşınma sonrası kota sıfırlanacağı için bu ADR'nin
+  extrapolasyon rakamları (13/37 aktif ref) o noktada geçersiz olur ve karar taze bir
+  ölçümle gözden geçirilmelidir.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,9 +18,11 @@ neden elendiğini** söyler.
 | [ADR-0004](ADR-0004-denge-takasi-cift-yonlu-dogrulama.md) | Denge takasında çift yönlü doğrulama | Kabul edildi | 2026-08-15 |
 | [ADR-0005](ADR-0005-modul-bayraklari-disa-kapali.md) | Modül bayraklarının API'ye ve arayüze açılmaması | Kabul edildi | 2026-08-11 |
 | [ADR-0006](ADR-0006-uc-dalli-terfi-modeli.md) | Üç dallı terfi modeli ve Terfi workflow'u | Kabul edildi | 2026-08-03 |
-| [ADR-0007](ADR-0007-docker-build-cache-asimetrisi.md) | Docker build cache asimetrisi: backend `mode=min`, frontend `mode=max` | Kabul edildi | 2026-08-15 |
+| [ADR-0007](ADR-0007-docker-build-cache-asimetrisi.md) | Docker build cache asimetrisi: backend `mode=min`, frontend `mode=max` | Yerini aldı: ADR-0011 | 2026-08-15 |
 | [ADR-0008](ADR-0008-sha-pinleme-surum-yukseltmeden-ayri.md) | SHA pinleme, sürüm yükseltmesinden ayrılır | Kabul edildi | 2026-08-15 |
 | [ADR-0009](ADR-0009-otomatik-geri-alma-sessizce-basarili-donmez.md) | Otomatik geri alma sessizce başarılı dönmez | Kabul edildi | 2026-08-17 |
+| ADR-0010 | *(ayrılmış — duvar örücü ve arama katmanı, `feat/algoritma-arama-katmani` dalında)* | — | — |
+| [ADR-0011](ADR-0011-docker-build-cache-modu-backend-restore-sonrasi.md) | Docker build cache modu: backend restore katmanı ayrıldıktan sonra yeniden değerlendirme (ADR-0007'nin yerini alır) | Kabul edildi | 2026-08-18 |
 
 [ADR-0000](ADR-0000-sablon.md) numara değil, boş şablondur; indekste karar olarak sayılmaz.
 

--- a/docs/devops/devops-backlog.md
+++ b/docs/devops/devops-backlog.md
@@ -44,9 +44,9 @@ kayıt orada, plan burada; ikisi arasında tekrar bırakılmaz.
 | 18 | Rollback güvenliği — D-24, D-25, D-27 ✅ (#1012, #1017); kalan **D-29 (tatbikat)** | 🟠 Yüksek | ⚠️ Açık |
 | 19 | .NET 8 → .NET 10 LTS geçişi — D-32b, EOL **2026-11-10** | 🔴 Kritik (tarihe bağlı) | ⚠️ Açık — planlama |
 
-Kategori 6, 2026-08-03 taramasının **22 açık** D-bulgusunu D-kodlarıyla birlikte listeler
-(51'den 29'u kapandı); yukarıdaki matris yalnızca kritik kümeleri özetler. §6.9 önceki
-taramada olmayan, uygulama sırasında bulunan dört yeni kalemi tutar.
+Kategori 6, 2026-08-03 taramasının **17 açık** D-bulgusunu D-kodlarıyla birlikte listeler
+(51'den 34'ü kapandı); yukarıdaki matris yalnızca kritik kümeleri özetler. §6.9 önceki
+taramada olmayan, uygulama sırasında bulunan yedi yeni kalemi tutar.
 
 ---
 
@@ -354,8 +354,13 @@ Kapanan satırlar aşağıdaki tablolardan çıkarıldı ve [Tamamlananlar](#tam
 bölümüne taşındı. **İkinci tur (2026-08-18, Faz 1 + Faz 4):** 13 bulgu daha kapandı —
 D-08, D-30, D-31, D-32, D-33, D-34, D-37, D-39, D-46, D-47, D-48, D-49, D-50
 (PR #1043, #1044, #1045, #1046, #1047, #1048, #1049). D-38 **kısmen** kapandı.
+**Üçüncü tur (2026-08-18, Faz 5/6/8):** 5 bulgu daha kapandı — D-42, D-51 (#1053);
+D-06, D-12, D-45 (#1054). D-13(c) **kısmen** kapandı (#1054); D-13(a) daha önceden
+kapanmıştı, bugün 48/48 action SHA-pinli olarak yeniden doğrulandı. D-15 kapsamı netleşti
+(#1055) ama kapanmadı — maruziyet daraltıldı, kalan zarar sürüyor. D-09 için karar verildi
+(kaldırılsın); uygulama paralel bir ajanda, henüz PR yok.
 
-**Kalan: 22 açık bulgu** — 5 kritik, 6 yüksek, 7 orta, 4 düşük.
+**Kalan: 17 açık bulgu** — 5 kritik, 5 yüksek, 5 orta, 2 düşük.
 Prod kapısının dört maddesinden dördü de kapandı; **madde 2.1 teknik olarak açık**
 (sunucu teyidi için bkz. §6.8).
 
@@ -364,7 +369,7 @@ Prod kapısının dört maddesinden dördü de kapandı; **madde 2.1 teknik olar
 | Kod | Bulgu | Bugünkü kanıt (2026-08-16) | Öncelik |
 |---|---|---|---|
 | D-02 | Servis portları internete açık — **kısmen kapandı (#991), sonra kısmen yeniden açıldı** | Kalan: `docker-compose.monitoring.test.yml:89` Grafana `3002:3000`; `docker-compose.test.yml:127` ERP MSSQL `1435:1433` — bu ikincisi **#938 ile geldi** ve loopback'e bağlanmamış tek port (diğer 5'i `127.0.0.1:` önekli). `profiles: ["e2e"]` arkasında ama `--profile e2e` verilirse dışarı açılır | 🔴 Kritik |
-| D-15 | Workflow'da hardcoded fallback parolalar | `.github/workflows/test-deploy.yml:172,176,179,181,183` — `gh secret list`'te `TEST_MSSQL_SA_PASSWORD`/`TEST_MINIO_*`/`SEED_*` yok (2026-08-18: repoda tanımlı 6 secret var, bunlar arasında değil) → fallback'ler her koşuda fiilen kullanılıyor | 🟠 Yüksek |
+| D-15 | Workflow'da hardcoded fallback parolalar — **kapsamı netleşti (#1055)** | `docs/devops/secret-management.md:113-146` envanteri: 22 secret referansından **6'sı tanımlı**, **9'u tanımsız-fallback'li** (`test-deploy.yml:172,175,176,179,183-187,293,296,297,299`). **Maruziyet daraltıldı:** fallback'ler yalnız runner içinde yaşayan geçici stack'i besliyor (`deploy` + `e2e-smoke` job'ları, her run sonunda `docker compose down -v` ile siliniyor); gerçek `deploy-test-server` sunucusu kendi `infra/env/.env.test`'ini kullanıyor, hiç etkilenmiyor. **Asıl zarar kalıcı:** secret hiç tanımlanmamış olsa da iş yeşil geçiyor — eksikliğin fark edilmesini engelliyor, fallback'i koddan kaldırmak ayrı bir sonraki iş | 🟠 Yüksek |
 | D-17 | MSSQL container'ı root çalışıyor — **kapsam büyüdü** | `docker-compose.test.yml:90,118,147`, `docker-compose.prod.yml:92` — `user: root`. Sayı 2'den **4'e** çıktı: `:118` (`erp-mssql`) ve `:147` (`erp-mssql-init`) #938 ile eklendi. Prod'a geçmeden düzeltilmeli | 🟢 Düşük |
 
 ### 6.2 Yedekleme ve veri kaybı
@@ -386,10 +391,8 @@ Prod kapısının dört maddesinden dördü de kapandı; **madde 2.1 teknik olar
 
 | Kod | Bulgu | Bugünkü kanıt | Öncelik |
 |---|---|---|---|
-| D-06 | Default branch'te GHA cache hiç yazılmıyor | Default branch `main`; hiçbir workflow `main` push'unda build etmiyor (`ci.yml:6-20`, `test-deploy.yml:13`) → `cache-from` iş branch'lerinde soğuk başlar. Düzeltme: nightly veya `main` push'unda seed job | 🟡 Orta |
-| D-09 | `ci.yml`'daki `docker-build` job'u — **kısmen kapandı** (#992) | Artık yalnızca `dev` PR'ında koşuyor (`ci.yml:204`); iş branch'i push'undaki kopya build kaldırıldı. Kalan soru: `dev` kapısındaki build'in değeri | 🟢 Düşük |
-| D-12 | Gereksiz seri `needs:` zinciri | `ci.yml:196` — `docker-build`, `needs: [frontend-ci, backend-ci]`; docker build bu job'ların çıktısına bağımlı değil | 🟢 Düşük |
-| D-13 | Küçük CI kalemleri | (a) `test-deploy.yml:327,340` hâlâ `build-push-action` **v5.4.0**, diğer 6 kullanım v7.3.0 — sürüm ayrışması. **PR #1032 (Dependabot) bunu ve 6 action'ı daha hizalıyor; ADR-0008'in öngördüğü devralma**; (b) `setup-dotnet`'te NuGet cache yok (`ci.yml:168`, `test-deploy.yml:48`); (c) `migration-check` + `backend-ci` aynı solution'ı Release'de iki kez derliyor; (d) frontend scope'ları hâlâ `mode=max` (`ci.yml:240`, `test-deploy.yml:145`) | 🟡 Orta |
+| D-09 | `ci.yml`'daki `docker-build` job'u — **karar verildi: kaldırılacak** | Bugün yalnızca `dev` PR'ında koşuyor (`ci.yml:192,202`). Kullanıcı kararı: bu ikinci build'in değeri yok, kaldırılsın. Paralel bir ajan uyguluyor; **PR numarası henüz yok** | 🟢 Düşük |
+| D-13 | Küçük CI kalemleri | **(a) kapandı** — 48/48 GitHub Action kullanımı SHA-pinli doğrulandı (`grep -c` ile yeniden sayıldı, 2026-08-18); `build-push-action` artık 8 kullanımın tamamında v7.3.0 (PR #1032, ADR-0008'in öngördüğü devralma). **(b) ölçülerek ertelendi** — `setup-dotnet`'te NuGet cache yok (`ci.yml:168`, `test-deploy.yml:48`); `dotnet restore` bugün yalnız ~8 sn sürüyor, cache eklense girdi başına ~200 MiB **(tahmin)** × ~27 aktif ref ≈ 5,4 GiB **(tahmin)** ek yük — kota zaten %82 dolu, bu %32'ye yakın ek aşım demek. Ayrıca `setup-dotnet`'in `cache: true`'su `packages.lock.json` istiyor, repoda hiç yok. Yeniden açma koşulu: lock dosyalarına geçilirse **ve** kota belirgin biçimde düşerse. **(c) kısmen kapandı (#1054)** — `migration-check` artık yalnız `dotnet restore apps/backend/CargoPilot.WebAPI/CargoPilot.WebAPI.csproj` (`test-deploy.yml:56,58`) çalıştırıyor, tüm solution'ı değil. **Tam tekilleştirme açık kalıyor:** `migration-check` (`test-deploy.yml`) ve `backend-ci` (`ci.yml`) farklı workflow dosyalarında, `needs:` yalnız aynı workflow içinde çalıştığı için iki job birleştirilemiyor. **(d) borç değil, ADR revize edildi** — ADR-0007'nin kendi yazdığı yeniden değerlendirme koşulu (#1047 ile restore/publish ayrı katmanlara bölündü) gerçekleşti; **ADR-0011** ölçerek backend'in `mode=min`'de kalmasına karar verdi (gerekçe değişti: artık ölçülmüş bir değer var — restore katmanı CACHED dönüyor — ama GHA kotası [`node-cache` tek başına kotanın %44,7'si] kaldırmıyor), frontend `mode=max` aynen sürüyor | 🟡 Orta |
 
 ### 6.5 Docker image ve build
 
@@ -405,11 +408,8 @@ Prod kapısının dört maddesinden dördü de kapandı; **madde 2.1 teknik olar
 | D-38 | Kaynak limitleri — **kısmen kapandı** (#1044) | Bellek tarafı kapandı: 22 servis tanımının tamamında `mem_limit` var (12 benzersiz servis, test 12 / prod 10). **Kalan:** `cpus` ve `pids_limit` hiçbir serviste yok — `grep -rn 'cpus\|pids_limit' infra/compose/` boş döner. CPU açlığı ve fork bombası hâlâ korumasız | 🔴 Kritik |
 | D-40 | Log rotation hiçbir serviste yok | `infra/` altında `logging:`/`max-size` hiç geçmiyor — 16 servisin tamamı etkileniyor. **known-issues #7 ile aynı konu**; o madde kapsamı bu bulguya göre düzeltilmişti. ⚠️ Sunucuda `/etc/docker/daemon.json` global rotation olabilir, önce bakılmalı | 🟠 Yüksek |
 | D-41 | Grafana SMTP hiç yapılandırılmamış | `infra/` altında `GF_SMTP` hiç geçmiyor; contact point ve notification policy dosyaları **mevcut**. **Bu madde 2.4'ün kanıtıdır** — teşhis oraya işlendi. Resend doğrulaması (known-issues #1) bitene kadar Slack/Discord webhook daha güvenli seçim | 🟠 Yüksek |
-| D-42 | Prod monitoring, test alert kurallarını da yüklüyor | `docker-compose.monitoring.prod.yml:83` alerting dizininin tamamını mount ediyor; dizinde `*.test.yml` dosyaları da var → prod Grafana `prometheus-test` UID'lerine bakan kuralları yükler, contact point UID'leri çakışır | 🟠 Yüksek |
 | D-43 | Eksik alert kuralları | `alert-rules.yml` 6 kural içeriyor. Eksik: MSSQL/MinIO container down, disk %90 critical, yedek başarısızlığı (D-20), monitoring'in kendi sağlığı, SSL bitiş tarihi. `monitoring-setup.md:157-161` hâlâ 3 kural listeliyor | 🟡 Orta |
 | D-44 | Prometheus/Loki retention ve limitler | `docker-compose.monitoring.*.yml:61` yalnız `--storage.tsdb.retention.time=30d`, **boyut tavanı yok**; Prometheus kendini/Grafana'yı/Loki'yi/MinIO'yu scrape etmiyor; Loki `limits_config`'te ingestion rate limit yok | 🟡 Orta |
-| D-45 | Promtail sadece 2 container'ı topluyor | `infra/docker/promtail/promtail.{test,prod}.yml:19` — yalnız backend/frontend. MSSQL, MinIO ve monitoring logları hiç toplanmıyor. Ayrıca `:6` `positions.filename: /tmp/positions.yaml` volume'suz → her restart'ta pozisyon kaybı | 🟡 Orta |
-| D-51 | Ölü konfigürasyon dosyaları | `infra/docker/minio/config/init-bucket.sh` ve `infra/docker/mssql/init/init.sql` hiçbir compose'da mount edilmiyor (`grep` sıfır sonuç) | 🟢 Düşük |
 
 ### 6.7 Doküman düzeltmeleri (kaynak §8)
 
@@ -445,9 +445,9 @@ açık**. Kapanış kanıtları:
 
 ---
 
-### 6.9 İkinci turdan çıkan yeni kalemler (2026-08-18)
+### 6.9 İkinci ve üçüncü turdan çıkan yeni kalemler (2026-08-18)
 
-Faz 1 ve Faz 4 sırasında bulunan, önceki taramada olmayan maddeler.
+Faz 1/4 ve Faz 5/6/8 sırasında bulunan, önceki taramada olmayan maddeler.
 
 | Kalem | Bulgu | Öncelik |
 |---|---|---|
@@ -455,6 +455,9 @@ Faz 1 ve Faz 4 sırasında bulunan, önceki taramada olmayan maddeler.
 | **Y-02 · Cloudflare 524** | Nginx `proxy_read_timeout` uzatıldı (D-46), ama Cloudflare kendi **100 sn**'lik origin timeout'unda **524** döndürüyor. Uzun optimizasyon koşusu için nginx tarafındaki iyileştirme kullanıcıya ulaşmıyor. Çözüm ya asenkron iş modeli ya Cloudflare tarafında ayar | 🟠 Yüksek |
 | **Y-03 · D-33 canlıda doğrulanmadı** | `imagetools create` yerelde doğrulandı; **gerçek GHCR'a karşı koşmadı**. İlk `sync-base-images` koşumunda `docker buildx imagetools inspect ghcr.io/divizyon/cargo-pilot-dotnet-sdk:8.0` ile multi-arch manifest'in korunduğu teyit edilmeli | 🟡 Orta |
 | **Y-04 · Perf taban çizgisi elle güncellenecek** | `PerformansTabanCizgisiTests` eşikleri bugünkü **regresyonlu** WeightBalance ölçümünü (29 sn) taban alıyor. F2-01 süreyi 11,4 sn'ye çektiğinde eşik otomatik daralmaz — taban çizgisi **elle** güncellenmeli, yoksa regresyon penceresi 2 kat yerine 5 kat açık kalır | 🟡 Orta |
+| **Y-05 · `node-cache` kotanın yarısını götürüyor, temizlik ona dokunamıyor** | Ölçüm (2026-08-18, `gh api .../actions/caches`): `node-cache-Linux-x64-npm-*` → 60 giriş / **4,468 GiB = kotanın %44,7'si** (toplam 284 giriş / 8,210 GiB / 10 GiB = %82,1). `cache-cleanup.yml`'nin boyut adımı yalnız `select(.key|startswith("buildkit-blob"))` filtresiyle çalışıyor, `node-cache` hiç süzülmüyor. Kök neden: `package-lock.json` aynı olsa bile her branch ve her PR ref'i kendi ~76 MiB kopyasını yazıyor. **Kullanıcı onayladı, paralel ajan uyguluyor:** (a) temizlik filtresine `node-cache` eklenmesi, (b) `setup-node`'un dahili cache'inin `cache/restore` (her zaman) + `cache/save` (yalnız default branch) olarak bölünmesi | 🟠 Yüksek |
+| **Y-06 · `ci.yml`'de `concurrency` grubu yok** | Aynı branch'e hızlı ardışık push'lar tam CI'ı baştan koşuyor (`feat/algoritma-arama-katmani`'nda 8 koşum, ikisi saniyeler arayla). Private repoda doğrudan fatura kalemi. **Kullanıcı onayladı, paralel ajan uyguluyor** — `cancel-in-progress` yalnız `pull_request` olaylarında, aksi hâlde korunan dallarda zorunlu check `cancelled` kalıp merge'i bloke eder | 🟠 Yüksek |
+| **Y-07 · promtail `mem_limit: 128m` gözden geçirilmeli** | D-45 sonrası 2 yerine ~8 container scrape edilecek; limit #1044 ile konuldu ve o zamanki kapsamı (2 container) yansıtıyor, D-45'in genişlettiği kapsamı değil | 🟡 Orta |
 
 ---
 
@@ -526,6 +529,58 @@ regresyon çıkarsa müdahale için tampon süre kalır.
 
 ---
 
+## Private repo geçişi
+
+{% hint style="warning" %}
+**⚠️ Planlama — geçiş tarihi henüz kesin değil**
+{% endhint %}
+
+Depo yakında **private bir repoya, geçmiş olmadan, sıfırdan tek ilk commit** olarak
+taşınacak. Bu, sıradan bir `git clone` + push değil — GitHub'ın repo geçmişine bağlı
+tüm mekanizmaları sıfırlanır. Aşağıdaki liste, taşınmadan önce planlanması gereken
+kayıpları ve maliyet kalemlerini kaydeder.
+
+### Geçişte kaybolacaklar
+
+- **17 sürüm tag'i, 6 GitHub Release, 28 `archive/*` tag'i** — `gh api /repos/Divizyon/cargo-pilot/tags`
+  ve `.../releases` ile bugün doğrulandı (45 toplam tag = 17 sürüm + 28 `archive/*`; 6 release).
+  GHCR'daki `v0.11`–`v0.17` imaj etiketleri de yeni repoda karşılıksız kalır (bu imajlar
+  bugünkü org/paket altında duruyor, ancak yeni repo farklı bir görünürlük/paket ağacına
+  taşınacaksa erişim yeniden kurulmalı) → **v0.11 ve sonrası için rollback yeteneği gidiyor.**
+  D-29 (rollback tatbikatı) geçişten **önce** yapılmalı, ya da yeni repoda imaj/tag
+  stratejisi baştan kurulmalı — hangisi önce olursa.
+- **Dependabot ve CodeQL alert geçmişi sıfırlanır.** Yeni repo, güvenlik taramalarına
+  temiz bir sayfa ile başlar; bugünkü açık/kapalı alert kaydı taşınmaz.
+- **GHA cache sıfırlanır** (bugün 284 giriş / 8,21 GiB — `gh api /repos/Divizyon/cargo-pilot/actions/cache/usage`,
+  2026-08-18). Bu bir kayıp değil bir fırsat: `cache-seed.yml` (D-06) ilk günden itibaren
+  default branch cache'ini besleyeceği için soğuk-başlangıç sorunu bu kez hiç yaşanmaz.
+- **Actions dakikaları ücretli hale gelir.** Public repo'da GitHub Actions dakikaları
+  sınırsız/ücretsizdi; private repoda plana bağlı bir kotaya ve faturaya döner. Bu, CI
+  süresini kısaltan her iş kalemini (D-12, Y-06, gelecekteki paralelleştirme) bir performans
+  iyileştirmesinden bir **maliyet kalemine** çevirir.
+- **Gerekçesi düşen kalemler:** OpenSSF Scorecard'a bağlı maddeler private repoda anlamını
+  yitirir (Scorecard yalnızca public repoları puanlar) — `LICENSE` maddesi zaten yapıldı
+  (✅), CODEOWNERS/zorunlu review kararı da bu gerekçeyle yeniden değerlendirilebilir. Git
+  geçmişi temizliği (`git filter-repo` ile SA parolasının geçmişten silinmesi, madde 2.6)
+  de anlamsızlaşır — sıfırdan tek commit zaten geçmişi siliyor.
+
+### Gerekçesi DÜŞMEYEN kalemler
+
+- **SA parola rotasyonu (madde 2.6).** Parola **zaten** public repoda açığa çıktı; taşınma
+  bunu geri almaz, yalnızca geleceğe kapı kapatır. Rotasyon hâlâ zorunludur.
+- **Sunucu tarafı maruziyet** (D-15'in gerçek zararı, `.env.test`/`.env.prod` dosyaları,
+  SSH erişimi vb.) — repo geçmişiyle ilgisiz, sunucuda duruyor.
+- **Yedekleme boşlukları** (D-03, D-04, D-20) — repo taşınmasıyla hiçbir ilgisi yok.
+
+### Yeni repoda minimum secret kümesi
+
+Yeni repoda hangi secret'ların tanımlanması gerektiği ayrıca çıkarılmadı — bu envanter
+zaten `docs/devops/secret-management.md`'nin **"Yeni Repoya Geçiş — Minimum Secret Kümesi"**
+bölümünde (satır 296+) mevcut ve güncel (#1055); burada tekrarlanmıyor, doğrudan oraya
+bakılmalı.
+
+---
+
 ## Tamamlananlar (Tarih Sırası)
 
 | Tarih | Madde | PR / Aksiyon |
@@ -566,3 +621,8 @@ regresyon çıkarsa müdahale için tampon süre kalır.
 | 2026-08-18 | **D-31** Frontend base image `nginx:1.31-alpine` → `alpine-slim` (imaj 33 MB) | #1048 |
 | 2026-08-18 | **D-32** Sync cron'u patch döngüsüne yaklaştırıldı; stratejik kısım §6.9'a ayrıldı | #1048 |
 | 2026-08-18 | **D-37** `.dockerignore` hijyeni genişletildi (frontend + backend) | #1049 |
+| 2026-08-18 | **D-42** Prod monitoring alerting mount'u dosya bazlı ayrıldı — prod artık yalnız kendi 6 kuralını yüklüyor (eskiden 12: 6 kendi + 6 test'in, test kuralları `prometheus-test` UID'ine bakıyordu); repo toplamı 12 kural korundu | #1053 |
+| 2026-08-18 | **D-51** Ölü konfigürasyon dosyaları silindi — `infra/docker/minio/config/init-bucket.sh` ve `infra/docker/mssql/init/init.sql` (yalnız TODO yorumu, gövde yok); işlevleri `MinioStorageService.cs:66` `EnsureBucketExistsAsync()` ve `DbInitializer.cs:28` `Database.MigrateAsync()` ile karşılanıyor | #1053 |
+| 2026-08-18 | **D-12** `docker-build`'in `needs: [frontend-ci, backend-ci]` zinciri kaldırıldı — `ci.yml` PR→dev duvar saati 363 → 238 sn (−%34, 4 koşum ölçümü) | #1054 |
+| 2026-08-18 | **D-06** Nightly `cache-seed.yml` eklendi — default branch'te frontend `mode=max` cache'i besleniyor, iki katmanlı kota koruması (her koşumda prune + 9 GiB valfi) | #1054 |
+| 2026-08-18 | **D-45** Promtail tüm `cargo-pilot-*` container'larını topluyor (canlı Loki ile doğrulandı: `cargo-pilot-loki-test` ingest edildi, `-prod` ve promtail'in kendisi filtrelendi); `positions.filename` kalıcı bind mount'a taşındı | #1054 |


### PR DESCRIPTION
## Özet

İki iş: **ADR-0011** (ADR-0007'nin kendi tetiklediği yeniden değerlendirme) ve **backlog tazelemesi** (Faz 5/6/8'in ilk turu + private repo geçişi bölümü).

---

## 1 · ADR-0011 — ADR-0007 kendi koşulunu tetikledi

ADR-0007 satır 61-62 şunu yazmıştı:

> *"Backend Dockerfile'ı ileride `restore` ve `publish`'i ayrı `RUN` katmanlarına bölerse bu madde yeniden değerlendirilmelidir — o zaman `mode=max`'ın gerçek bir karşılığı olur."*

**PR #1047 tam bunu yaptı.** `apps/backend/Dockerfile:21` (`RUN dotnet restore`) ve `:37` (`RUN dotnet publish --no-restore`) artık ayrı katmanlar. Koşul gerçekleşti, yeniden değerlendirme yapıldı.

### Ölçüm — kararın dayandığı sayılar

Yerel, Docker 29.7.2, buildx `docker-container` driver, `type=local` cache export'u GHA vekili olarak:

| Ölçüm | `mode=min` | `mode=max` |
|---|---|---|
| Export boyutu | 97,4 MiB (12 blob) | **684,7 MiB (25 blob)** |
| Delta | | **≈587,3 MiB / generation** |

**Değer kontrolü:** `Program.cs` değiştirilip (yalnız kaynak değişikliği) `--cache-from` ile yeniden build edildi:

| | restore katmanı |
|---|---|
| `mode=min` cache'inden | **MISS** — 11,6 s yeniden koştu |
| `mode=max` cache'inden | **CACHED HIT** |

Yani **ADR-0007'nin öngörüsü doğru çıktı: `mode=max`'ın artık gerçek bir çapraz-commit değeri var.**

### Ama kota yasaklıyor

Taze `gh api` ölçümü: **284 giriş / 8,21 GiB / 10 GiB (%82,1)**; `node-cache-*` tek başına 60 giriş / 4,47 GiB (%44,7); **37 aktif ref**, bunlardan **13'ü** şu an canlı backend cache generation'ı taşıyor.

| Kapsam | Ek maliyet | Toplam |
|---|---|---|
| 587,3 MiB × 13 canlı generation | ≈ 7,46 GiB | ≈ 15,7 GiB = **kotanın %157'si** |
| 587,3 MiB × 37 aktif ref | ≈ 21,2 GiB | **kotanın 2 katından fazla** |

Her iki senaryoda da backend'i `mode=max`'a çevirmek kotayı patlatıyor.

### Karar

**Backend `mode=min`'de kalır — sonuç değişmedi, gerekçe değişti.** Eski gerekçe "ara katman yok, `mode=max`'ın karşılığı yok"; yeni gerekçe **"karşılığı var, kota izin vermiyor"**. Frontend `mode=max` değişmedi.

Dört numaralı alt karar (her biri `Gerekçe` + `Sonuçları` ile), **dört elenen alternatif** (konvansiyon en az iki istiyor):

| Elenen alternatif | Neden |
|---|---|
| Backend'i de `mode=max`'a çevirmek | **Ölçümle elendi** — yukarıdaki kota aritmetiği |
| Backend cache'ini tamamen kapatmak | — |
| Dört cache satırını `mode=min`'e "hizalamak" | ADR-0007'den değişmeden devralındı |
| Y-05 ile eşzamanlı olarak backend'i `mode=max`'a geçirmek | Y-05 paralel PR'da, sonucu henüz gözlenmedi |

### ADR-0007'nin durumu

`Durum: Kabul edildi` → **`Yerini aldı: ADR-0011`**. **Gövdesine dokunulmadı** — diff tam olarak 1 ekleme / 1 silme, yalnız o satır.

Neden tam devralma: ADR-0007'nin iki kararı var ve #2 (frontend `mode=max`) hâlâ geçerli; konvansiyonun dört durum değeri **kısmi devralmayı ifade edemiyor**. Bu yüzden ADR-0011 karar #2'yi kendi içinde yeniden ifade edip yürürlükte tutuyor — böylece güncel cache politikasını **tek** yürürlükteki ADR anlatıyor.

### ⚠️ ADR-0010 ayrıldı, kullanılmadı

`docs/adr/README.md` indeksine şu satır eklendi:

```
| ADR-0010 | *(ayrılmış — duvar örücü ve arama katmanı, `feat/algoritma-arama-katmani` dalında)* | — | — |
```

**Sebep:** `ADR-0010-duvar-orucu-ve-arama-katmani.md` o dalda **zaten var** ama `dev`'de değil. Konvansiyon "bir numara asla geri kullanılmaz" diyor ve paralel çalışmada numaranın önden ayrılabileceğini öngörüyor. `dev`'de 0010 kullanılsaydı o dal merge olduğunda çakışacaktı.

`SUMMARY.md`'ye ADR-0011 satırı eklendi (konvansiyon aynı PR'da şart koşuyor).

---

## 2 · Backlog tazelemesi

Her kalem yazılmadan önce **repo durumuna karşı doğrulandı**, prompt'tan kopyalanmadı.

**Kapatılanlar → Tamamlananlar bölümüne taşındı:**

| Bulgu | PR | Kanıt |
|---|---|---|
| **D-42** | #1053 | Alerting dosya bazlı mount; prod artık yalnız kendi 6 kuralını yüklüyor (eskiden 12) |
| **D-51** | #1053 | Ölü `init-bucket.sh` / `init.sql` silindi; işlevleri `MinioStorageService.cs:66` ve `DbInitializer.cs:28`'de |
| **D-12** | #1054 | `needs:` zinciri kaldırıldı; 363 → 238 sn (−%34) |
| **D-06** | #1054 | `cache-seed.yml` mevcut |
| **D-45** | #1054 | Promtail tüm `cargo-pilot-*`'ı topluyor, positions kalıcı |

**Güncellenenler:**
- **D-13(c)** — yerinde "kısmi" işaretlendi: `migration-check` artık yalnız `CargoPilot.WebAPI.csproj` grafını restore ediyor; tam tekilleştirme çapraz-workflow `needs:` sınırı yüzünden açık.
- **D-13(a)** — kapalı doğrulandı: 48/48 action SHA-pinli, `build-push-action` her yerde v7.3.0.
- **D-09** — "karar verildi: kaldır, paralel ajan uyguluyor" (PR #1056).
- **D-15** — daraltılmış kapsam kanıtıyla güncellendi (22 referans / 6 tanımlı / 9 fallback), **açık kalıyor** 🟠.

**§6.9'a eklenen yeni kalemler:** Y-05 (node-cache kotanın %44,7'si), Y-06 (`ci.yml`'de `concurrency` yok), Y-07 (promtail `mem_limit` gözden geçirilmeli).

**Açık bulgu yeniden sayıldı — 6.1–6.6 tablolarından doğrudan sayarak:**

| | Önce | **Şimdi** |
|---|---|---|
| Açık D-bulgusu | 22 | **17** |
| Kritik | 5 | 5 |
| Yüksek | 6 | 5 |
| Orta | 7 | 5 |
| Düşük | 4 | 2 |

§6.8'in "sunucuda teyit gerektirenler" uyarısı **dokunulmadı**.

### Yeni bölüm: private repo geçişi

Depo private bir repoya, **geçmiş olmadan, sıfırdan tek ilk commit** olarak taşınacak. `gh api` ile doğrulandı: **45 tag** (17 sürüm + 28 `archive/*`) ve **6 Release** var.

Geçişte kaybolacaklar ve sonuçları:
- 17 sürüm tag'i · 6 Release · 28 `archive/*` tag'i · GHCR'daki v0.11–v0.17 imajları → **v0.11+ rollback yeteneği gidiyor** (D-29 tatbikatı geçişten önce yapılmalı ya da yeni repoda imaj/tag stratejisi baştan kurulmalı)
- Dependabot ve CodeQL alert geçmişi sıfırlanır
- GHA cache sıfırlanır → `cache-seed.yml` ilk günden değerli
- Actions dakikaları **ücretli** → süre kısaltma işleri maliyet kalemi

**Gerekçesi düşen kalemler:** OpenSSF Scorecard bağlantılı olanlar (`LICENSE` zaten yapıldı; CODEOWNERS/review kararı), git geçmişi temizliği.
**Gerekçesi DÜŞMEYEN:** SA parola rotasyonu (parola public repoda zaten açığa çıktı, taşınmak geri almıyor) · sunucu tarafı maruziyet · yedekleme boşlukları.

Yeni repoda tanımlanacak minimum secret kümesi **tekrarlanmadı** — #1055'in `secret-management.md` §"Yeni Repoya Geçiş" bölümüne atıf verildi.

## İlgili User Story / Issue

ADR-0007'nin yeniden değerlendirme koşulu · Faz 5/6/8 ilk turu · private repo geçişi

## Değişiklik Tipi

- [x] 📄 Dokümantasyon / mimari karar kaydı

## Test Edildi mi?

- [x] `Dockerfile:21` / `:37` katman ayrımı doğrulandı (ADR-0011'in ön koşulu)
- [x] `mode=min` vs `mode=max` export boyutu ve CACHED farkı **gerçekten ölçüldü**
- [x] Kota ve aktif ref sayısı taze `gh api` çağrısıyla alındı
- [x] Backlog'daki her kapanış repo durumuna karşı doğrulandı
- [x] Açık bulgu sayısı tablolardan **yeniden sayıldı** (17), verilen rakam kopyalanmadı
- [x] ADR-0007'nin gövdesi **değişmedi** (diff: 1 satır, yalnız `Durum`)
- [x] Diff yalnız `docs/**` + `SUMMARY.md` → workflow/infra/apps dokunulmadı

## Ekran Görüntüleri

UI değişikliği yok.

## Kontrol Listesi

- [x] Kod standartlarına uygun
- [x] Commit mesajları commit kurallarına uygun
- [x] Linter hataları yok
- [x] Self-review yapıldı
- [x] Dokümantasyon güncellendi — `docs/adr/README.md` indeksi ve `SUMMARY.md` aynı PR'da

## Ek Notlar

- **Ölçüm vekili açıkça işaretli:** ADR-0011'in byte maliyeti yerel `type=local` export'undan türetildi, gerçek GHA `type=gha` ölçümü değil. Bu, ADR-0011'in `## Açık konular` bölümünde yazılı.
- Backlog'daki "13 canlı generation / 37 aktif ref" anlık `gh api` okumaları — günlük kayar.
- Bu PR **yalnız doküman**; kod, workflow ve infra dosyası değişmedi.
