### PR TITLE
HTTP istek logu eklendi (OBS-01)

### DIFF
--- a/apps/backend/CargoPilot.WebAPI/Program.cs
+++ b/apps/backend/CargoPilot.WebAPI/Program.cs
@@ -5,6 +5,7 @@ using CargoPilot.Infrastructure.Persistence.Seeding;
 using CargoPilot.WebAPI;
 using Hangfire;
 using Serilog;
+using Serilog.Events;
 using Serilog.Formatting.Compact;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -35,6 +36,23 @@ if (!useInMemory) {
     var dbInitializer = scope.ServiceProvider.GetRequiredService<DbInitializer>();
     await dbInitializer.InitializeAsync();
 }
+
+// OBS-01: Her HTTP isteği için tek satırlık yapılandırılmış log.
+// Sağlık ve metrik uçları izleme sistemleri tarafından sürekli çağrıldığı için
+// Verbose'a düşürülür; aksi hâlde gerçek trafiği gürültüyle boğar.
+app.UseSerilogRequestLogging(options =>
+    options.GetLevel = (httpContext, _, exception) =>
+    {
+        if (exception is not null || httpContext.Response.StatusCode >= StatusCodes.Status500InternalServerError)
+        {
+            return LogEventLevel.Error;
+        }
+
+        var path = httpContext.Request.Path;
+        return path.StartsWithSegments("/health") || path.StartsWithSegments("/metrics")
+            ? LogEventLevel.Verbose
+            : LogEventLevel.Information;
+    });
 
 app.UsePresentation(useInMemory);
 


### PR DESCRIPTION
`BACKEND_REVIEW.md` OBS-01, ilk adım.

## Sorun

~17.000 satırlık uygulama kodunda HTTP istek logu **hiç üretilmiyordu** — `UseSerilogRequestLogging` kayıtlı değildi. Bir üretim olayında elde yalnızca Prometheus HTTP sayaçları ve yakalanmamış exception'lar kalıyor; "hangi kullanıcı hangi isteği ne zaman yaptı, ne döndü" sorusu kodla cevaplanamıyordu. Loki/Promtail yatırımı büyük ölçüde boşa çalışıyordu.

## Çözüm

`app.UseSerilogRequestLogging(...)` eklendi. Sağlık ve metrik uçları izleme sistemleri tarafından sürekli çağrıldığı için `Verbose`'a düşürüldü — aksi hâlde gerçek trafiği gürültüyle boğardı. 5xx ve exception `Error` seviyesinde loglanıyor.

## Neden ayrı PR

Bu satır Faz 1 dal bölmesi sırasında gözden kaçtı. Orijinal commit hem `AddPresentation` çağrı yerini hem istek logu satırını içeriyordu. `AddPresentation` imzası #1062'de değiştiği için çağrı yerinin **aynı commit'te** olması gerekiyordu (yoksa o commit tek başına derlenmiyordu) — onu #1062'ye kattım, istek logu satırı ayrı commit'e alınmayı bekliyordu ama oluşturulmadı.

Merge sonrası `dev`'i doğrularken yakaladım: `Program.cs`'te `UseSerilog` var (Serilog host kurulumu) ama `UseSerilogRequestLogging` yok.

## Doğrulama

`dotnet build` 0 hata · `dotnet test` 473/473 geçiyor.

İş akışı logları ve korelasyon kimliği (OBS-01 ikinci adım + OBS-02) Faz 2'de.

🤖 Generated with [Claude Code](https://claude.com/claude-code)