### PR TITLE
Soft-delete query filter için regresyon testleri eklendi

### DIFF
--- a/apps/backend/CargoPilot.Infrastructure.Tests/SoftDeleteQueryFilterTests.cs
+++ b/apps/backend/CargoPilot.Infrastructure.Tests/SoftDeleteQueryFilterTests.cs
@@ -1,0 +1,116 @@
+using CargoPilot.Application.Abstractions;
+using CargoPilot.Domain.Entities;
+using CargoPilot.Domain.Enums;
+using CargoPilot.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace CargoPilot.Infrastructure.Tests;
+
+/// <summary>
+/// Soft-delete global query filter'inin model genelinde eksiksiz uygulandigini sabitler.
+/// Tek bir entity'de filtre unutulursa silinmis kayitlar sessizce sorgulara sizar.
+/// </summary>
+public sealed class SoftDeleteQueryFilterTests
+{
+    private const string IsDeletedColumn = nameof(BaseEntity.IsDeleted);
+
+    private static AppDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlServer("Server=localhost;Database=CargoPilotModelOnly;Trusted_Connection=True;")
+            .Options;
+
+        return new AppDbContext(options, new AnonymousCurrentUserService());
+    }
+
+    private static List<IEntityType> SoftDeletableEntityTypes(AppDbContext context)
+    {
+        return context.Model
+            .GetEntityTypes()
+            .Where(entityType => entityType.FindProperty(IsDeletedColumn) is not null)
+            .ToList();
+    }
+
+    [Fact]
+    public void Model_IsDeletedTasiyanEntityleriIcerir()
+    {
+        using var context = CreateContext();
+
+        // Testin bos kumede calisip yanlislikla "gecti" demesini engeller.
+        Assert.NotEmpty(SoftDeletableEntityTypes(context));
+    }
+
+    [Fact]
+    public void Model_IsDeletedTasiyanHerEntityIcinQueryFilterTanimlar()
+    {
+        using var context = CreateContext();
+
+        var filtersiz = SoftDeletableEntityTypes(context)
+            .Where(entityType => entityType.GetQueryFilter() is null)
+            .Select(entityType => entityType.ClrType.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            filtersiz.Count == 0,
+            $"Su entity'lerde soft-delete query filter eksik: {string.Join(", ", filtersiz)}");
+    }
+
+    [Fact]
+    public void Model_QueryFilterlariIsDeletedUzerindenCalisir()
+    {
+        using var context = CreateContext();
+
+        var isDeletedeDokunmayan = SoftDeletableEntityTypes(context)
+            .Where(entityType =>
+                entityType.GetQueryFilter() is { } filter &&
+                !filter.ToString().Contains(IsDeletedColumn, StringComparison.Ordinal))
+            .Select(entityType => entityType.ClrType.Name)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            isDeletedeDokunmayan.Count == 0,
+            $"Su entity'lerin query filter'i IsDeleted kontrolu icermiyor: {string.Join(", ", isDeletedeDokunmayan)}");
+    }
+
+    [Fact]
+    public void Sorgu_SilinmisKayitlariDisarida_BirakanPredicateUretir()
+    {
+        using var context = CreateContext();
+
+        var sql = context.Items.Select(item => item.Id).ToQueryString();
+
+        Assert.Contains(IsDeletedColumn, sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Sorgu_IgnoreQueryFiltersIle_SoftDeletePredicateiniUretmez()
+    {
+        using var context = CreateContext();
+
+        var sql = context.Items.IgnoreQueryFilters().Select(item => item.Id).ToQueryString();
+
+        Assert.DoesNotContain(IsDeletedColumn, sql, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Sorgu_PlanIcinDe_SoftDeletePredicateiUretir()
+    {
+        using var context = CreateContext();
+
+        var sql = context.LoadingPlans.Select(plan => plan.Id).ToQueryString();
+
+        Assert.Contains(IsDeletedColumn, sql, StringComparison.Ordinal);
+    }
+
+    private sealed class AnonymousCurrentUserService : ICurrentUserService
+    {
+        public Guid? UserId => null;
+
+        public Guid? CompanyId => null;
+
+        public UserType? UserType => null;
+    }
+}


### PR DESCRIPTION
`BACKEND_REVIEW.md` DB-01 (1. adım).

## Raporun tespiti yanlıştı

Rapor "`HasQueryFilter` kod tabanında hiç kullanılmıyor" diyor ve bunu "doğrulandı" olarak işaretliyor. **Bu doğru değil** — raporu yazan yalnızca `AppDbContext.cs`'e bakmış, `Persistence/Configurations/` klasörünü açmamış.

Soft-delete global query filter **zaten tam olarak uygulanmış** durumda: `BaseEntity`'den türeyen **18 entity'nin 18'inde de** ilgili konfigürasyonda `HasQueryFilter(x => !x.IsDeleted)` var. Filtresi olmayan 6 konfigürasyon `BaseEntity`'den türemiyor ve `IsDeleted` alanı hiç yok.

Bu proje filtreyi `OnModelCreating`'de toplamak yerine her entity'nin kendi `IEntityTypeConfiguration` sınıfına koyma konvansiyonunu kullanıyor. Bu yüzden **hiçbir üretim kodu değiştirilmedi** — değiştirilecek bir şey yoktu ve mevcut konvansiyonu taşımak gereksiz bir refactor olurdu.

## Eksik olan şey: testi

Filtre yürürlükteydi ama onu koruyan tek bir test yoktu. 6 test eklendi, iki katmandan doğruluyor:

- **Model metadata:** `IsDeleted` taşıyan *her* entity tipinin `GetQueryFilter()`'ının null olmadığı ve filtrenin gerçekten `IsDeleted`'a dokunduğu. Filtresiz yeni bir entity eklenirse test kırmızı döner ve eksik tipi mesajda listeler.
- **Davranışsal:** gerçek SQL Server provider'ının ürettiği T-SQL'de (`ToQueryString()`, bağlantı açmadan) soft-delete predicate'inin bulunduğu, `IgnoreQueryFilters()` ile bulunmadığı.

Sqlite in-memory bilinçli olarak seçilmedi: model 15+ konfigürasyonda `HasDefaultValueSql("GETUTCDATE()")` ve bir `HasComputedColumnSql` içeriyor, `EnsureCreated()` Sqlite'ta patlar. `ToQueryString()` yaklaşımı hem daha gerçekçi hem yeni paket gerektirmiyor. Boş kümede sessizce geçme riskine karşı `NotEmpty` guard'ı var.

## `IgnoreQueryFilters` taraması

Tüm backend tarandı. Silinmiş kaydı bilerek okuyan tek yer `NotificationRepository.HardDeleteOlderThanAsync` ve orada `IgnoreQueryFilters()` **zaten doğru kullanılıyor**. Restore/undelete metodu, "silinenleri göster" ekranı veya query filter'ı baypas eden ham SQL yok.

## Faz 2 için not

Kiracı (`CompanyId`) filtresi bu PR'ın kapsamı **dışında** — yol haritası onu entegrasyon testleriyle birlikte Faz 2'ye koyuyor. O iş yapılırken Hangfire job'larının tamamı `IgnoreQueryFilters` kaçış yoluna ihtiyaç duyacak, çünkü `ICurrentUserService.CompanyId` arka plan işlerinde null.

`dotnet test` — Infrastructure.Tests 33/33 geçiyor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)