### PR TITLE
E2E ERP 403 düzeltildi: seed admin bayrağı yapılandırılabilir, opt-in seed'de varsayılan şirket

### DIFF
--- a/apps/backend/CargoPilot.Infrastructure/Persistence/Seeding/DbInitializer.cs
+++ b/apps/backend/CargoPilot.Infrastructure/Persistence/Seeding/DbInitializer.cs
@@ -12,6 +12,7 @@ public sealed class DbInitializer {
     private const string DefaultAdminEmail = "admin@cargopilot.com";
     private const string EnableAdminSeedKey = "Seed:EnableAdminSeed";
     private const string DefaultAdminPasswordKey = "Seed:DefaultAdminPassword";
+    private const string AdminMustChangePasswordKey = "Seed:AdminMustChangePassword";
 
     private readonly AppDbContext _context;
     private readonly IPasswordHasher _passwordHasher;
@@ -50,7 +51,18 @@ public sealed class DbInitializer {
             return;
         }
 
-        await SeedAdminUserAsync(company, mustChangePassword: !isDevelopment, cancellationToken);
+        // Seed açıkça istenmiş ama DB'de hiç şirket yok (taze test/CI yığını):
+        // admin şirketsiz kalırsa tüm şirket kapsamlı uçlar Auth.NoCompany ile
+        // kilitlenir. Yalnızca bu koşulda varsayılan şirket açılır; sahte ERP
+        // entegrasyonu Development dışında yine seed'lenmez.
+        company ??= await CreateDefaultCompanyAsync(cancellationToken);
+
+        // İlk girişte parola değişimi üretim varsayılanıdır; otomasyon ortamları
+        // (CI e2e yığını) Seed:AdminMustChangePassword=false ile kapatabilir.
+        var mustChangePassword = !isDevelopment
+            && _configuration.GetValue(AdminMustChangePasswordKey, defaultValue: true);
+
+        await SeedAdminUserAsync(company, mustChangePassword, cancellationToken);
     }
 
     private Task<Company?> GetOldestCompanyAsync(CancellationToken cancellationToken) =>
@@ -58,19 +70,21 @@ public sealed class DbInitializer {
             .OrderBy(c => c.CreatedAtUtc)
             .FirstOrDefaultAsync(cancellationToken);
 
+    private async Task<Company> CreateDefaultCompanyAsync(CancellationToken cancellationToken) {
+        var company = new Company(
+            id: Guid.NewGuid(),
+            name: DefaultCompanyName,
+            subscriptionType: SubscriptionType.Free,
+            maxUserCount: 5);
+
+        await _context.Companies.AddAsync(company, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+        return company;
+    }
+
     private async Task<Company> SeedDevelopmentDataAsync(CancellationToken cancellationToken) {
-        var company = await GetOldestCompanyAsync(cancellationToken);
-
-        if (company is null) {
-            company = new Company(
-                id: Guid.NewGuid(),
-                name: DefaultCompanyName,
-                subscriptionType: SubscriptionType.Free,
-                maxUserCount: 5);
-
-            await _context.Companies.AddAsync(company, cancellationToken);
-            await _context.SaveChangesAsync(cancellationToken);
-        }
+        var company = await GetOldestCompanyAsync(cancellationToken)
+            ?? await CreateDefaultCompanyAsync(cancellationToken);
 
         var integrationExists = await _context.Integrations
             .AnyAsync(i => i.CompanyId == company.Id, cancellationToken);

--- a/infra/compose/docker-compose.test.yml
+++ b/infra/compose/docker-compose.test.yml
@@ -36,6 +36,11 @@ services:
       # gerekiyor ve kod bu yolda MustChangePassword'ü zorluyor. Kapatmak için
       # .env.test'te SEED_ENABLE_ADMIN_SEED=false yeterlidir.
       Seed__EnableAdminSeed: ${SEED_ENABLE_ADMIN_SEED:-true}
+      # Test/CI yığınında ilk giriş parola değişimi kapalı: e2e otomasyonu seed
+      # admin ile API çağırıyor; açık olsaydı MustChangePasswordMiddleware her
+      # isteği 403 AUTH_MUST_CHANGE_PASSWORD ile keserdi (2026-08-19 arızası).
+      # Üretim varsayılanı (true) prod compose'ta değişmeden duruyor.
+      Seed__AdminMustChangePassword: ${SEED_ADMIN_MUST_CHANGE_PASSWORD:-false}
       Seed__DefaultAdminPassword: ${Seed__DefaultAdminPassword}
       Jwt__Secret: ${JWT_SECRET}
       OAuth__Google__ClientId: ${GOOGLE_CLIENT_ID:-}


### PR DESCRIPTION
## Ne

`e2e-smoke`'un tüm ERP senaryolarını düşüren sistematik 403'ün düzeltmesi (v0.19.0'daki bilinen regresyon).

## Kök neden (kanıtlı)

#1064 (`9d6a059e`), Development dışındaki ortamlarda seed admin'i `MustChangePassword=true` ile yaratmaya başladı. E2E yığını `ASPNETCORE_ENVIRONMENT=Test` + taze DB ile kurulduğu için admin her koşuda bu bayrakla doğuyor; login başarılı ama `MustChangePasswordMiddleware` (`Middlewares/MustChangePasswordMiddleware.cs:14-23`) `mcp=true` claim'li her isteği `403 AUTH_MUST_CHANGE_PASSWORD` ile kesiyor. Her senaryonun ilk authenticated çağrısı `DELETE /api/v1/erp-settings` olduğundan hepsi aynı satırda düştü (Serilog: "responded 403 in 31.6ms" — uygulama içi; 403 gövdesi bayt düzeyinde middleware JSON'uyla eşleşti, run `32186420693`).

Aynı commit'in ikincil kırılması: Test ortamında artık şirket seed'lenmediği için taze DB'de admin `CompanyId=null` kalıyordu — mcp düzeltilse bile tüm ERP uçları `Auth.NoCompany` ile düşecekti.

## Düzeltme (en küçük güvenli diff)

1. **`Seed:AdminMustChangePassword` anahtarı** (varsayılan `true` — üretim sertliği aynen korunur). `docker-compose.test.yml` bunu `false`'a çeker (yalnız test/CI; prod compose'a dokunulmadı).
2. **Opt-in seed'de varsayılan şirket:** `Seed:EnableAdminSeed=true` iken DB'de hiç şirket yoksa `Default Logistics` açılır ve admin ona bağlanır. Sahte `TestERP` entegrasyonu Development dışında yine seed'lenmez (DB-05 geri açılmıyor; entegrasyonu `EnsureIntegrationAsync` zaten üretiyor). Şirket yaratma kodu `CreateDefaultCompanyAsync`'e alındı, dev yolu da onu kullanıyor — davranış değişikliği yok.

E2E assert'leri gevşetilmedi: 403 gerçek ürün davranışıydı, arıza seed yapılandırmasındaydı.

## Doğrulama

- `CargoPilot.Infrastructure` build 0 hata; Infrastructure.Tests 116/116, Engine.Tests 306/306 yerel yeşil.
- Asıl kanıt merge sonrası `e2e-smoke`: taze yığında login → `DELETE /api/v1/erp-settings` → 404 beklenir, ERP senaryoları yeşillenmeli.
