### PR TITLE
Refresh token'lar veritabanında hash'lenerek saklanıyor

### DIFF
--- a/apps/backend/CargoPilot.Domain/Entities/UserSession.cs
+++ b/apps/backend/CargoPilot.Domain/Entities/UserSession.cs
@@ -4,7 +4,11 @@ public sealed class UserSession {
     public Guid Id { get; private set; }
     public DateTime CreatedAtUtc { get; private set; }
     public Guid UserId { get; private set; }
-    public string Token { get; private set; } = null!;
+    /// <summary>
+    /// Refresh token'ın SHA-256 hash'i. Ham token hiçbir zaman saklanmaz;
+    /// yalnızca istemciye döner. Doğrulama gelen token'ın hash'i ile yapılır.
+    /// </summary>
+    public string TokenHash { get; private set; } = null!;
     public string? CreatedByIp { get; private set; }
     public DateTime ExpiresAt { get; private set; }
     public DateTime LastUsedAt { get; private set; }
@@ -23,7 +27,7 @@ public sealed class UserSession {
     public UserSession(
         Guid id,
         Guid userId,
-        string token,
+        string tokenHash,
         DateTime expiresAt,
         DateTime lastUsedAt,
         string? createdByIp = null,
@@ -31,7 +35,7 @@ public sealed class UserSession {
         Id = id;
         CreatedAtUtc = DateTime.UtcNow;
         UserId = userId;
-        Token = token;
+        TokenHash = tokenHash;
         CreatedByIp = createdByIp;
         ExpiresAt = expiresAt;
         LastUsedAt = lastUsedAt;

--- a/apps/backend/CargoPilot.Infrastructure.Tests/RefreshTokenHasherTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/RefreshTokenHasherTests.cs
@@ -1,0 +1,48 @@
+using CargoPilot.Infrastructure.Security;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// Refresh token'larin veritabanina yalnizca hash'lenerek yazildigini sabitler.
+/// Ham token asla saklanmaz; dogrulama gelen token'in hash'i uzerinden yapilir.
+/// </summary>
+public sealed class RefreshTokenHasherTests
+{
+    private const string SampleToken = "yTLC0Nn0M9pDh0DkTBB0kwFVYIu2BZ0kEEXtQ0TIS6M=";
+
+    [Fact]
+    public void Hash_AyniTokenIcin_HerZamanAyniDegeriUretir()
+    {
+        var first = RefreshTokenHasher.Hash(SampleToken);
+        var second = RefreshTokenHasher.Hash(SampleToken);
+
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void Hash_HamTokendanFarklidir()
+    {
+        var hash = RefreshTokenHasher.Hash(SampleToken);
+
+        Assert.NotEqual(SampleToken, hash);
+        Assert.DoesNotContain(SampleToken, hash, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Hash_FarkliTokenlarIcin_FarkliDegerUretir()
+    {
+        var first = RefreshTokenHasher.Hash(SampleToken);
+        var second = RefreshTokenHasher.Hash(SampleToken + "x");
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void Hash_KolonUzunluguIle_UyumluHexDondurur()
+    {
+        var hash = RefreshTokenHasher.Hash(SampleToken);
+
+        Assert.Equal(64, hash.Length);
+        Assert.All(hash, ch => Assert.True(char.IsAsciiHexDigitUpper(ch), $"Beklenmeyen karakter: {ch}"));
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Auth/AuthService.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Auth/AuthService.cs
@@ -10,6 +10,7 @@ using CargoPilot.Application.Features.Auth.DTOs;
 using CargoPilot.Domain.Entities;
 using CargoPilot.Domain.Enums;
 using CargoPilot.Infrastructure.Persistence;
+using CargoPilot.Infrastructure.Security;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -27,12 +28,11 @@ internal sealed class AuthService : IAuthService
 #pragma warning restore S2068
 
     /// <summary>
-    /// Refresh token'lar veritabanına hash'lenerek yazılır; veritabanı sızıntısında
-    /// token'lar doğrudan kullanılamaz. Token yüksek entropili rastgele değer
-    /// olduğundan sözlük saldırısı geçerli değildir, SHA-256 yeterlidir.
+    /// Refresh token'lar veritabanına yalnızca hash'lenerek yazılır; ham token
+    /// sadece istemciye döner. Doğrulama <see cref="RefreshTokenHasher"/> üzerinden yapılır.
     /// </summary>
     private static string HashRefreshToken(string refreshToken)
-        => Convert.ToHexString(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(refreshToken)));
+        => RefreshTokenHasher.Hash(refreshToken);
 
     private static readonly Action<ILogger, Guid, Exception?> LogNewDeviceEmailFailed =
         LoggerMessage.Define<Guid>(
@@ -241,7 +241,7 @@ internal sealed class AuthService : IAuthService
         var session = new UserSession(
             id: Guid.NewGuid(),
             userId: user.Id,
-            token: HashRefreshToken(refreshToken),
+            tokenHash: HashRefreshToken(refreshToken),
             expiresAt: sessionExpiry,
             lastUsedAt: now,
             createdByIp: ipAddress,
@@ -309,7 +309,7 @@ internal sealed class AuthService : IAuthService
 
         var session = await _context.UserSessions
             .Include(s => s.User)
-            .FirstOrDefaultAsync(s => s.Token == hashedToken, cancellationToken);
+            .FirstOrDefaultAsync(s => s.TokenHash == hashedToken, cancellationToken);
 
         if (session is null || session.User is null)
             return Result<RefreshResponse>.Failure(AuthErrors.InvalidToken);
@@ -355,7 +355,7 @@ internal sealed class AuthService : IAuthService
         var newSession = new UserSession(
             id: Guid.NewGuid(),
             userId: session.UserId,
-            token: HashRefreshToken(newRefreshToken),
+            tokenHash: HashRefreshToken(newRefreshToken),
             expiresAt: sessionExpiry,
             lastUsedAt: now,
             createdByIp: ipAddress,
@@ -466,7 +466,7 @@ internal sealed class AuthService : IAuthService
         var hashedToken = HashRefreshToken(refreshToken);
 
         var session = await _context.UserSessions
-            .FirstOrDefaultAsync(s => s.Token == hashedToken, cancellationToken);
+            .FirstOrDefaultAsync(s => s.TokenHash == hashedToken, cancellationToken);
 
         if (session is null || session.IsRevoked)
             return Result<bool>.Success(true);
@@ -519,7 +519,7 @@ internal sealed class AuthService : IAuthService
         _context.UserSessions.Add(new UserSession(
             id: Guid.NewGuid(),
             userId: user.Id,
-            token: HashRefreshToken(refreshToken),
+            tokenHash: HashRefreshToken(refreshToken),
             expiresAt: sessionExpiry,
             lastUsedAt: now,
             createdByIp: null,

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/UserSessionConfiguration.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Configurations/UserSessionConfiguration.cs
@@ -16,8 +16,9 @@ internal sealed class UserSessionConfiguration : IEntityTypeConfiguration<UserSe
         builder.Property(session => session.UserId)
             .IsRequired();
 
-        builder.Property(session => session.Token)
-            .HasMaxLength(500)
+        // SHA-256 hash hex olarak 64 karakter; kolon sabit uzunlukta tutulur.
+        builder.Property(session => session.TokenHash)
+            .HasMaxLength(64)
             .IsRequired();
 
         builder.Property(session => session.CreatedByIp)
@@ -41,6 +42,6 @@ internal sealed class UserSessionConfiguration : IEntityTypeConfiguration<UserSe
             .HasForeignKey(session => session.UserId)
             .OnDelete(DeleteBehavior.Cascade);
 
-        builder.HasIndex(session => session.Token);
+        builder.HasIndex(session => session.TokenHash);
     }
 }

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260818184243_UserSessionTokenHashlendi.Designer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260818184243_UserSessionTokenHashlendi.Designer.cs
@@ -4,6 +4,7 @@ using CargoPilot.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CargoPilot.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260818184243_UserSessionTokenHashlendi")]
+    partial class UserSessionTokenHashlendi
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -784,28 +787,6 @@ namespace CargoPilot.Infrastructure.Persistence.Migrations
                     b.Property<string>("ReportUrl")
                         .HasMaxLength(2048)
                         .HasColumnType("nvarchar(2048)");
-
-                    b.Property<long?>("SearchDurationMs")
-                        .HasColumnType("bigint");
-
-                    b.Property<int?>("SearchEvaluations")
-                        .HasColumnType("int");
-
-                    b.Property<bool?>("SearchImproved")
-                        .HasColumnType("bit");
-
-                    b.Property<int?>("SearchIterations")
-                        .HasColumnType("int");
-
-                    b.Property<int>("Seed")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasDefaultValue(0);
-
-                    b.Property<int>("Sequencer")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int")
-                        .HasDefaultValue(0);
 
                     b.Property<string>("ThumbnailUrl")
                         .HasColumnType("nvarchar(max)");

--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260818184243_UserSessionTokenHashlendi.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Migrations/20260818184243_UserSessionTokenHashlendi.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CargoPilot.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class UserSessionTokenHashlendi : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Duz metin refresh token'lar hash'e cevrilemez (tek yonlu fonksiyon).
+            // Kolon dusurulmeden once tum aktif oturumlar gecersiz kilinir; kullanicilar
+            // bir kez yeniden login olur. Satirlar silinmez, cihaz gecmisi korunur.
+            migrationBuilder.Sql("UPDATE [UserSessions] SET [IsRevoked] = 1 WHERE [IsRevoked] = 0;");
+
+            migrationBuilder.DropIndex(
+                name: "IX_UserSessions_Token",
+                table: "UserSessions");
+
+            migrationBuilder.DropColumn(
+                name: "Token",
+                table: "UserSessions");
+
+            migrationBuilder.AddColumn<string>(
+                name: "TokenHash",
+                table: "UserSessions",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserSessions_TokenHash",
+                table: "UserSessions",
+                column: "TokenHash");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_UserSessions_TokenHash",
+                table: "UserSessions");
+
+            migrationBuilder.DropColumn(
+                name: "TokenHash",
+                table: "UserSessions");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Token",
+                table: "UserSessions",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserSessions_Token",
+                table: "UserSessions",
+                column: "Token");
+        }
+    }
+}

--- a/apps/backend/CargoPilot.Infrastructure/Security/RefreshTokenHasher.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Security/RefreshTokenHasher.cs
@@ -1,0 +1,16 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace CargoPilot.Infrastructure.Security;
+
+/// <summary>
+/// Refresh token'lar veritabanına hash'lenerek yazılır; veritabanı sızıntısında
+/// token'lar doğrudan kullanılamaz. Token yüksek entropili rastgele değer
+/// olduğundan sözlük saldırısı geçerli değildir, SHA-256 yeterlidir.
+/// Parola sıfırlama ve e-posta değişikliği token'larıyla aynı hash deseni kullanılır.
+/// </summary>
+public static class RefreshTokenHasher {
+    /// <summary>Ham refresh token'ın SHA-256 hash'ini büyük harfli hex olarak döner.</summary>
+    public static string Hash(string refreshToken) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(refreshToken)));
+}


### PR DESCRIPTION
`BACKEND_REVIEW.md` SEC-02 (Kritik).

## Sorun

`UserSession.Token` ham string olarak saklanıyor ve doğrudan indeksleniyordu. Veritabanına okuma erişimi elde eden herkes (yedek sızıntısı, `sa` hesabı, dışa açık MSSQL portu) tüm kullanıcılar adına doğrudan yeniden oynatılabilir oturum elde ederdi. Aynı kod tabanı parola sıfırlama ve e-posta değişikliği token'larını zaten hash'liyordu — bu tutarsızlık bilinçli bir karardan çok gözden kaçmaya işaret ediyor.

## Çözüm

- `UserSession.Token` → `TokenHash` (SHA-256 hex, `nvarchar(64)`), index `TokenHash`'e taşındı.
- Doğrulama gelen ham token'ın hash'i üzerinden yapılıyor; ham token yalnızca istemciye dönüyor, veritabanına asla yazılmıyor.
- Hash'leme `PasswordResetToken` / `EmailChangeToken` deseniyle birebir aynı, `RefreshTokenHasher` yardımcısına alındı.
- Rotasyon, reuse-detection, logout ve revoke davranışı **değişmedi**.

## ⚠️ Veri etkisi — tüm kullanıcılar yeniden login olacak

Düz metin token'lar hash'e çevrilemez (tek yönlü fonksiyon). `UserSessionTokenHashlendi` migration'ı:

1. Önce tüm aktif oturumları revoke eder (`UPDATE [UserSessions] SET [IsRevoked] = 1 WHERE [IsRevoked] = 0`)
2. Sonra `Token` kolonunu ve index'ini düşürür, `TokenHash` ekler

Satırlar **silinmez** — cihaz geçmişi korunur ve tüm kullanıcılara toplu "yeni cihaz" uyarı e-postası gitmez. Eski satırların `TokenHash` değeri boş string kalır; SHA-256 hex her zaman 64 karakter olduğu için hiçbir doğrulama isteğiyle eşleşemez.

`Down()` kolonu geri ekler ama token'lar kurtarılamaz — beklenen davranış. `UserSessions` dışında hiçbir tabloya dokunulmadı.

Migration `dotnet ef` ile **`dev` modeli üzerinde** üretildi (`20260818184243`), yani dev'deki 19 yeni migration'ın ardına doğru sırayla düşüyor.

## Test

4 birim testi (`RefreshTokenHasherTests`): determinizm, ham token ≠ hash, farklı token → farklı hash, 64 karakter uppercase hex (kolon uzunluğuyla uyum).

`dotnet build` 0 hata · `dotnet test` 326/326 geçiyor.

Auth akışlarının uçtan uca testi (rotasyon, replay reddi) entegrasyon test altyapısı gerektirdiği için Faz 2'ye bırakıldı (TEST-03/TEST-04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)